### PR TITLE
Reformatting source code with clang-format - TouhouDanmakufu folder

### DIFF
--- a/source/TouhouDanmakufu/Common/DnhCommon.cpp
+++ b/source/TouhouDanmakufu/Common/DnhCommon.cpp
@@ -1,6 +1,8 @@
-#include"DnhCommon.hpp"
-#include"DnhGcLibImpl.hpp"
+#include "DnhCommon.hpp"
+#include "DnhGcLibImpl.hpp"
+
 //Note: watch this file, this one contains information on script interpretation
+
 /**********************************************************
 //ScriptInformation
 **********************************************************/
@@ -9,8 +11,7 @@ const std::wstring ScriptInformation::DEFAULT = L"DEFAULT";
 ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(std::wstring pathScript, bool bNeedHeader)
 {
 	ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(pathScript);
-	if(reader == NULL || !reader->Open())
-	{
+	if (reader == NULL || !reader->Open()) {
 		Logger::WriteTop(ErrorUtility::GetFileNotFoundErrorMessage(pathScript));
 		return NULL;
 	}
@@ -29,12 +30,10 @@ ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(std:
 
 	Scanner scanner(source);
 	int encoding = scanner.GetEncoding();
-	try
-	{
+	try {
 		bool bScript = false;
 		int type = TYPE_SINGLE;
-		if(!bNeedHeader)
-		{
+		if (!bNeedHeader) {
 			type = TYPE_UNKNOWN;
 			bScript = true;
 		}
@@ -48,97 +47,76 @@ ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(std:
 		std::vector<std::wstring> listPlayer;
 		std::wstring replayName = L"";
 
-		while(scanner.HasNext())
-		{
+		while (scanner.HasNext()) {
 			Token& tok = scanner.Next();
-			if(tok.GetType() == Token::TK_EOF)//Eofの識別子が来たらファイルの調査終了
-			{
+			if (tok.GetType() == Token::TK_EOF) { //Eofの識別子が来たらファイルの調査終了
 				break;
-			}
-			else if(tok.GetType() == Token::TK_SHARP)
-			{
+			} else if (tok.GetType() == Token::TK_SHARP) {
 				tok = scanner.Next();
 				std::wstring element = tok.GetElement();
 				bool bShiftJisDanmakufu = false;
-				if(encoding == Encoding::SHIFT_JIS)
-				{
+				if (encoding == Encoding::SHIFT_JIS) {
 					int start = tok.GetStartPointer();
 					int end = tok.GetEndPointer();
 					bShiftJisDanmakufu = scanner.CompareMemory(start, end, "東方弾幕風");
 				}
 
-				if(element == L"東方弾幕風" || element == L"TouhouDanmakufu" || bShiftJisDanmakufu)
-				{
+				if (element == L"東方弾幕風" || element == L"TouhouDanmakufu" || bShiftJisDanmakufu) {
 					bScript = true;
-					if(scanner.Next().GetType() != Token::TK_OPENB)continue;
+					if (scanner.Next().GetType() != Token::TK_OPENB)
+						continue;
 					tok = scanner.Next();
 					std::wstring strType = tok.GetElement();
-					if(scanner.Next().GetType() != Token::TK_CLOSEB)throw gstd::wexception();
+					if (scanner.Next().GetType() != Token::TK_CLOSEB)
+						throw gstd::wexception();
 
-					if(strType == L"Single")type = TYPE_SINGLE;
-					else if(strType == L"Plural")type = TYPE_PLURAL;
-					else if(strType == L"Stage")type = TYPE_STAGE;
-					else if(strType == L"Package")type = TYPE_PACKAGE;
-					else if(strType == L"Player")type = TYPE_PLAYER;
-					else if(!bNeedHeader)throw gstd::wexception();
-				}
-				else if(element == L"ID")
-				{
+					if (strType == L"Single")
+						type = TYPE_SINGLE;
+					else if (strType == L"Plural")
+						type = TYPE_PLURAL;
+					else if (strType == L"Stage")
+						type = TYPE_STAGE;
+					else if (strType == L"Package")
+						type = TYPE_PACKAGE;
+					else if (strType == L"Player")
+						type = TYPE_PLAYER;
+					else if (!bNeedHeader)
+						throw gstd::wexception();
+				} else if (element == L"ID") {
 					idScript = _GetString(scanner);
-				}
-				else if(element == L"Title")
-				{
+				} else if (element == L"Title") {
 					title = _GetString(scanner);
-				}
-				else if(element == L"Text")
-				{
+				} else if (element == L"Text") {
 					text = _GetString(scanner);
-				}
-				else if(element == L"Image")
-				{
+				} else if (element == L"Image") {
 					pathImage = _GetString(scanner);
-				}
-				else if(element == L"System")
-				{
+				} else if (element == L"System") {
 					pathSystem = _GetString(scanner);
-				}
-				else if(element == L"Background")
-				{
+				} else if (element == L"Background") {
 					pathBackground = _GetString(scanner);
-				}
-				else if(element == L"BGM")
-				{
+				} else if (element == L"BGM") {
 					pathBGM = _GetString(scanner);
-				}
-				else if(element == L"Player")
-				{
+				} else if (element == L"Player") {
 					listPlayer = _GetStringList(scanner);
-				}
-				else if(element == L"ReplayName")
-				{
+				} else if (element == L"ReplayName") {
 					replayName = _GetString(scanner);
 				}
 			}
 		}
 
-		if(bScript)
-		{
+		if (bScript) {
 			//IDがなかった場合はしょうがないのでファイル名にする。
-			if(idScript.size() == 0)
+			if (idScript.size() == 0)
 				idScript = PathProperty::GetFileNameWithoutExtension(pathScript);
 
-			if(replayName.size() == 0)
-			{
+			if (replayName.size() == 0) {
 				replayName = idScript;
-				if(replayName.size() > 8)
+				if (replayName.size() > 8)
 					replayName = replayName.substr(0, 8);
 			}
 
-			if(pathImage.size() > 2)
-			{
-				if(pathImage[0] == L'.' &&
-					(pathImage[1] == L'/' || pathImage[1] == L'\\'))
-				{
+			if (pathImage.size() > 2) {
+				if (pathImage[0] == L'.' && (pathImage[1] == L'/' || pathImage[1] == L'\\')) {
 					pathImage = pathImage.substr(2);
 					pathImage = PathProperty::GetFileDirectory(pathScript) + pathImage;
 				}
@@ -159,9 +137,7 @@ ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(std:
 			res->SetPlayerList(listPlayer);
 			res->SetReplayName(replayName);
 		}
-	}
-	catch(...)
-	{
+	} catch (...) {
 		res = NULL;
 	}
 
@@ -170,10 +146,7 @@ ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(std:
 bool ScriptInformation::IsExcludeExtention(std::wstring ext)
 {
 	bool res = false;
-	if(ext == L".dat" || ext == L".mid" || ext == L".wav" || ext == L".mp3" || ext == L".ogg" ||
-		ext == L".bmp" || ext == L".png" || ext == L"jpg" ||
-		ext == L".mqo" || ext == L".elem")
-	{
+	if (ext == L".dat" || ext == L".mid" || ext == L".wav" || ext == L".mp3" || ext == L".ogg" || ext == L".bmp" || ext == L".png" || ext == L"jpg" || ext == L".mqo" || ext == L".elem") {
 		res = true;
 	}
 	return res;
@@ -183,8 +156,7 @@ std::wstring ScriptInformation::_GetString(Scanner& scanner)
 	std::wstring res = DEFAULT;
 	scanner.CheckType(scanner.Next(), Token::TK_OPENB);
 	Token& tok = scanner.Next();
-	if(tok.GetType() == Token::TK_STRING)
-	{
+	if (tok.GetType() == Token::TK_STRING) {
 		res = tok.GetString();
 	}
 	scanner.CheckType(scanner.Next(), Token::TK_CLOSEB);
@@ -194,32 +166,29 @@ std::vector<std::wstring> ScriptInformation::_GetStringList(Scanner& scanner)
 {
 	std::vector<std::wstring> res;
 	scanner.CheckType(scanner.Next(), Token::TK_OPENB);
-	while(true) 
-	{
+	while (true) {
 		Token& tok = scanner.Next();
 		int type = tok.GetType();
-		if(type == Token::TK_CLOSEB)break;
-		else if(type == Token::TK_STRING)
-		{
+		if (type == Token::TK_CLOSEB)
+			break;
+		else if (type == Token::TK_STRING) {
 			std::wstring wstr = tok.GetString();
 			res.push_back(wstr);
 		}
 	}
 	return res;
 }
-std::vector<ref_count_ptr<ScriptInformation> > ScriptInformation::CreatePlayerScriptInformationList()
+std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::CreatePlayerScriptInformationList()
 {
-	std::vector<ref_count_ptr<ScriptInformation> > res;
+	std::vector<ref_count_ptr<ScriptInformation>> res;
 	std::vector<std::wstring> listPlayerPath = GetPlayerList();
 	std::wstring dirInfo = PathProperty::GetFileDirectory(GetScriptPath());
-	for(int iPath = 0 ; iPath < listPlayerPath.size() ; iPath++)
-	{
+	for (int iPath = 0; iPath < listPlayerPath.size(); iPath++) {
 		std::wstring pathPlayer = listPlayerPath[iPath];
 		std::wstring path = EPathProperty::ExtendRelativeToFull(dirInfo, pathPlayer);
 
 		ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-		if(reader == NULL || !reader->Open())
-		{
+		if (reader == NULL || !reader->Open()) {
 			Logger::WriteTop(ErrorUtility::GetFileNotFoundErrorMessage(path));
 			continue;
 		}
@@ -228,44 +197,44 @@ std::vector<ref_count_ptr<ScriptInformation> > ScriptInformation::CreatePlayerSc
 		int size = reader->GetFileSize();
 		source.resize(size);
 		reader->Read(&source[0], size);
-		
-		ref_count_ptr<ScriptInformation> info = 
-			ScriptInformation::CreateScriptInformation(path, L"", source);
-		if(info != NULL && info->GetType() == ScriptInformation::TYPE_PLAYER)
-		{
+
+		ref_count_ptr<ScriptInformation> info = ScriptInformation::CreateScriptInformation(path, L"", source);
+		if (info != NULL && info->GetType() == ScriptInformation::TYPE_PLAYER) {
 			res.push_back(info);
 		}
 	}
 	return res;
 }
-std::vector<ref_count_ptr<ScriptInformation> > ScriptInformation::CreateScriptInformationList(std::wstring path, bool bNeedHeader)
+std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::CreateScriptInformationList(std::wstring path, bool bNeedHeader)
 {
-	std::vector<ref_count_ptr<ScriptInformation> > res;
+	std::vector<ref_count_ptr<ScriptInformation>> res;
 	File file(path);
-	if(!file.Open())return res;
-	if(file.GetSize() < HEADER_ARCHIVEFILE.size())return res;
+	if (!file.Open())
+		return res;
+	if (file.GetSize() < HEADER_ARCHIVEFILE.size())
+		return res;
 
 	std::string header;
 	header.resize(HEADER_ARCHIVEFILE.size());
 	file.Read(&header[0], header.size());
-	if(header == HEADER_ARCHIVEFILE)
-	{
+	if (header == HEADER_ARCHIVEFILE) {
 		file.Close();
 
 		ArchiveFile archive(path);
-		if(!archive.Open())return res;
+		if (!archive.Open())
+			return res;
 
-		std::multimap<std::wstring, ref_count_ptr<ArchiveFileEntry> > mapEntry = archive.GetEntryMap();
-		std::multimap<std::wstring, ref_count_ptr<ArchiveFileEntry> >::iterator itr = mapEntry.begin();
-		for(; itr != mapEntry.end() ; itr++)
-		{
+		std::multimap<std::wstring, ref_count_ptr<ArchiveFileEntry>> mapEntry = archive.GetEntryMap();
+		std::multimap<std::wstring, ref_count_ptr<ArchiveFileEntry>>::iterator itr = mapEntry.begin();
+		for (; itr != mapEntry.end(); itr++) {
 			//明らかに関係なさそうな拡張子は除外
 			ref_count_ptr<ArchiveFileEntry> entry = itr->second;
 			std::wstring dir = PathProperty::GetFileDirectory(path);
 			std::wstring tPath = dir + entry->GetDirectory() + entry->GetName();
 
 			std::wstring ext = PathProperty::GetFileExtension(tPath);
-			if(ScriptInformation::IsExcludeExtention(ext))continue;
+			if (ScriptInformation::IsExcludeExtention(ext))
+				continue;
 
 			ref_count_ptr<gstd::ByteBuffer> buffer = ArchiveFile::CreateEntryBuffer(entry);
 			std::string source = "";
@@ -274,16 +243,15 @@ std::vector<ref_count_ptr<ScriptInformation> > ScriptInformation::CreateScriptIn
 			buffer->Read(&source[0], size);
 
 			ref_count_ptr<ScriptInformation> info = CreateScriptInformation(tPath, path, source, bNeedHeader);
-			if(info != NULL)
+			if (info != NULL)
 				res.push_back(info);
 		}
-	}
-	else
-	{
+	} else {
 
 		//明らかに関係なさそうな拡張子は除外
 		std::wstring ext = PathProperty::GetFileExtension(path);
-		if(ScriptInformation::IsExcludeExtention(ext))return res;
+		if (ScriptInformation::IsExcludeExtention(ext))
+			return res;
 
 		file.SetFilePointerBegin();
 		std::string source = "";
@@ -292,54 +260,48 @@ std::vector<ref_count_ptr<ScriptInformation> > ScriptInformation::CreateScriptIn
 		file.Read(&source[0], size);
 
 		ref_count_ptr<ScriptInformation> info = CreateScriptInformation(path, L"", source, bNeedHeader);
-		if(info != NULL)
+		if (info != NULL)
 			res.push_back(info);
 	}
 
 	return res;
 }
-std::vector<ref_count_ptr<ScriptInformation> > ScriptInformation::FindPlayerScriptInformationList(std::wstring dir)
+std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::FindPlayerScriptInformationList(std::wstring dir)
 {
-	std::vector<ref_count_ptr<ScriptInformation> > res;
+	std::vector<ref_count_ptr<ScriptInformation>> res;
 	WIN32_FIND_DATA data;
 	HANDLE hFind;
 	std::wstring findDir = dir + L"*.*";
 	hFind = FindFirstFile(findDir.c_str(), &data);
-	do 
-	{
+	do {
 		std::wstring name = data.cFileName;
-		if((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) && 
-			(name != L".." && name != L"."))
-		{
+		if ((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) && (name != L".." && name != L".")) {
 			//ディレクトリ
 			std::wstring tDir = dir + name;
 			tDir += L"\\";
 
-			std::vector<ref_count_ptr<ScriptInformation> > list = FindPlayerScriptInformationList(tDir);
-			for(std::vector<ref_count_ptr<ScriptInformation> >::iterator itr = list.begin() ; itr != list.end() ; itr++)
-			{
+			std::vector<ref_count_ptr<ScriptInformation>> list = FindPlayerScriptInformationList(tDir);
+			for (std::vector<ref_count_ptr<ScriptInformation>>::iterator itr = list.begin(); itr != list.end(); itr++) {
 				res.push_back(*itr);
 			}
 			continue;
 		}
-		if(wcscmp(data.cFileName, L"..")==0 || wcscmp(data.cFileName, L".")==0)
+		if (wcscmp(data.cFileName, L"..") == 0 || wcscmp(data.cFileName, L".") == 0)
 			continue;
 
 		//ファイル
 		std::wstring path = dir + name;
 
 		//スクリプト解析
-		std::vector<ref_count_ptr<ScriptInformation> > listInfo = CreateScriptInformationList(path, true);
-		for(int iInfo = 0 ; iInfo < listInfo.size() ; iInfo++)
-		{
+		std::vector<ref_count_ptr<ScriptInformation>> listInfo = CreateScriptInformationList(path, true);
+		for (int iInfo = 0; iInfo < listInfo.size(); iInfo++) {
 			ref_count_ptr<ScriptInformation> info = listInfo[iInfo];
-			if(info != NULL && info->GetType() == ScriptInformation::TYPE_PLAYER)
-			{
+			if (info != NULL && info->GetType() == ScriptInformation::TYPE_PLAYER) {
 				res.push_back(info);
 			}
 		}
 
-	}while(FindNextFile(hFind, &data));
+	} while (FindNextFile(hFind, &data));
 	FindClose(hFind);
 
 	return res;
@@ -353,53 +315,46 @@ ErrorDialog::ErrorDialog(HWND hParent)
 {
 	hParent_ = hParent;
 }
-LRESULT ErrorDialog::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
+LRESULT ErrorDialog::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	switch (uMsg)
-	{
-		case WM_DESTROY:
-		{
-			_FinishMessageLoop();
-			break;
-		}
-		case WM_CLOSE:
+	switch (uMsg) {
+	case WM_DESTROY: {
+		_FinishMessageLoop();
+		break;
+	}
+	case WM_CLOSE:
+		DestroyWindow(hWnd_);
+		break;
+	case WM_KEYDOWN:
+		if (wParam == VK_RETURN) {
 			DestroyWindow(hWnd_);
-			break;
-		case WM_KEYDOWN:
-			if( wParam == VK_RETURN)
-			{
-				DestroyWindow(hWnd_);
-			}
-			break;
-		case WM_COMMAND:
-		{
-			int param = wParam & 0xffff;
-			if(param == button_.GetWindowId())
-			{
-				DestroyWindow(hWnd_);
-			}
-
-			break;
 		}
-		case WM_SIZE:
-		{
-			RECT rect;
-			::GetClientRect(hWnd_, &rect);
-			int wx = rect.left;
-			int wy = rect.top;
-			int wWidth = rect.right-rect.left;
-			int wHeight = rect.bottom-rect.top;
-			
-			RECT rcButton = button_.GetClientRect();
-			int widthButton = rcButton.right - rcButton.left;
-			int heightButton = rcButton.bottom - rcButton.top;
-			button_.SetBounds(wWidth / 2 - widthButton / 2, wHeight - heightButton - 8 , widthButton, heightButton);
-
-			edit_.SetBounds(wx+8, wy+8, wWidth-16, wHeight- heightButton - 24);
-
-			break;
+		break;
+	case WM_COMMAND: {
+		int param = wParam & 0xffff;
+		if (param == button_.GetWindowId()) {
+			DestroyWindow(hWnd_);
 		}
 
+		break;
+	}
+	case WM_SIZE: {
+		RECT rect;
+		::GetClientRect(hWnd_, &rect);
+		int wx = rect.left;
+		int wy = rect.top;
+		int wWidth = rect.right - rect.left;
+		int wHeight = rect.bottom - rect.top;
+
+		RECT rcButton = button_.GetClientRect();
+		int widthButton = rcButton.right - rcButton.left;
+		int heightButton = rcButton.bottom - rcButton.top;
+		button_.SetBounds(wWidth / 2 - widthButton / 2, wHeight - heightButton - 8, widthButton, heightButton);
+
+		edit_.SetBounds(wx + 8, wy + 8, wWidth - 16, wHeight - heightButton - 24);
+
+		break;
+	}
 	}
 	return _CallPreviousWindowProcedure(hWnd, uMsg, wParam, lParam);
 }
@@ -409,30 +364,27 @@ bool ErrorDialog::ShowModal(std::wstring msg)
 	std::wstring wName = L"ErrorWindow";
 
 	WNDCLASSEX wcex;
-	ZeroMemory(&wcex,sizeof(wcex));
-	wcex.cbSize=sizeof(WNDCLASSEX); 
-	wcex.lpfnWndProc=(WNDPROC)WindowBase::_StaticWindowProcedure;
-	wcex.hInstance=hInst;
-	wcex.hIcon=NULL;
-	wcex.hCursor=LoadCursor(NULL, IDC_ARROW);
-	wcex.hbrBackground=(HBRUSH)(COLOR_WINDOW);
-	wcex.lpszMenuName=NULL;
-	wcex.lpszClassName=wName.c_str();
-	wcex.hIconSm=NULL;
+	ZeroMemory(&wcex, sizeof(wcex));
+	wcex.cbSize = sizeof(WNDCLASSEX);
+	wcex.lpfnWndProc = (WNDPROC)WindowBase::_StaticWindowProcedure;
+	wcex.hInstance = hInst;
+	wcex.hIcon = NULL;
+	wcex.hCursor = LoadCursor(NULL, IDC_ARROW);
+	wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW);
+	wcex.lpszMenuName = NULL;
+	wcex.lpszClassName = wName.c_str();
+	wcex.hIconSm = NULL;
 	RegisterClassEx(&wcex);
 
-   	hWnd_=::CreateWindow(wcex.lpszClassName,
+	hWnd_ = ::CreateWindow(wcex.lpszClassName,
 		wName.c_str(),
-		WS_OVERLAPPEDWINDOW  ,
-		0,0,480,320,hParent_,(HMENU)NULL,hInst,NULL);
+		WS_OVERLAPPEDWINDOW,
+		0, 0, 480, 320, hParent_, (HMENU)NULL, hInst, NULL);
 	::ShowWindow(hWnd_, SW_HIDE);
 	this->Attach(hWnd_);
 
-
 	gstd::WEditBox::Style styleEdit;
-	styleEdit.SetStyle(WS_CHILD | WS_VISIBLE |
-		ES_MULTILINE|ES_READONLY|ES_AUTOHSCROLL|ES_AUTOVSCROLL|
-		WS_HSCROLL | WS_VSCROLL);
+	styleEdit.SetStyle(WS_CHILD | WS_VISIBLE | ES_MULTILINE | ES_READONLY | ES_AUTOHSCROLL | ES_AUTOVSCROLL | WS_HSCROLL | WS_VSCROLL);
 	styleEdit.SetStyleEx(WS_EX_CLIENTEDGE);
 	edit_.Create(hWnd_, styleEdit);
 	edit_.SetText(msg);
@@ -459,13 +411,13 @@ DnhConfiguration::DnhConfiguration()
 
 	//キー登録
 	padIndex_ = 0;
-	mapKey_[EDirectInput::KEY_LEFT] = new VirtualKey(DIK_LEFT, 0, 0);//キーボード「←」とジョイパッド「←」を登録
-	mapKey_[EDirectInput::KEY_RIGHT] = new VirtualKey(DIK_RIGHT, 0, 1);//キーボード「→」とジョイパッド「→」を登録
-	mapKey_[EDirectInput::KEY_UP] = new VirtualKey(DIK_UP, 0, 2);//キーボード「↑」とジョイパッド「↑」を登録
-	mapKey_[EDirectInput::KEY_DOWN] = new VirtualKey(DIK_DOWN, 0, 3);	//キーボード「↓」とジョイパッド「↓」を登録
+	mapKey_[EDirectInput::KEY_LEFT] = new VirtualKey(DIK_LEFT, 0, 0); //キーボード「←」とジョイパッド「←」を登録
+	mapKey_[EDirectInput::KEY_RIGHT] = new VirtualKey(DIK_RIGHT, 0, 1); //キーボード「→」とジョイパッド「→」を登録
+	mapKey_[EDirectInput::KEY_UP] = new VirtualKey(DIK_UP, 0, 2); //キーボード「↑」とジョイパッド「↑」を登録
+	mapKey_[EDirectInput::KEY_DOWN] = new VirtualKey(DIK_DOWN, 0, 3); //キーボード「↓」とジョイパッド「↓」を登録
 
 	mapKey_[EDirectInput::KEY_OK] = new VirtualKey(DIK_Z, 0, 5);
-	mapKey_[EDirectInput::KEY_CANCEL] = new VirtualKey(DIK_X, 0, 6);	
+	mapKey_[EDirectInput::KEY_CANCEL] = new VirtualKey(DIK_X, 0, 6);
 
 	mapKey_[EDirectInput::KEY_SHOT] = new VirtualKey(DIK_Z, 0, 5);
 	mapKey_[EDirectInput::KEY_BOMB] = new VirtualKey(DIK_X, 0, 6);
@@ -492,23 +444,23 @@ bool DnhConfiguration::_LoadDefintionFile()
 {
 	std::wstring path = PathProperty::GetModuleDirectory() + L"th_dnh.def";
 	PropertyFile prop;
-	if(!prop.Load(path))return false;
+	if (!prop.Load(path))
+		return false;
 
 	pathPackageScript_ = prop.GetString(L"package.script.main", L"");
-	if(pathPackageScript_.size() > 0)
-	{
+	if (pathPackageScript_.size() > 0) {
 		pathPackageScript_ = PathProperty::GetModuleDirectory() + pathPackageScript_;
 	}
 
 	windowTitle_ = prop.GetString(L"window.title", L"");
 
-	screenWidth_ = prop.GetInteger(L"screen.width", 640); // + ::GetSystemMetrics(SM_CXEDGE) + 10 
-	screenWidth_ = max(screenWidth_, 640); // + ::GetSystemMetrics(SM_CXEDGE) + 10 
-	screenWidth_ = min(screenWidth_, 1920); // + ::GetSystemMetrics(SM_CXEDGE) + 10 
+	screenWidth_ = prop.GetInteger(L"screen.width", 640); // + ::GetSystemMetrics(SM_CXEDGE) + 10
+	screenWidth_ = max(screenWidth_, 640); // + ::GetSystemMetrics(SM_CXEDGE) + 10
+	screenWidth_ = min(screenWidth_, 1920); // + ::GetSystemMetrics(SM_CXEDGE) + 10
 
-	screenHeight_ = prop.GetInteger(L"screen.height", 480); // +::GetSystemMetrics(SM_CXEDGE) + 10 
-	screenHeight_ = max(screenHeight_, 480); // +::GetSystemMetrics(SM_CXEDGE) + 10 
-	screenHeight_ = min(screenHeight_, 1200); // +::GetSystemMetrics(SM_CXEDGE) + 10 
+	screenHeight_ = prop.GetInteger(L"screen.height", 480); // +::GetSystemMetrics(SM_CXEDGE) + 10
+	screenHeight_ = max(screenHeight_, 480); // +::GetSystemMetrics(SM_CXEDGE) + 10
+	screenHeight_ = min(screenHeight_, 1200); // +::GetSystemMetrics(SM_CXEDGE) + 10
 
 	return true;
 }
@@ -517,16 +469,18 @@ bool DnhConfiguration::LoadConfigFile()
 	std::wstring path = PathProperty::GetModuleDirectory() + L"config.dat";
 	RecordBuffer record;
 	bool res = record.ReadFromFile(path);
-	if(!res)return false;
+	if (!res)
+		return false;
 
 	int version = record.GetRecordAsInteger("version");
-	if(version != VERSION)return false;
+	if (version != VERSION)
+		return false;
 
 	modeScreen_ = record.GetRecordAsInteger("modeScreen");
 	sizeWindow_ = record.GetRecordAsInteger("sizeWindow");
 	fpsType_ = record.GetRecordAsInteger("fpsType");
 
-	if(record.IsExists("padIndex"))
+	if (record.IsExists("padIndex"))
 		padIndex_ = record.GetRecordAsInteger("padIndex");
 
 	ByteBuffer bufKey;
@@ -534,10 +488,8 @@ bool DnhConfiguration::LoadConfigFile()
 	bufKey.SetSize(bufKeySize);
 	record.GetRecord("mapKey", bufKey.GetPointer(), bufKey.GetSize());
 	int mapKeyCount = bufKey.ReadInteger();
-	if(mapKeyCount == mapKey_.size())
-	{
-		for(int iKey = 0 ; iKey < mapKeyCount ; iKey++)
-		{
+	if (mapKeyCount == mapKey_.size()) {
+		for (int iKey = 0; iKey < mapKeyCount; iKey++) {
 			int id = bufKey.ReadInteger();
 			int keyCode = bufKey.ReadInteger();
 			int padIndex = bufKey.ReadInteger();
@@ -549,7 +501,7 @@ bool DnhConfiguration::LoadConfigFile()
 
 	bLogWindow_ = record.GetRecordAsBoolean("bLogWindow");
 	bLogFile_ = record.GetRecordAsBoolean("bLogFile");
-	if(record.IsExists("bMouseVisible"))
+	if (record.IsExists("bMouseVisible"))
 		bMouseVisible_ = record.GetRecordAsBoolean("bMouseVisible");
 
 	return res;
@@ -567,12 +519,11 @@ bool DnhConfiguration::SaveConfigFile()
 	record.SetRecordAsInteger("padIndex", padIndex_);
 	ByteBuffer bufKey;
 	bufKey.WriteInteger(mapKey_.size());
-	std::map<int, ref_count_ptr<VirtualKey> >::iterator itrKey = mapKey_.begin();
-	for(; itrKey != mapKey_.end(); itrKey++)
-	{
+	std::map<int, ref_count_ptr<VirtualKey>>::iterator itrKey = mapKey_.begin();
+	for (; itrKey != mapKey_.end(); itrKey++) {
 		int id = itrKey->first;
 		ref_count_ptr<VirtualKey> vk = itrKey->second;
-		
+
 		bufKey.WriteInteger(id);
 		bufKey.WriteInteger(vk->GetKeyCode());
 		bufKey.WriteInteger(padIndex_);
@@ -590,7 +541,8 @@ bool DnhConfiguration::SaveConfigFile()
 }
 ref_count_ptr<VirtualKey> DnhConfiguration::GetVirtualKey(int id)
 {
-	if(mapKey_.find(id) == mapKey_.end())return NULL;
+	if (mapKey_.find(id) == mapKey_.end())
+		return NULL;
 
 	ref_count_ptr<VirtualKey> res = mapKey_[id];
 	return res;

--- a/source/TouhouDanmakufu/Common/DnhCommon.hpp
+++ b/source/TouhouDanmakufu/Common/DnhCommon.hpp
@@ -1,93 +1,90 @@
 #ifndef __TOUHOUDANMAKUFU_DNHCOMMON__
 #define __TOUHOUDANMAKUFU_DNHCOMMON__
 
-#include"DnhConstant.hpp"
+#include "DnhConstant.hpp"
 
 /**********************************************************
 //ScriptInformation
 **********************************************************/
-class ScriptInformation
-{
-	public:
-		enum
-		{
-			TYPE_UNKNOWN,
-			TYPE_PLAYER,
-			TYPE_SINGLE,
-			TYPE_PLURAL,
-			TYPE_STAGE,
-			TYPE_PACKAGE,
+class ScriptInformation {
+public:
+	enum {
+		TYPE_UNKNOWN,
+		TYPE_PLAYER,
+		TYPE_SINGLE,
+		TYPE_PLURAL,
+		TYPE_STAGE,
+		TYPE_PACKAGE,
 
-			MAX_ID = 8,
-		};
-		const static std::wstring DEFAULT;
-		class Sort;
-		struct PlayerListSort;
-	private:
-		int type_;
-		std::wstring pathArchive_;
-		std::wstring pathScript_;
+		MAX_ID = 8,
+	};
+	const static std::wstring DEFAULT;
+	class Sort;
+	struct PlayerListSort;
 
-		std::wstring id_;
-		std::wstring title_;
-		std::wstring text_;
-		std::wstring pathImage_;
-		std::wstring pathSystem_;
-		std::wstring pathBackground_;
-		std::wstring pathBGM_;
-		std::vector<std::wstring> listPlayer_;
+public:
+	ScriptInformation() {}
+	virtual ~ScriptInformation() {}
+	int GetType() { return type_; }
+	void SetType(int type) { type_ = type; }
+	std::wstring GetArchivePath() { return pathArchive_; }
+	void SetArchivePath(std::wstring path) { pathArchive_ = path; }
+	std::wstring GetScriptPath() { return pathScript_; }
+	void SetScriptPath(std::wstring path) { pathScript_ = path; }
 
-		std::wstring replayName_;
-		
+	std::wstring GetID() { return id_; }
+	void SetID(std::wstring id) { id_ = id; }
+	std::wstring GetTitle() { return title_; }
+	void SetTitle(std::wstring title) { title_ = title; }
+	std::wstring GetText() { return text_; }
+	void SetText(std::wstring text) { text_ = text; }
+	std::wstring GetImagePath() { return pathImage_; }
+	void SetImagePath(std::wstring path) { pathImage_ = path; }
+	std::wstring GetSystemPath() { return pathSystem_; }
+	void SetSystemPath(std::wstring path) { pathSystem_ = path; }
+	std::wstring GetBackgroundPath() { return pathBackground_; }
+	void SetBackgroundPath(std::wstring path) { pathBackground_ = path; }
+	std::wstring GetBgmPath() { return pathBGM_; }
+	void SetBgmPath(std::wstring path) { pathBGM_ = path; }
+	std::vector<std::wstring> GetPlayerList() { return listPlayer_; }
+	void SetPlayerList(std::vector<std::wstring> list) { listPlayer_ = list; }
 
-	public:
-		ScriptInformation(){}
-		virtual ~ScriptInformation(){}
-		int GetType(){return type_;}
-		void SetType(int type){type_ = type;}
-		std::wstring GetArchivePath(){return pathArchive_;}
-		void SetArchivePath(std::wstring path){pathArchive_ = path;}
-		std::wstring GetScriptPath(){return pathScript_;}
-		void SetScriptPath(std::wstring path){pathScript_ = path;}
+	std::wstring GetReplayName() { return replayName_; }
+	void SetReplayName(std::wstring name) { replayName_ = name; }
 
-		std::wstring GetID(){return id_;}
-		void SetID(std::wstring id){id_ = id;}
-		std::wstring GetTitle(){return title_;}
-		void SetTitle(std::wstring title){title_ = title;}
-		std::wstring GetText(){return text_;}
-		void SetText(std::wstring text){text_ = text;}
-		std::wstring GetImagePath(){return pathImage_;}
-		void SetImagePath(std::wstring path){pathImage_ = path;}
-		std::wstring GetSystemPath(){return pathSystem_;}
-		void SetSystemPath(std::wstring path){pathSystem_ = path;}
-		std::wstring GetBackgroundPath(){return pathBackground_;}
-		void SetBackgroundPath(std::wstring path){pathBackground_ = path;}
-		std::wstring GetBgmPath(){return pathBGM_;}
-		void SetBgmPath(std::wstring path){pathBGM_ = path;}
-		std::vector<std::wstring> GetPlayerList(){return listPlayer_;}
-		void SetPlayerList(std::vector<std::wstring> list){listPlayer_ = list;}
+	std::vector<ref_count_ptr<ScriptInformation>> CreatePlayerScriptInformationList();
 
-		std::wstring GetReplayName(){return replayName_;}
-		void SetReplayName(std::wstring name){replayName_ = name;}
+public:
+	static ref_count_ptr<ScriptInformation> CreateScriptInformation(std::wstring pathScript, bool bNeedHeader = true);
+	static ref_count_ptr<ScriptInformation> CreateScriptInformation(std::wstring pathScript, std::wstring pathArchive, std::string source, bool bNeedHeader = true);
 
-		std::vector<ref_count_ptr<ScriptInformation> > CreatePlayerScriptInformationList();
+	static std::vector<ref_count_ptr<ScriptInformation>> CreateScriptInformationList(std::wstring path, bool bNeedHeader = true);
+	static std::vector<ref_count_ptr<ScriptInformation>> FindPlayerScriptInformationList(std::wstring dir);
+	static bool IsExcludeExtention(std::wstring ext);
 
-	public:
-		static ref_count_ptr<ScriptInformation> CreateScriptInformation(std::wstring pathScript, bool bNeedHeader = true);
-		static ref_count_ptr<ScriptInformation> CreateScriptInformation(std::wstring pathScript, std::wstring pathArchive, std::string source, bool bNeedHeader = true);
-		
-		static std::vector<ref_count_ptr<ScriptInformation> > CreateScriptInformationList(std::wstring path, bool bNeedHeader = true);
-		static std::vector<ref_count_ptr<ScriptInformation> > FindPlayerScriptInformationList(std::wstring dir);
-		static bool IsExcludeExtention(std::wstring ext);
+private:
+	static std::wstring _GetString(Scanner& scanner);
+	static std::vector<std::wstring> _GetStringList(Scanner& scanner);
 
-	private:
-		static std::wstring _GetString(Scanner& scanner);
-		static std::vector<std::wstring> _GetStringList(Scanner& scanner);
+private:
+	int type_;
+	std::wstring pathArchive_;
+	std::wstring pathScript_;
+
+	std::wstring id_;
+	std::wstring title_;
+	std::wstring text_;
+	std::wstring pathImage_;
+	std::wstring pathSystem_;
+	std::wstring pathBackground_;
+	std::wstring pathBGM_;
+	std::vector<std::wstring> listPlayer_;
+
+	std::wstring replayName_;
 };
 
-class ScriptInformation::Sort
-{
-	public:
+class ScriptInformation::Sort {
+public:
 	BOOL operator()(const ref_count_ptr<ScriptInformation>& lf, const ref_count_ptr<ScriptInformation>& rf)
 	{
 		ref_count_ptr<ScriptInformation> lsp = lf;
@@ -102,8 +99,7 @@ class ScriptInformation::Sort
 	}
 };
 
-struct ScriptInformation::PlayerListSort
-{
+struct ScriptInformation::PlayerListSort {
 	BOOL operator()(const ref_count_ptr<ScriptInformation>& lf, const ref_count_ptr<ScriptInformation>& rf)
 	{
 		ref_count_ptr<ScriptInformation> lsp = lf;
@@ -116,98 +112,98 @@ struct ScriptInformation::PlayerListSort
 	}
 };
 
-
 /**********************************************************
 //ErrorDialog
 **********************************************************/
-class ErrorDialog : public ModalDialog
-{
-	protected:
-		static HWND hWndParentStatic_;
+class ErrorDialog : public ModalDialog {
+public:
+	ErrorDialog(HWND hParent);
+	bool ShowModal(std::wstring msg);
 
-		WEditBox edit_;
-		WButton button_;
+	static void SetParentWindowHandle(HWND hWndParent) { hWndParentStatic_ = hWndParent; }
+	static void ShowErrorDialog(std::wstring msg)
+	{
+		ErrorDialog dialog(hWndParentStatic_);
+		dialog.ShowModal(msg);
+	}
 
-		virtual LRESULT _WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
+protected:
+	static HWND hWndParentStatic_;
 
-	public:
-		ErrorDialog(HWND hParent);
-		bool ShowModal(std::wstring msg);
+	WEditBox edit_;
+	WButton button_;
 
-		static void SetParentWindowHandle(HWND hWndParent){hWndParentStatic_ = hWndParent;}
-		static void ShowErrorDialog(std::wstring msg){ErrorDialog dialog(hWndParentStatic_); dialog.ShowModal(msg);}
+	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 };
-
-
 
 /**********************************************************
 //DnhConfiguration
 **********************************************************/
-class DnhConfiguration : public Singleton<DnhConfiguration>
-{
-		static const int VERSION;
-	public:
-		enum
-		{
-			WINDOW_SIZE_640x480 = 0,
-			WINDOW_SIZE_800x600,
-			WINDOW_SIZE_960x720,
-			WINDOW_SIZE_1280x960,
-			WINDOW_SIZE_1600x1200,
-			WINDOW_SIZE_1920x1200,
+class DnhConfiguration : public Singleton<DnhConfiguration> {
+	static const int VERSION;
 
-			FPS_NORMAL = 0,
-			FPS_1_2,// 1/2
-			FPS_1_3,// 1/3
-			FPS_AUTO,
-		};
+public:
+	enum {
+		WINDOW_SIZE_640x480 = 0,
+		WINDOW_SIZE_800x600,
+		WINDOW_SIZE_960x720,
+		WINDOW_SIZE_1280x960,
+		WINDOW_SIZE_1600x1200,
+		WINDOW_SIZE_1920x1200,
 
-	private:
-		int modeScreen_;//DirectGraphics::SCREENMODE_FULLSCREEN,SCREENMODE_WINDOW
-		int sizeWindow_;
-		int fpsType_;
+		FPS_NORMAL = 0,
+		FPS_1_2, // 1/2
+		FPS_1_3, // 1/3
+		FPS_AUTO,
+	};
 
-		int padIndex_;
-		std::map<int, ref_count_ptr<VirtualKey> > mapKey_;
+public:
+	DnhConfiguration();
+	virtual ~DnhConfiguration();
+	bool LoadConfigFile();
+	bool SaveConfigFile();
 
-		bool bLogWindow_;
-		bool bLogFile_;
-		bool bMouseVisible_;
+	int GetScreenMode() { return modeScreen_; }
+	void SetScreenMode(int mode) { modeScreen_ = mode; }
+	int GetWindowSize() { return sizeWindow_; }
+	void SetWindowSize(int size) { sizeWindow_ = size; }
+	int GetFpsType() { return fpsType_; }
+	void SetFpsType(int type) { fpsType_ = type; }
 
-		std::wstring pathPackageScript_;
-		std::wstring windowTitle_;
-		int screenWidth_;
-		int screenHeight_;
+	int GetPadIndex() { return padIndex_; }
+	void SetPadIndex(int index) { padIndex_ = index; }
+	ref_count_ptr<VirtualKey> GetVirtualKey(int id);
 
-		bool _LoadDefintionFile();
-	public:
-		DnhConfiguration();
-		virtual ~DnhConfiguration();
-		bool LoadConfigFile();
-		bool SaveConfigFile();
+	bool IsLogWindow() { return bLogWindow_; }
+	void SetLogWindow(bool b) { bLogWindow_ = b; }
+	bool IsLogFile() { return bLogFile_; }
+	void SetLogFile(bool b) { bLogFile_ = b; }
+	bool IsMouseVisible() { return bMouseVisible_; }
+	void SetMouseVisible(bool b) { bMouseVisible_ = b; }
 
-		int GetScreenMode(){return modeScreen_;}
-		void SetScreenMode(int mode){modeScreen_ = mode;}
-		int GetWindowSize(){return sizeWindow_;}
-		void SetWindowSize(int size){sizeWindow_ = size;}
-		int GetFpsType(){return fpsType_;}
-		void SetFpsType(int type){fpsType_ = type;}
+	std::wstring GetPackageScriptPath() { return pathPackageScript_; }
+	std::wstring GetWindowTitle() { return windowTitle_; }
+	int GetScreenWidth() { return screenWidth_; }
+	int GetScreenHeight() { return screenHeight_; }
 
-		int GetPadIndex(){return padIndex_;}
-		void SetPadIndex(int index){padIndex_ = index;}
-		ref_count_ptr<VirtualKey> GetVirtualKey(int id);
+private:
+	int modeScreen_; //DirectGraphics::SCREENMODE_FULLSCREEN,SCREENMODE_WINDOW
+	int sizeWindow_;
+	int fpsType_;
 
-		bool IsLogWindow(){return bLogWindow_;}
-		void SetLogWindow(bool b){bLogWindow_ = b;}
-		bool IsLogFile(){return bLogFile_;}
-		void SetLogFile(bool b){bLogFile_ = b;}
-		bool IsMouseVisible(){return bMouseVisible_;}
-		void SetMouseVisible(bool b){bMouseVisible_ = b;}
+	int padIndex_;
+	std::map<int, ref_count_ptr<VirtualKey>> mapKey_;
 
-		std::wstring GetPackageScriptPath(){return pathPackageScript_;}
-		std::wstring GetWindowTitle(){return windowTitle_;}
-		int GetScreenWidth(){return screenWidth_;}
-		int GetScreenHeight(){return screenHeight_;}
+	bool bLogWindow_;
+	bool bLogFile_;
+	bool bMouseVisible_;
+
+	std::wstring pathPackageScript_;
+	std::wstring windowTitle_;
+	int screenWidth_;
+	int screenHeight_;
+
+	bool _LoadDefintionFile();
 };
 
 #endif

--- a/source/TouhouDanmakufu/Common/DnhConstant.hpp
+++ b/source/TouhouDanmakufu/Common/DnhConstant.hpp
@@ -1,7 +1,7 @@
 #ifndef __TOUHOUDANMAKUFU_DNHCONSTANT__
 #define __TOUHOUDANMAKUFU_DNHCONSTANT__
 
-#include"../../GcLib/GcLib.hpp"
+#include "../../GcLib/GcLib.hpp"
 
 using namespace gstd;
 using namespace directx;
@@ -11,5 +11,3 @@ const int STANDARD_FPS = 60;
 const std::wstring DNH_VERSION = L"[.1 pre6a open]";
 
 #endif
-
-

--- a/source/TouhouDanmakufu/Common/DnhGcLibImpl.cpp
+++ b/source/TouhouDanmakufu/Common/DnhGcLibImpl.cpp
@@ -1,5 +1,5 @@
-#include"DnhGcLibImpl.hpp"
-#include"DnhCommon.hpp"
+#include "DnhGcLibImpl.hpp"
+#include "DnhCommon.hpp"
 
 /**********************************************************
 //EPathProperty
@@ -56,31 +56,26 @@ std::wstring EPathProperty::GetCommonDataPath(std::wstring scriptPath, std::wstr
 std::wstring EPathProperty::ExtendRelativeToFull(std::wstring dir, std::wstring path)
 {
 	path = StringUtility::ReplaceAll(path, L"\\", L"/");
-	if(path.size() >= 2)
-	{
-		if(path[0] == L'.' && path[1] == L'/')
-		{
+	if (path.size() >= 2) {
+		if (path[0] == L'.' && path[1] == L'/') {
 			path = path.substr(2);
 			path = dir + path;
 		}
 	}
 
 	std::wstring drive = PathProperty::GetDriveName(path);
-	if(drive.size() == 0)
-	{
+	if (drive.size() == 0) {
 		path = GetModuleDirectory() + path;
 	}
 
 	return path;
 }
 
-
 /**********************************************************
 //ELogger
 **********************************************************/
 ELogger::ELogger()
 {
-
 }
 void ELogger::Initialize(bool bFile, bool bWindow)
 {
@@ -107,19 +102,14 @@ EFpsController::EFpsController()
 {
 	DnhConfiguration* config = DnhConfiguration::GetInstance();
 	int fpsType = config->GetFpsType();
-	if(fpsType == DnhConfiguration::FPS_NORMAL ||
-		fpsType == DnhConfiguration::FPS_1_2 ||
-		fpsType == DnhConfiguration::FPS_1_3)
-	{
+	if (fpsType == DnhConfiguration::FPS_NORMAL || fpsType == DnhConfiguration::FPS_1_2 || fpsType == DnhConfiguration::FPS_1_3) {
 		StaticFpsController* controller = new StaticFpsController();
-		if(fpsType == DnhConfiguration::FPS_1_2)
+		if (fpsType == DnhConfiguration::FPS_1_2)
 			controller->SetSkipRate(1);
-		else if(fpsType == DnhConfiguration::FPS_1_3)
+		else if (fpsType == DnhConfiguration::FPS_1_3)
 			controller->SetSkipRate(2);
 		controller_ = controller;
-	}
-	else
-	{
+	} else {
 		AutoSkipFpsController* controller = new AutoSkipFpsController();
 		controller_ = controller;
 	}
@@ -145,7 +135,6 @@ bool ETaskManager::Initialize()
 	return true;
 }
 
-
 /**********************************************************
 //ETextureManager
 **********************************************************/
@@ -153,16 +142,14 @@ bool ETextureManager::Initialize()
 {
 	bool res = TextureManager::Initialize();
 
-	for(int iRender = 0 ; iRender < MAX_RESERVED_RENDERTARGET ; iRender++)
-	{
+	for (int iRender = 0; iRender < MAX_RESERVED_RENDERTARGET; iRender++) {
 		std::wstring name = GetReservedRenderTargetName(iRender);
 		ref_count_ptr<Texture> texture = new Texture();
 		res &= texture->CreateRenderTarget(name);
 		Add(name, texture);
 	}
 
-	if(!res)
-	{
+	if (!res) {
 		throw gstd::wexception(L"ETextureManager初期化失敗");
 	}
 	return res;
@@ -200,7 +187,7 @@ void EDirectInput::ResetVirtualKeyMap()
 	AddKeyMap(KEY_DOWN, config->GetVirtualKey(KEY_DOWN));
 
 	AddKeyMap(KEY_OK, config->GetVirtualKey(KEY_OK));
-	AddKeyMap(KEY_CANCEL, config->GetVirtualKey(KEY_CANCEL));	
+	AddKeyMap(KEY_CANCEL, config->GetVirtualKey(KEY_CANCEL));
 
 	AddKeyMap(KEY_SHOT, config->GetVirtualKey(KEY_SHOT));
 	AddKeyMap(KEY_BOMB, config->GetVirtualKey(KEY_BOMB));

--- a/source/TouhouDanmakufu/Common/DnhGcLibImpl.hpp
+++ b/source/TouhouDanmakufu/Common/DnhGcLibImpl.hpp
@@ -1,185 +1,167 @@
 #ifndef __TOUHOUDANMAKUFU_DNHGCLIBIMPL__
 #define __TOUHOUDANMAKUFU_DNHGCLIBIMPL__
 
-#include"DnhConstant.hpp"
+#include "DnhConstant.hpp"
 
 /**********************************************************
 //EPathProperty
 **********************************************************/
-class EPathProperty : public Singleton<EPathProperty>, public PathProperty
-{
-	public:
-		static std::wstring GetSystemResourceDirectory();
-		static std::wstring GetSystemImageDirectory();
-		static std::wstring GetSystemBgmDirectory();
-		static std::wstring GetSystemSeDirectory();
+class EPathProperty : public Singleton<EPathProperty>, public PathProperty {
+public:
+	static std::wstring GetSystemResourceDirectory();
+	static std::wstring GetSystemImageDirectory();
+	static std::wstring GetSystemBgmDirectory();
+	static std::wstring GetSystemSeDirectory();
 
-		static std::wstring GetStgScriptRootDirectory();
-		static std::wstring GetStgDefaultScriptDirectory();
-		static std::wstring GetPlayerScriptRootDirectory();
+	static std::wstring GetStgScriptRootDirectory();
+	static std::wstring GetStgDefaultScriptDirectory();
+	static std::wstring GetPlayerScriptRootDirectory();
 
-		static std::wstring GetReplaySaveDirectory(std::wstring scriptPath);
-		static std::wstring GetCommonDataPath(std::wstring scriptPath, std::wstring area);
+	static std::wstring GetReplaySaveDirectory(std::wstring scriptPath);
+	static std::wstring GetCommonDataPath(std::wstring scriptPath, std::wstring area);
 
-		static std::wstring ExtendRelativeToFull(std::wstring dir, std::wstring path);
+	static std::wstring ExtendRelativeToFull(std::wstring dir, std::wstring path);
 };
 
 /**********************************************************
 //ELogger
 **********************************************************/
-class ELogger : public Singleton<ELogger>, public WindowLogger
-{
-	private:
-		gstd::ref_count_ptr<gstd::ScriptCommonDataInfoPanel> panelCommonData_;
-	public:
-		ELogger();
-		void Initialize(bool bFile, bool bWindow);
+class ELogger : public Singleton<ELogger>, public WindowLogger {
+public:
+	ELogger();
+	void Initialize(bool bFile, bool bWindow);
 
-		gstd::ref_count_ptr<gstd::ScriptCommonDataInfoPanel> GetScriptCommonDataInfoPanel(){return panelCommonData_;}
-		void UpdateCommonDataInfoPanel(gstd::ref_count_ptr<ScriptCommonDataManager> commonDataManager);
+	gstd::ref_count_ptr<gstd::ScriptCommonDataInfoPanel> GetScriptCommonDataInfoPanel() { return panelCommonData_; }
+	void UpdateCommonDataInfoPanel(gstd::ref_count_ptr<ScriptCommonDataManager> commonDataManager);
+
+private:
+	gstd::ref_count_ptr<gstd::ScriptCommonDataInfoPanel> panelCommonData_;
 };
-
 
 /**********************************************************
 //EFpsController
 **********************************************************/
-class EFpsController : public Singleton<EFpsController>
-{
-	private:
-		int fastModeKey_;
-		ref_count_ptr<FpsController> controller_;
-	public:
-		EFpsController();
+class EFpsController : public Singleton<EFpsController> {
+public:
+	EFpsController();
 
-		void SetFps(int fps){controller_->SetFps(fps);}
-		int GetFps(){return controller_->GetFps();}
-		void SetTimerEnable(bool b){controller_->SetTimerEnable(b);}
-		
-		void Wait(){controller_->Wait();}
-		bool IsSkip(){return controller_->IsSkip();}
-		void SetCriticalFrame(){controller_->SetCriticalFrame();}
-		float GetCurrentFps(){return controller_->GetCurrentFps();}
-		float GetCurrentWorkFps(){return controller_->GetCurrentWorkFps();}
-		float GetCurrentRenderFps(){return controller_->GetCurrentRenderFps();}
-		bool IsFastMode(){return controller_->IsFastMode();}
-		void SetFastMode(bool b){controller_->SetFastMode(b);}
+	void SetFps(int fps) { controller_->SetFps(fps); }
+	int GetFps() { return controller_->GetFps(); }
+	void SetTimerEnable(bool b) { controller_->SetTimerEnable(b); }
 
-		void AddFpsControlObject(ref_count_weak_ptr<FpsControlObject> obj){controller_->AddFpsControlObject(obj);}
-		void RemoveFpsControlObject(ref_count_weak_ptr<FpsControlObject> obj){controller_->RemoveFpsControlObject(obj);}
+	void Wait() { controller_->Wait(); }
+	bool IsSkip() { return controller_->IsSkip(); }
+	void SetCriticalFrame() { controller_->SetCriticalFrame(); }
+	float GetCurrentFps() { return controller_->GetCurrentFps(); }
+	float GetCurrentWorkFps() { return controller_->GetCurrentWorkFps(); }
+	float GetCurrentRenderFps() { return controller_->GetCurrentRenderFps(); }
+	bool IsFastMode() { return controller_->IsFastMode(); }
+	void SetFastMode(bool b) { controller_->SetFastMode(b); }
 
-		int GetFastModeKey(){return fastModeKey_;}
-		void SetFastModeKey(int key){fastModeKey_ = key;}
+	void AddFpsControlObject(ref_count_weak_ptr<FpsControlObject> obj) { controller_->AddFpsControlObject(obj); }
+	void RemoveFpsControlObject(ref_count_weak_ptr<FpsControlObject> obj) { controller_->RemoveFpsControlObject(obj); }
+
+	int GetFastModeKey() { return fastModeKey_; }
+	void SetFastModeKey(int key) { fastModeKey_ = key; }
+
+private:
+	int fastModeKey_;
+	ref_count_ptr<FpsController> controller_;
 };
 
 /**********************************************************
 //EFileManager
 **********************************************************/
-class EFileManager : public Singleton<EFileManager>, public FileManager
-{
-	public:
-		void ResetArchiveFile();
+class EFileManager : public Singleton<EFileManager>, public FileManager {
+public:
+	void ResetArchiveFile();
 };
 
 /**********************************************************
 //ETaskManager
 **********************************************************/
-class ETaskManager : public Singleton<ETaskManager>, public WorkRenderTaskManager
-{
-	enum
-	{
+class ETaskManager : public Singleton<ETaskManager>, public WorkRenderTaskManager {
+	enum {
 		TASK_WORK_PRI_MAX = 10,
 		TASK_RENDER_PRI_MAX = 10,
 	};
-	public:
-		bool Initialize();
-};
 
+public:
+	bool Initialize();
+};
 
 /**********************************************************
 //ETextureManager
 **********************************************************/
-class ETextureManager : public Singleton<ETextureManager>, public TextureManager
-{
-		enum
-		{
-			MAX_RESERVED_RENDERTARGET = 3,
-		};
-	public:
-		virtual bool Initialize();
-		std::wstring GetReservedRenderTargetName(int index);
+class ETextureManager : public Singleton<ETextureManager>, public TextureManager {
+	enum {
+		MAX_RESERVED_RENDERTARGET = 3,
+	};
+
+public:
+	virtual bool Initialize();
+	std::wstring GetReservedRenderTargetName(int index);
 };
 
 /**********************************************************
 //EMeshManager
 **********************************************************/
-class EMeshManager : public Singleton<EMeshManager>, public DxMeshManager
-{
-
+class EMeshManager : public Singleton<EMeshManager>, public DxMeshManager {
 };
 
 /**********************************************************
 //EMeshManager
 **********************************************************/
-class EShaderManager : public Singleton<EShaderManager>, public ShaderManager
-{
-
+class EShaderManager : public Singleton<EShaderManager>, public ShaderManager {
 };
 
 /**********************************************************
 //EDxTextRenderer
 **********************************************************/
-class EDxTextRenderer : public Singleton<EDxTextRenderer>, public DxTextRenderer
-{
-
+class EDxTextRenderer : public Singleton<EDxTextRenderer>, public DxTextRenderer {
 };
 
 /**********************************************************
 //EDirectSoundManager
 **********************************************************/
-class EDirectSoundManager : public Singleton<EDirectSoundManager>, public DirectSoundManager
-{
-
+class EDirectSoundManager : public Singleton<EDirectSoundManager>, public DirectSoundManager {
 };
 
 /**********************************************************
 //EDirectInput
 **********************************************************/
-class EDirectInput : public Singleton<EDirectInput>, public VirtualKeyManager
-{
-	public:
-		enum
-		{
-			KEY_INVALID = -1,
+class EDirectInput : public Singleton<EDirectInput>, public VirtualKeyManager {
+public:
+	enum {
+		KEY_INVALID = -1,
 
-			KEY_LEFT,
-			KEY_RIGHT,
-			KEY_UP,
-			KEY_DOWN,
+		KEY_LEFT,
+		KEY_RIGHT,
+		KEY_UP,
+		KEY_DOWN,
 
-			KEY_OK,
-			KEY_CANCEL,
+		KEY_OK,
+		KEY_CANCEL,
 
-			KEY_SHOT,
-			KEY_BOMB,
-			KEY_SLOWMOVE,
-			KEY_USER1,
-			KEY_USER2,
+		KEY_SHOT,
+		KEY_BOMB,
+		KEY_SLOWMOVE,
+		KEY_USER1,
+		KEY_USER2,
 
-			KEY_PAUSE,
+		KEY_PAUSE,
 
-			VK_USER_ID_STAGE = 256,
-			VK_USER_ID_PLAYER = 512,
+		VK_USER_ID_STAGE = 256,
+		VK_USER_ID_PLAYER = 512,
 
-		};
+	};
 
-		int padIndex_;
+	int padIndex_;
 
-	public:
-		virtual bool Initialize(HWND hWnd);
-		void ResetVirtualKeyMap();
-		int GetPadIndex(){return padIndex_;}
+public:
+	virtual bool Initialize(HWND hWnd);
+	void ResetVirtualKeyMap();
+	int GetPadIndex() { return padIndex_; }
 };
 
-
 #endif
-

--- a/source/TouhouDanmakufu/Common/DnhReplay.cpp
+++ b/source/TouhouDanmakufu/Common/DnhReplay.cpp
@@ -1,5 +1,5 @@
-#include"DnhReplay.hpp"
-#include"DnhGcLibImpl.hpp"
+#include "DnhReplay.hpp"
+#include "DnhGcLibImpl.hpp"
 
 /**********************************************************
 //ReplayInformation
@@ -15,9 +15,8 @@ std::vector<int> ReplayInformation::GetStageIndexList()
 {
 	std::vector<int> res;
 
-	std::map<int, ref_count_ptr<StageData> >::iterator itr = mapStageData_.begin();
-	for(; itr!=mapStageData_.end() ; itr++)
-	{
+	std::map<int, ref_count_ptr<StageData>>::iterator itr = mapStageData_.begin();
+	for (; itr != mapStageData_.end(); itr++) {
 		int stage = itr->first;
 		res.push_back(stage);
 	}
@@ -30,8 +29,7 @@ std::wstring ReplayInformation::GetDateAsString()
 	std::wstring res = StringUtility::Format(
 		L"%04d/%02d/%02d %02d:%02d",
 		date_.wYear, date_.wMonth, date_.wDay,
-		date_.wHour, date_.wMinute
-	);
+		date_.wHour, date_.wMinute);
 
 	return res;
 }
@@ -71,7 +69,7 @@ bool ReplayInformation::SaveToFile(std::wstring scriptPath, int index)
 	rec.SetRecord("totalScore", totalScore_);
 	rec.SetRecordAsDouble("fpsAvarage", fpsAvarage_);
 	rec.SetRecord("date", date_);
-	
+
 	RecordBuffer recUserData;
 	userData_->WriteRecord(recUserData);
 	rec.SetRecordAsRecordBuffer("userData", recUserData);
@@ -79,8 +77,7 @@ bool ReplayInformation::SaveToFile(std::wstring scriptPath, int index)
 	std::vector<int> listStage = GetStageIndexList();
 	rec.SetRecordAsInteger("stageCount", listStage.size());
 	rec.SetRecord("stageIndexList", &listStage[0], sizeof(int) * listStage.size());
-	for(int iStage = 0 ; iStage < listStage.size(); iStage++)
-	{
+	for (int iStage = 0; iStage < listStage.size(); iStage++) {
 		int stage = listStage[iStage];
 		std::string key = StringUtility::Format("stage%d", stage);
 
@@ -96,20 +93,22 @@ bool ReplayInformation::SaveToFile(std::wstring scriptPath, int index)
 ref_count_ptr<ReplayInformation> ReplayInformation::CreateFromFile(std::wstring scriptPath, std::wstring fileName)
 {
 	std::wstring dir = EPathProperty::GetReplaySaveDirectory(scriptPath);
-//	std::string scriptName = PathProperty::GetFileNameWithoutExtension(scriptPath);
-//	std::string path = dir + scriptName + StringUtility::Format("_replay%02d.dat", index);
+	// std::string scriptName = PathProperty::GetFileNameWithoutExtension(scriptPath);
+	// std::string path = dir + scriptName + StringUtility::Format("_replay%02d.dat", index);
 	std::wstring path = dir + fileName;
-	
+
 	ref_count_ptr<ReplayInformation> res = CreateFromFile(path);
-	return res; 
+	return res;
 }
 ref_count_ptr<ReplayInformation> ReplayInformation::CreateFromFile(std::wstring path)
 {
 	RecordBuffer rec;
-	if(!rec.ReadFromFile(path, "REPLAY"))return NULL;
+	if (!rec.ReadFromFile(path, "REPLAY"))
+		return NULL;
 
 	int version = rec.GetRecordAsInteger("version");
-	if(version != 1)return NULL;
+	if (version != 1)
+		return NULL;
 
 	ref_count_ptr<ReplayInformation> res = new ReplayInformation();
 	res->path_ = path;
@@ -122,10 +121,9 @@ ref_count_ptr<ReplayInformation> ReplayInformation::CreateFromFile(std::wstring 
 	rec.GetRecord("totalScore", res->totalScore_);
 	res->fpsAvarage_ = rec.GetRecordAsDouble("fpsAvarage");
 	rec.GetRecord("date", res->date_);
-	
+
 	res->userData_->Clear();
-	if(rec.IsExists("userData"))
-	{
+	if (rec.IsExists("userData")) {
 		RecordBuffer recUserData;
 		rec.GetRecordAsRecordBuffer("userData", recUserData);
 		res->userData_->ReadRecord(recUserData);
@@ -134,9 +132,8 @@ ref_count_ptr<ReplayInformation> ReplayInformation::CreateFromFile(std::wstring 
 	int stageCount = rec.GetRecordAsInteger("stageCount");
 	std::vector<int> listStage;
 	listStage.resize(stageCount);
-	rec.GetRecord("stageIndexList",&listStage[0], sizeof(int) * stageCount);
-	for(int iStage = 0 ; iStage < listStage.size(); iStage++)
-	{
+	rec.GetRecord("stageIndexList", &listStage[0], sizeof(int) * stageCount);
+	for (int iStage = 0; iStage < listStage.size(); iStage++) {
 		int stage = listStage[iStage];
 		std::string key = StringUtility::Format("stage%d", stage);
 		ref_count_ptr<StageData> data = new StageData();
@@ -149,26 +146,23 @@ ref_count_ptr<ReplayInformation> ReplayInformation::CreateFromFile(std::wstring 
 	return res;
 }
 
-
 //ReplayInformation::StageData
 double ReplayInformation::StageData::GetFramePerSecondAvarage()
 {
 	double res = 0;
-	for(int iFrame = 0 ; iFrame < listFramePerSecond_.size(); iFrame++)
-	{
+	for (int iFrame = 0; iFrame < listFramePerSecond_.size(); iFrame++) {
 		res += listFramePerSecond_[iFrame];
 	}
 
-	if(listFramePerSecond_.size() > 0)
+	if (listFramePerSecond_.size() > 0)
 		res /= listFramePerSecond_.size();
 	return res;
 }
 std::set<std::string> ReplayInformation::StageData::GetCommonDataAreaList()
 {
 	std::set<std::string> res;
-	std::map<std::string, ref_count_ptr<RecordBuffer> >::iterator itrCommonData;
-	for(itrCommonData = mapCommonData_.begin() ; itrCommonData != mapCommonData_.end() ; itrCommonData++)
-	{
+	std::map<std::string, ref_count_ptr<RecordBuffer>>::iterator itrCommonData;
+	for (itrCommonData = mapCommonData_.begin(); itrCommonData != mapCommonData_.end(); itrCommonData++) {
 		std::string key = itrCommonData->first;
 		res.insert(key);
 	}
@@ -177,8 +171,7 @@ std::set<std::string> ReplayInformation::StageData::GetCommonDataAreaList()
 ref_count_ptr<ScriptCommonData> ReplayInformation::StageData::GetCommonData(std::string area)
 {
 	ref_count_ptr<ScriptCommonData> res = new ScriptCommonData();
-	if(mapCommonData_.find(area) != mapCommonData_.end())
-	{
+	if (mapCommonData_.find(area) != mapCommonData_.end()) {
 		ref_count_ptr<RecordBuffer> record = mapCommonData_[area];
 		res->ReadRecord(*record);
 	}
@@ -187,7 +180,7 @@ ref_count_ptr<ScriptCommonData> ReplayInformation::StageData::GetCommonData(std:
 void ReplayInformation::StageData::SetCommonData(std::string area, ref_count_ptr<ScriptCommonData> commonData)
 {
 	ref_count_ptr<RecordBuffer> record = new RecordBuffer();
-	if(commonData != NULL)
+	if (commonData != NULL)
 		commonData->WriteRecord(*record);
 	mapCommonData_[area] = record;
 }
@@ -197,9 +190,9 @@ void ReplayInformation::StageData::ReadRecord(gstd::RecordBuffer& record)
 	mainScriptID_ = record.GetRecordAsStringW("mainScriptID");
 	mainScriptName_ = record.GetRecordAsStringW("mainScriptName");
 	mainScriptRelativePath_ = record.GetRecordAsStringW("mainScriptRelativePath");
-	if(record.IsExists("scoreStart"))
+	if (record.IsExists("scoreStart"))
 		record.GetRecord("scoreStart", &scoreStart_, sizeof(_int64));
-	if(record.IsExists("scoreLast"))
+	if (record.IsExists("scoreLast"))
 		record.GetRecord("scoreLast", &scoreLast_, sizeof(_int64));
 	record.GetRecord("graze", &graze_, sizeof(_int64));
 	record.GetRecord("point", &point_, sizeof(_int64));
@@ -209,14 +202,13 @@ void ReplayInformation::StageData::ReadRecord(gstd::RecordBuffer& record)
 
 	int countFramePerSecond = record.GetRecordAsInteger("countFramePerSecond");
 	listFramePerSecond_.resize(countFramePerSecond);
-	record.GetRecord("listFramePerSecond",&listFramePerSecond_[0], sizeof(float) * listFramePerSecond_.size());
+	record.GetRecord("listFramePerSecond", &listFramePerSecond_[0], sizeof(float) * listFramePerSecond_.size());
 
 	//共通データ
 	gstd::RecordBuffer recComMap;
 	record.GetRecordAsRecordBuffer("mapCommonData", recComMap);
 	std::vector<std::string> listKeyCommonData = recComMap.GetKeyList();
-	for(int iCommonData = 0 ; iCommonData < listKeyCommonData.size() ; iCommonData++)
-	{
+	for (int iCommonData = 0; iCommonData < listKeyCommonData.size(); iCommonData++) {
 		std::string key = listKeyCommonData[iCommonData];
 		ref_count_ptr<RecordBuffer> recComData = new RecordBuffer();
 		recComMap.GetRecordAsRecordBuffer(key, *recComData);
@@ -247,13 +239,12 @@ void ReplayInformation::StageData::WriteRecord(gstd::RecordBuffer& record)
 
 	int countFramePerSecond = listFramePerSecond_.size();
 	record.SetRecordAsInteger("countFramePerSecond", countFramePerSecond);
-	record.SetRecord("listFramePerSecond",&listFramePerSecond_[0], sizeof(float) * listFramePerSecond_.size());
+	record.SetRecord("listFramePerSecond", &listFramePerSecond_[0], sizeof(float) * listFramePerSecond_.size());
 
 	//共通データ
 	gstd::RecordBuffer recComMap;
-	std::map<std::string, ref_count_ptr<RecordBuffer> >::iterator itrCommonData;
-	for(itrCommonData = mapCommonData_.begin() ; itrCommonData != mapCommonData_.end() ; itrCommonData++)
-	{
+	std::map<std::string, ref_count_ptr<RecordBuffer>>::iterator itrCommonData;
+	for (itrCommonData = mapCommonData_.begin(); itrCommonData != mapCommonData_.end(); itrCommonData++) {
 		std::string key = itrCommonData->first;
 		ref_count_ptr<RecordBuffer> recComData = itrCommonData->second;
 		recComMap.SetRecordAsRecordBuffer(key, *recComData);
@@ -275,7 +266,6 @@ void ReplayInformation::StageData::WriteRecord(gstd::RecordBuffer& record)
 **********************************************************/
 ReplayInformationManager::ReplayInformationManager()
 {
-
 }
 ReplayInformationManager::~ReplayInformationManager()
 {
@@ -291,25 +281,23 @@ void ReplayInformationManager::UpdateInformationList(std::wstring pathScript)
 
 	int indexFree = ReplayInformation::INDEX_USER;
 	std::vector<std::wstring>::iterator itr;
-	for(itr = listPath.begin() ; itr != listPath.end() ; itr++)
-	{
+	for (itr = listPath.begin(); itr != listPath.end(); itr++) {
 		std::wstring path = *itr;
 		std::wstring fileName = PathProperty::GetFileName(path);
 
-		if(fileName.find(fileNameHead) == std::wstring::npos)continue;
+		if (fileName.find(fileNameHead) == std::wstring::npos)
+			continue;
 
 		ref_count_ptr<ReplayInformation> info = ReplayInformation::CreateFromFile(pathScript, fileName);
-		if(info == NULL)continue;
+		if (info == NULL)
+			continue;
 
 		std::wstring strKey = fileName.substr(fileNameHead.size());
 		strKey = PathProperty::GetFileNameWithoutExtension(strKey);
 		int index = StringUtility::ToInteger(strKey);
-		if(index > 0)
-		{
+		if (index > 0) {
 			strKey = StringUtility::Format(L"%d", index);
-		}
-		else
-		{
+		} else {
 			index = indexFree;
 			indexFree++;
 			strKey = StringUtility::Format(L"%d", index);
@@ -318,14 +306,12 @@ void ReplayInformationManager::UpdateInformationList(std::wstring pathScript)
 		int key = StringUtility::ToInteger(strKey);
 		mapInfo_[key] = info;
 	}
-
 }
 std::vector<int> ReplayInformationManager::GetIndexList()
 {
 	std::vector<int> res;
-	std::map<int, ref_count_ptr<ReplayInformation> >::iterator itr;
-	for(itr = mapInfo_.begin() ; itr != mapInfo_.end() ; itr++)
-	{
+	std::map<int, ref_count_ptr<ReplayInformation>>::iterator itr;
+	for (itr = mapInfo_.begin(); itr != mapInfo_.end(); itr++) {
 		int key = itr->first;
 		res.push_back(key);
 	}
@@ -333,6 +319,7 @@ std::vector<int> ReplayInformationManager::GetIndexList()
 }
 ref_count_ptr<ReplayInformation> ReplayInformationManager::GetInformation(int index)
 {
-	if(mapInfo_.find(index) == mapInfo_.end())return NULL;
+	if (mapInfo_.find(index) == mapInfo_.end())
+		return NULL;
 	return mapInfo_[index];
 }

--- a/source/TouhouDanmakufu/Common/DnhReplay.hpp
+++ b/source/TouhouDanmakufu/Common/DnhReplay.hpp
@@ -1,168 +1,174 @@
 #ifndef __TOUHOUDANMAKUFU_DNHREPLAY__
 #define __TOUHOUDANMAKUFU_DNHREPLAY__
 
-#include"DnhCommon.hpp"
+#include "DnhCommon.hpp"
 
 /**********************************************************
 //ReplayInformation
 **********************************************************/
-class ReplayInformation
-{
-	public:
-		enum
-		{
-			INDEX_ACTIVE = 0,
-			INDEX_DIGIT_MIN = 1,
-			INDEX_DIGIT_MAX = 99,
-			INDEX_USER = 100,
-		};
+class ReplayInformation {
+public:
+	enum {
+		INDEX_ACTIVE = 0,
+		INDEX_DIGIT_MIN = 1,
+		INDEX_DIGIT_MAX = 99,
+		INDEX_USER = 100,
+	};
 
-		class StageData;
-	private:
-		std::wstring path_;
-		std::wstring playerScriptID_;
-		std::wstring playerScriptFileName_;
-		std::wstring playerScriptReplayName_;
+	class StageData;
 
-		std::wstring comment_;
-		std::wstring userName_;
-		_int64 totalScore_;
-		double fpsAvarage_;
-		SYSTEMTIME date_;
-		ref_count_ptr<ScriptCommonData> userData_;
-		std::map<int, ref_count_ptr<StageData> > mapStageData_;
+private:
+	std::wstring path_;
+	std::wstring playerScriptID_;
+	std::wstring playerScriptFileName_;
+	std::wstring playerScriptReplayName_;
 
-	public:
-		ReplayInformation();
-		virtual ~ReplayInformation();
+	std::wstring comment_;
+	std::wstring userName_;
+	_int64 totalScore_;
+	double fpsAvarage_;
+	SYSTEMTIME date_;
+	ref_count_ptr<ScriptCommonData> userData_;
+	std::map<int, ref_count_ptr<StageData>> mapStageData_;
 
-		std::wstring GetPath(){return path_;}
-		std::wstring GetPlayerScriptID(){return playerScriptID_;}
-		void SetPlayerScriptID(std::wstring id){playerScriptID_ = id;}
-		std::wstring GetPlayerScriptFileName(){return playerScriptFileName_;}
-		void SetPlayerScriptFileName(std::wstring name){playerScriptFileName_ = name;}
-		std::wstring GetPlayerScriptReplayName(){return playerScriptReplayName_;}
-		void SetPlayerScriptReplayName(std::wstring name){playerScriptReplayName_ = name;}
+public:
+	ReplayInformation();
+	virtual ~ReplayInformation();
 
-		std::wstring GetComment(){return comment_;}
-		void SetComment(std::wstring comment){comment_ = comment;}
-		std::wstring GetUserName(){return userName_;}
-		void SetUserName(std::wstring name){userName_ = name;}
-		_int64 GetTotalScore(){return totalScore_;}
-		void SetTotalScore(_int64 score){totalScore_ = score;}
-		double GetAvarageFps(){return fpsAvarage_;}
-		void SetAvarageFps(double fps){fpsAvarage_ = fps;}
-		SYSTEMTIME GetDate(){return date_;}
-		void SetDate(SYSTEMTIME date){date_ = date;}
-		std::wstring GetDateAsString();
+	std::wstring GetPath() { return path_; }
+	std::wstring GetPlayerScriptID() { return playerScriptID_; }
+	void SetPlayerScriptID(std::wstring id) { playerScriptID_ = id; }
+	std::wstring GetPlayerScriptFileName() { return playerScriptFileName_; }
+	void SetPlayerScriptFileName(std::wstring name) { playerScriptFileName_ = name; }
+	std::wstring GetPlayerScriptReplayName() { return playerScriptReplayName_; }
+	void SetPlayerScriptReplayName(std::wstring name) { playerScriptReplayName_ = name; }
 
-		void SetUserData(std::string key, gstd::value val);
-		gstd::value GetUserData(std::string key);
-		bool IsUserDataExists(std::string key);
+	std::wstring GetComment() { return comment_; }
+	void SetComment(std::wstring comment) { comment_ = comment; }
+	std::wstring GetUserName() { return userName_; }
+	void SetUserName(std::wstring name) { userName_ = name; }
+	_int64 GetTotalScore() { return totalScore_; }
+	void SetTotalScore(_int64 score) { totalScore_ = score; }
+	double GetAvarageFps() { return fpsAvarage_; }
+	void SetAvarageFps(double fps) { fpsAvarage_ = fps; }
+	SYSTEMTIME GetDate() { return date_; }
+	void SetDate(SYSTEMTIME date) { date_ = date; }
+	std::wstring GetDateAsString();
 
-		ref_count_ptr<StageData> GetStageData(int stage){return mapStageData_[stage];}
-		void SetStageData(int stage, ref_count_ptr<StageData> data){mapStageData_[stage] = data;}
-		std::vector<int> GetStageIndexList();
+	void SetUserData(std::string key, gstd::value val);
+	gstd::value GetUserData(std::string key);
+	bool IsUserDataExists(std::string key);
 
-		bool SaveToFile(std::wstring scriptPath, int index);
-		static ref_count_ptr<ReplayInformation> CreateFromFile(std::wstring scriptPath, std::wstring fileName);
-		static ref_count_ptr<ReplayInformation> CreateFromFile(std::wstring path);
+	ref_count_ptr<StageData> GetStageData(int stage) { return mapStageData_[stage]; }
+	void SetStageData(int stage, ref_count_ptr<StageData> data) { mapStageData_[stage] = data; }
+	std::vector<int> GetStageIndexList();
+
+	bool SaveToFile(std::wstring scriptPath, int index);
+	static ref_count_ptr<ReplayInformation> CreateFromFile(std::wstring scriptPath, std::wstring fileName);
+	static ref_count_ptr<ReplayInformation> CreateFromFile(std::wstring path);
 };
 
-class ReplayInformation::StageData
-{
-	private:
-		//ステージ情報
-		std::wstring mainScriptID_;
-		std::wstring mainScriptName_;
-		std::wstring mainScriptRelativePath_;
+class ReplayInformation::StageData {
+public:
+	StageData()
+	{
+		recordKey_ = new gstd::RecordBuffer();
+		scoreStart_ = 0;
+		scoreLast_ = 0;
+	}
+	virtual ~StageData() {}
 
-		_int64 scoreStart_;
-		_int64 scoreLast_;
-		_int64 graze_;
-		_int64 point_;
-		int frameEnd_;
-		int randSeed_;
-		std::vector<float> listFramePerSecond_;
-		ref_count_ptr<gstd::RecordBuffer> recordKey_;
-		std::map<std::string, ref_count_ptr<gstd::RecordBuffer> > mapCommonData_;
+	std::wstring GetMainScriptID() { return mainScriptID_; }
+	void SetMainScriptID(std::wstring id) { mainScriptID_ = id; }
+	std::wstring GetMainScriptName() { return mainScriptName_; }
+	void SetMainScriptName(std::wstring name) { mainScriptName_ = name; }
+	std::wstring GetMainScriptRelativePath() { return mainScriptRelativePath_; }
+	void SetMainScriptRelativePath(std::wstring path) { mainScriptRelativePath_ = path; }
+	_int64 GetStartScore() { return scoreStart_; }
+	void SetStartScore(_int64 score) { scoreStart_ = score; }
+	_int64 GetLastScore() { return scoreLast_; }
+	void SetLastScore(_int64 score) { scoreLast_ = score; }
+	_int64 GetGraze() { return graze_; }
+	void SetGraze(_int64 graze) { graze_ = graze; }
+	_int64 GetPoint() { return point_; }
+	void SetPoint(_int64 point) { point_ = point; }
+	int GetEndFrame() { return frameEnd_; }
+	void SetEndFrame(int frame) { frameEnd_ = frame; }
+	int GetRandSeed() { return randSeed_; }
+	void SetRandSeed(int seed) { randSeed_ = seed; }
+	float GetFramePerSecond(int frame)
+	{
+		int index = frame / 60;
+		int res = index < listFramePerSecond_.size() ? listFramePerSecond_[index] : 0;
+		return res;
+	}
+	void AddFramePerSecond(float frame) { listFramePerSecond_.push_back(frame); }
+	double GetFramePerSecondAvarage();
+	ref_count_ptr<gstd::RecordBuffer> GetReplayKeyRecord() { return recordKey_; }
+	void SetReplayKeyRecord(ref_count_ptr<gstd::RecordBuffer> rec) { recordKey_ = rec; }
+	std::set<std::string> GetCommonDataAreaList();
+	ref_count_ptr<ScriptCommonData> GetCommonData(std::string area);
+	void SetCommonData(std::string area, ref_count_ptr<ScriptCommonData> commonData);
 
-		//自機情報
-		std::wstring playerScriptID_;
-		std::wstring playerScriptFileName_;
-		std::wstring playerScriptReplayName_;
+	std::wstring GetPlayerScriptID() { return playerScriptID_; }
+	void SetPlayerScriptID(std::wstring id) { playerScriptID_ = id; }
+	std::wstring GetPlayerScriptFileName() { return playerScriptFileName_; }
+	void SetPlayerScriptFileName(std::wstring name) { playerScriptFileName_ = name; }
+	std::wstring GetPlayerScriptReplayName() { return playerScriptReplayName_; }
+	void SetPlayerScriptReplayName(std::wstring name) { playerScriptReplayName_ = name; }
+	double GetPlayerLife() { return playerLife_; }
+	void SetPlayerLife(double life) { playerLife_ = life; }
+	double GetPlayerBombCount() { return playerBombCount_; }
+	void SetPlayerBombCount(double bomb) { playerBombCount_ = bomb; }
+	double GetPlayerPower() { return playerPower_; }
+	void SetPlayerPower(double power) { playerPower_ = power; }
+	int GetPlayerRebirthFrame() { return playerRebirthFrame_; }
+	void SetPlayerRebirthFrame(int frame) { playerRebirthFrame_ = frame; }
 
-		double playerLife_;
-		double playerBombCount_;
-		double playerPower_;
-		int playerRebirthFrame_;//くらいボム有効フレーム
+	void ReadRecord(gstd::RecordBuffer& record);
+	void WriteRecord(gstd::RecordBuffer& record);
 
-	public:
-		StageData(){recordKey_ = new gstd::RecordBuffer();scoreStart_=0;scoreLast_=0;}
-		virtual ~StageData(){}
+private:
+	//ステージ情報
+	std::wstring mainScriptID_;
+	std::wstring mainScriptName_;
+	std::wstring mainScriptRelativePath_;
 
-		std::wstring GetMainScriptID(){return mainScriptID_;}
-		void SetMainScriptID(std::wstring id){mainScriptID_ = id;}
-		std::wstring GetMainScriptName(){return mainScriptName_;}
-		void SetMainScriptName(std::wstring name){mainScriptName_ = name;}
-		std::wstring GetMainScriptRelativePath(){return mainScriptRelativePath_;}
-		void SetMainScriptRelativePath(std::wstring path){mainScriptRelativePath_ = path;}
-		_int64 GetStartScore(){return scoreStart_;}
-		void SetStartScore(_int64 score){scoreStart_ = score;}
-		_int64 GetLastScore(){return scoreLast_;}
-		void SetLastScore(_int64 score){scoreLast_ = score;}
-		_int64 GetGraze(){return graze_;}
-		void SetGraze(_int64 graze){graze_ = graze;}
-		_int64 GetPoint(){return point_;}
-		void SetPoint(_int64 point){point_ = point;}
-		int GetEndFrame(){return frameEnd_;}
-		void SetEndFrame(int frame){frameEnd_ = frame;}
-		int GetRandSeed(){return randSeed_;}
-		void SetRandSeed(int seed){randSeed_ = seed;}
-		float GetFramePerSecond(int frame){int index = frame / 60; int res = index < listFramePerSecond_.size() ? listFramePerSecond_[index] : 0; return res;}
-		void AddFramePerSecond(float frame){listFramePerSecond_.push_back(frame);}
-		double GetFramePerSecondAvarage();
-		ref_count_ptr<gstd::RecordBuffer> GetReplayKeyRecord(){return recordKey_;}
-		void SetReplayKeyRecord(ref_count_ptr<gstd::RecordBuffer> rec){recordKey_ = rec;}
-		std::set<std::string> GetCommonDataAreaList();
-		ref_count_ptr<ScriptCommonData> GetCommonData(std::string area);
-		void SetCommonData(std::string area, ref_count_ptr<ScriptCommonData> commonData);
+	_int64 scoreStart_;
+	_int64 scoreLast_;
+	_int64 graze_;
+	_int64 point_;
+	int frameEnd_;
+	int randSeed_;
+	std::vector<float> listFramePerSecond_;
+	ref_count_ptr<gstd::RecordBuffer> recordKey_;
+	std::map<std::string, ref_count_ptr<gstd::RecordBuffer>> mapCommonData_;
 
-		std::wstring GetPlayerScriptID(){return playerScriptID_;}
-		void SetPlayerScriptID(std::wstring id){playerScriptID_ = id;}
-		std::wstring GetPlayerScriptFileName(){return playerScriptFileName_;}
-		void SetPlayerScriptFileName(std::wstring name){playerScriptFileName_ = name;}
-		std::wstring GetPlayerScriptReplayName(){return playerScriptReplayName_;}
-		void SetPlayerScriptReplayName(std::wstring name){playerScriptReplayName_ = name;}
-		double GetPlayerLife(){return playerLife_;}
-		void SetPlayerLife(double life){playerLife_ = life;}
-		double GetPlayerBombCount(){return playerBombCount_;}
-		void SetPlayerBombCount(double bomb){playerBombCount_ = bomb;}
-		double GetPlayerPower(){return playerPower_;}
-		void SetPlayerPower(double power){playerPower_ = power;}
-		int GetPlayerRebirthFrame(){return playerRebirthFrame_;}
-		void SetPlayerRebirthFrame(int frame){playerRebirthFrame_ = frame;}
+	//自機情報
+	std::wstring playerScriptID_;
+	std::wstring playerScriptFileName_;
+	std::wstring playerScriptReplayName_;
 
-		void ReadRecord(gstd::RecordBuffer& record);
-		void WriteRecord(gstd::RecordBuffer& record);
+	double playerLife_;
+	double playerBombCount_;
+	double playerPower_;
+	int playerRebirthFrame_; //くらいボム有効フレーム
 };
 
 /**********************************************************
 //ReplayInformationManager
 **********************************************************/
-class ReplayInformationManager
-{
-	public:
+class ReplayInformationManager {
+public:
+	ReplayInformationManager();
+	virtual ~ReplayInformationManager();
 
-	protected:
-		std::map<int, ref_count_ptr<ReplayInformation> > mapInfo_;
-	public:
-		ReplayInformationManager();
-		virtual ~ReplayInformationManager();
+	void UpdateInformationList(std::wstring pathScript);
+	std::vector<int> GetIndexList();
+	ref_count_ptr<ReplayInformation> GetInformation(int index);
 
-		void UpdateInformationList(std::wstring pathScript);
-		std::vector<int> GetIndexList();
-		ref_count_ptr<ReplayInformation> GetInformation(int index);
+protected:
+	std::map<int, ref_count_ptr<ReplayInformation>> mapInfo_;
 };
 
 #endif

--- a/source/TouhouDanmakufu/Common/DnhScript.cpp
+++ b/source/TouhouDanmakufu/Common/DnhScript.cpp
@@ -1,30 +1,29 @@
-#include"DnhScript.hpp"
-#include"DnhCommon.hpp"
-#include"DnhGcLibImpl.hpp"
+#include "DnhScript.hpp"
+#include "DnhCommon.hpp"
+#include "DnhGcLibImpl.hpp"
 
 /**********************************************************
 //DnhScript
 **********************************************************/
-const static function dnhFunction[] =  
-{
-	{"KEY_INVALID", constant<EDirectInput::KEY_INVALID>::func, 0},
+const static function dnhFunction[] = {
+	{ "KEY_INVALID", constant<EDirectInput::KEY_INVALID>::func, 0 },
 
-	{"VK_LEFT", constant<EDirectInput::KEY_LEFT>::func, 0},
-	{"VK_RIGHT", constant<EDirectInput::KEY_RIGHT>::func, 0},
-	{"VK_UP", constant<EDirectInput::KEY_UP>::func, 0},
-	{"VK_DOWN", constant<EDirectInput::KEY_DOWN>::func, 0},
-	{"VK_SHOT", constant<EDirectInput::KEY_SHOT>::func, 0},
-	{"VK_BOMB", constant<EDirectInput::KEY_BOMB>::func, 0},
-	{"VK_SPELL", constant<EDirectInput::KEY_BOMB>::func, 0},
-	{"VK_SLOWMOVE", constant<EDirectInput::KEY_SLOWMOVE>::func, 0},
-	{"VK_USER1", constant<EDirectInput::KEY_USER1>::func, 0},
-	{"VK_USER2", constant<EDirectInput::KEY_USER2>::func, 0},
-	{"VK_OK", constant<EDirectInput::KEY_OK>::func, 0},
-	{"VK_CANCEL", constant<EDirectInput::KEY_CANCEL>::func, 0},
-	{"VK_PAUSE", constant<EDirectInput::KEY_PAUSE>::func, 0},
+	{ "VK_LEFT", constant<EDirectInput::KEY_LEFT>::func, 0 },
+	{ "VK_RIGHT", constant<EDirectInput::KEY_RIGHT>::func, 0 },
+	{ "VK_UP", constant<EDirectInput::KEY_UP>::func, 0 },
+	{ "VK_DOWN", constant<EDirectInput::KEY_DOWN>::func, 0 },
+	{ "VK_SHOT", constant<EDirectInput::KEY_SHOT>::func, 0 },
+	{ "VK_BOMB", constant<EDirectInput::KEY_BOMB>::func, 0 },
+	{ "VK_SPELL", constant<EDirectInput::KEY_BOMB>::func, 0 },
+	{ "VK_SLOWMOVE", constant<EDirectInput::KEY_SLOWMOVE>::func, 0 },
+	{ "VK_USER1", constant<EDirectInput::KEY_USER1>::func, 0 },
+	{ "VK_USER2", constant<EDirectInput::KEY_USER2>::func, 0 },
+	{ "VK_OK", constant<EDirectInput::KEY_OK>::func, 0 },
+	{ "VK_CANCEL", constant<EDirectInput::KEY_CANCEL>::func, 0 },
+	{ "VK_PAUSE", constant<EDirectInput::KEY_PAUSE>::func, 0 },
 
-	{"VK_USER_ID_STAGE", constant<EDirectInput::VK_USER_ID_STAGE>::func, 0},
-	{"VK_USER_ID_PLAYER", constant<EDirectInput::VK_USER_ID_PLAYER>::func, 0},
+	{ "VK_USER_ID_STAGE", constant<EDirectInput::VK_USER_ID_STAGE>::func, 0 },
+	{ "VK_USER_ID_PLAYER", constant<EDirectInput::VK_USER_ID_PLAYER>::func, 0 },
 };
 DnhScript::DnhScript()
 {

--- a/source/TouhouDanmakufu/Common/DnhScript.hpp
+++ b/source/TouhouDanmakufu/Common/DnhScript.hpp
@@ -1,17 +1,14 @@
 #ifndef __TOUHOUDANMAKUFU_DNHSCRIPT__
 #define __TOUHOUDANMAKUFU_DNHSCRIPT__
 
-#include"DnhCommon.hpp"
-
+#include "DnhCommon.hpp"
 
 /**********************************************************
 //DnhScript
 **********************************************************/
-class DnhScript : public ManagedScript
-{
-
-	public:
-		DnhScript();
+class DnhScript : public ManagedScript {
+public:
+	DnhScript();
 };
 
 #endif

--- a/source/TouhouDanmakufu/Common/StgCommon.cpp
+++ b/source/TouhouDanmakufu/Common/StgCommon.cpp
@@ -1,5 +1,5 @@
-#include"StgCommon.hpp"
-#include"StgSystem.hpp"
+#include "StgCommon.hpp"
+#include "StgSystem.hpp"
 
 /**********************************************************
 //StgMoveObject
@@ -13,18 +13,16 @@ StgMoveObject::StgMoveObject(StgStageController* stageController)
 }
 StgMoveObject::~StgMoveObject()
 {
-
 }
 void StgMoveObject::_Move()
 {
-	if(pattern_ == NULL)return;
+	if (pattern_ == NULL)
+		return;
 
-	if(mapPattern_.size() > 0)
-	{
-		std::map<int, ref_count_ptr<StgMovePattern>::unsync >::iterator itr = mapPattern_.begin();
+	if (mapPattern_.size() > 0) {
+		std::map<int, ref_count_ptr<StgMovePattern>::unsync>::iterator itr = mapPattern_.begin();
 		int frame = itr->first;
-		if(frame == framePattern_)
-		{
+		if (frame == framePattern_) {
 			ref_count_ptr<StgMovePattern>::unsync pattern = itr->second;
 			_AttachReservedPattern(pattern);
 			mapPattern_.erase(frame);
@@ -37,20 +35,17 @@ void StgMoveObject::_Move()
 void StgMoveObject::_AttachReservedPattern(ref_count_ptr<StgMovePattern>::unsync pattern)
 {
 	//速度継続など
-	if(pattern_ == NULL)
+	if (pattern_ == NULL)
 		pattern_ = new StgMovePattern_Angle(this);
 
 	int newMoveType = pattern->GetType();
-	if(newMoveType == StgMovePattern::TYPE_ANGLE)
-	{
+	if (newMoveType == StgMovePattern::TYPE_ANGLE) {
 		StgMovePattern_Angle* angPattern = (StgMovePattern_Angle*)pattern.GetPointer();
-		if(angPattern->GetSpeed() == StgMovePattern::NO_CHANGE)
+		if (angPattern->GetSpeed() == StgMovePattern::NO_CHANGE)
 			angPattern->SetSpeed(pattern_->GetSpeed());
-		if(angPattern->GetDirectionAngle() == StgMovePattern::NO_CHANGE)
+		if (angPattern->GetDirectionAngle() == StgMovePattern::NO_CHANGE)
 			angPattern->SetDirectionAngle(pattern_->GetDirectionAngle());
-	}
-	else if(newMoveType == StgMovePattern::TYPE_XY)
-	{
+	} else if (newMoveType == StgMovePattern::TYPE_XY) {
 		StgMovePattern_XY* xyPattern = (StgMovePattern_XY*)pattern.GetPointer();
 
 		double speed = pattern_->GetSpeed();
@@ -61,9 +56,9 @@ void StgMoveObject::_AttachReservedPattern(ref_count_ptr<StgMovePattern>::unsync
 		double speedX = speed * c;
 		double speedY = speed * s;
 
-		if(xyPattern->GetSpeedX() == StgMovePattern::NO_CHANGE)
+		if (xyPattern->GetSpeedX() == StgMovePattern::NO_CHANGE)
 			xyPattern->SetSpeedX(speedX);
-		if(xyPattern->GetSpeedY() == StgMovePattern::NO_CHANGE)
+		if (xyPattern->GetSpeedY() == StgMovePattern::NO_CHANGE)
 			xyPattern->SetSpeedY(speedY);
 	}
 
@@ -72,14 +67,14 @@ void StgMoveObject::_AttachReservedPattern(ref_count_ptr<StgMovePattern>::unsync
 }
 double StgMoveObject::GetSpeed()
 {
-	if(pattern_ == NULL)return 0;
+	if (pattern_ == NULL)
+		return 0;
 	double res = pattern_->GetSpeed();
 	return res;
 }
 void StgMoveObject::SetSpeed(double speed)
 {
-	if(pattern_ == NULL || pattern_->GetType() != StgMovePattern::TYPE_ANGLE)
-	{
+	if (pattern_ == NULL || pattern_->GetType() != StgMovePattern::TYPE_ANGLE) {
 		pattern_ = new StgMovePattern_Angle(this);
 	}
 	StgMovePattern_Angle* pattern = (StgMovePattern_Angle*)pattern_.GetPointer();
@@ -87,14 +82,14 @@ void StgMoveObject::SetSpeed(double speed)
 }
 double StgMoveObject::GetDirectionAngle()
 {
-	if(pattern_ == NULL)return 0;
+	if (pattern_ == NULL)
+		return 0;
 	double res = pattern_->GetDirectionAngle();
 	return res;
 }
 void StgMoveObject::SetDirectionAngle(double angle)
 {
-	if(pattern_ == NULL || pattern_->GetType() != StgMovePattern::TYPE_ANGLE)
-	{
+	if (pattern_ == NULL || pattern_->GetType() != StgMovePattern::TYPE_ANGLE) {
 		pattern_ = new StgMovePattern_Angle(this);
 	}
 	StgMovePattern_Angle* pattern = (StgMovePattern_Angle*)pattern_.GetPointer();
@@ -102,15 +97,15 @@ void StgMoveObject::SetDirectionAngle(double angle)
 }
 void StgMoveObject::AddPattern(int frameDelay, ref_count_ptr<StgMovePattern>::unsync pattern)
 {
-	if(frameDelay == 0)
+	if (frameDelay == 0)
 		_AttachReservedPattern(pattern);
-	else
-	{
+	else {
 		int frame = frameDelay + framePattern_;
 		mapPattern_[frame] = pattern;
 	}
 }
-double StgMoveObject::cssn(double s, double ang) {
+double StgMoveObject::cssn(double s, double ang)
+{
 	const double PAI = 3.14159265358979323846;
 	const double TWOPAI = PAI * 2;
 	double c = sqrt(1 - s * s);
@@ -138,13 +133,15 @@ ref_count_ptr<StgMoveObject>::unsync StgMovePattern::_GetMoveObject(int id)
 {
 	StgStageController* controller = _GetStageController();
 	ref_count_ptr<DxScriptObjectBase>::unsync base = controller->GetMainRenderObject(id);
-	if(base == NULL || base->IsDeleted())return NULL;
+	if (base == NULL || base->IsDeleted())
+		return NULL;
 
 	return ref_count_ptr<StgMoveObject>::unsync::DownCast(base);
 }
 
 //StgMovePattern_Angle
-StgMovePattern_Angle::StgMovePattern_Angle(StgMoveObject* target) : StgMovePattern(target)
+StgMovePattern_Angle::StgMovePattern_Angle(StgMoveObject* target)
+	: StgMovePattern(target)
 {
 	typeMove_ = TYPE_ANGLE;
 	speed_ = 0;
@@ -156,20 +153,18 @@ StgMovePattern_Angle::StgMovePattern_Angle(StgMoveObject* target) : StgMovePatte
 }
 void StgMovePattern_Angle::Move()
 {
-	if(frameWork_ == 0)
+	if (frameWork_ == 0)
 		_Activate();
 	double angle = angDirection_;
 
-	if(acceleration_ != 0)
-	{
+	if (acceleration_ != 0) {
 		speed_ += acceleration_;
-		if(acceleration_ > 0)
+		if (acceleration_ > 0)
 			speed_ = min(speed_, maxSpeed_);
-		if(acceleration_ < 0)
+		if (acceleration_ < 0)
 			speed_ = max(speed_, maxSpeed_);
 	}
-	if(angularVelocity_ != 0)
-	{
+	if (angularVelocity_ != 0) {
 		angDirection_ += angularVelocity_;
 	}
 
@@ -187,26 +182,24 @@ void StgMovePattern_Angle::Move()
 	frameWork_++;
 }
 
-double StgMovePattern::cssn(double s, double ang) {
+double StgMovePattern::cssn(double s, double ang)
+{
 	const double PAI = 3.14159265358979323846;
 	const double TWOPAI = PAI * 2;
 	double c = sqrt(1 - s * s);
-	double angMod = fmod(ang,TWOPAI);
+	double angMod = fmod(ang, TWOPAI);
 	double fullRad = (angMod * TWOPAI < 0) ? (angMod + TWOPAI) : angMod;
 	double normRad = (fullRad > PAI) ? (fullRad - TWOPAI) : fullRad;
-	if (abs(normRad) > (PAI / 2)) {
+	if (abs(normRad) > (PAI / 2))
 		c *= -1;
-	}
 	return c;
 }
 
 void StgMovePattern_Angle::_Activate()
 {
-	if(idRalativeID_ != DxScript::ID_INVALID)
-	{
+	if (idRalativeID_ != DxScript::ID_INVALID) {
 		ref_count_ptr<StgMoveObject>::unsync obj = _GetMoveObject(idRalativeID_);
-		if(obj != NULL)
-		{
+		if (obj != NULL) {
 			double px = target_->GetPositionX();
 			double py = target_->GetPositionY();
 			double tx = obj->GetPositionX();
@@ -215,11 +208,11 @@ void StgMovePattern_Angle::_Activate()
 			angDirection_ += angle;
 		}
 	}
-
 }
 
 //StgMovePattern_XY
-StgMovePattern_XY::StgMovePattern_XY(StgMoveObject* target) : StgMovePattern(target)
+StgMovePattern_XY::StgMovePattern_XY(StgMoveObject* target)
+	: StgMovePattern(target)
 {
 	typeMove_ = TYPE_XY;
 	speedX_ = 0;
@@ -231,23 +224,21 @@ StgMovePattern_XY::StgMovePattern_XY(StgMoveObject* target) : StgMovePattern(tar
 }
 void StgMovePattern_XY::Move()
 {
-	if(frameWork_ == 0)
+	if (frameWork_ == 0)
 		_Activate();
 
-	if(accelerationX_ != 0)
-	{
+	if (accelerationX_ != 0) {
 		speedX_ += accelerationX_;
-		if(accelerationX_ > 0)
+		if (accelerationX_ > 0)
 			speedX_ = min(speedX_, maxSpeedX_);
-		if(accelerationX_ < 0)
+		if (accelerationX_ < 0)
 			speedX_ = max(speedX_, maxSpeedX_);
 	}
-	if(accelerationY_ != 0)
-	{
+	if (accelerationY_ != 0) {
 		speedY_ += accelerationY_;
-		if(accelerationY_ > 0)
+		if (accelerationY_ > 0)
 			speedY_ = min(speedY_, maxSpeedY_);
-		if(accelerationY_ < 0)
+		if (accelerationY_ < 0)
 			speedY_ = max(speedY_, maxSpeedY_);
 	}
 
@@ -271,7 +262,8 @@ double StgMovePattern_XY::GetDirectionAngle()
 }
 
 //StgMovePattern_Line
-StgMovePattern_Line::StgMovePattern_Line(StgMoveObject* target) : StgMovePattern(target)
+StgMovePattern_Line::StgMovePattern_Line(StgMoveObject* target)
+	: StgMovePattern(target)
 {
 	typeMove_ = TYPE_NONE;
 	speed_ = 0;
@@ -282,8 +274,7 @@ StgMovePattern_Line::StgMovePattern_Line(StgMoveObject* target) : StgMovePattern
 }
 void StgMovePattern_Line::Move()
 {
-	if(typeLine_ == TYPE_SPEED || typeLine_ == TYPE_FRAME)
-	{
+	if (typeLine_ == TYPE_SPEED || typeLine_ == TYPE_FRAME) {
 		double ang = Math::DegreeToRadian(angDirection_);
 		double s = sin(ang);
 		double c = cos(ang);
@@ -295,26 +286,20 @@ void StgMovePattern_Line::Move()
 		target_->SetPositionX(px);
 		target_->SetPositionY(py);
 		frameStop_--;
-		if(frameStop_ <= 0)
-		{
+		if (frameStop_ <= 0) {
 			typeLine_ = TYPE_NONE;
 			speed_ = 0;
 		}
-	}
-	else if(typeLine_ == TYPE_WEIGHT)
-	{
+	} else if (typeLine_ == TYPE_WEIGHT) {
 		double nx = target_->GetPositionX();
 		double ny = target_->GetPositionY();
 		double dist = pow(pow(toX_ - nx, 2) + pow(toY_ - ny, 2), 0.5);
-		if(dist < 1)
-		{
+		if (dist < 1) {
 			typeLine_ = TYPE_NONE;
 			speed_ = 0;
-		}
-		else
-		{
+		} else {
 			speed_ = dist / weight_;
-			if(speed_ > maxSpeed_)
+			if (speed_ > maxSpeed_)
 				speed_ = maxSpeed_;
 			double ang = Math::DegreeToRadian(angDirection_);
 			double s = sin(ang);
@@ -326,7 +311,6 @@ void StgMovePattern_Line::Move()
 			target_->SetPositionX(px);
 			target_->SetPositionY(py);
 		}
-
 	}
 }
 void StgMovePattern_Line::SetAtSpeed(double tx, double ty, double speed)

--- a/source/TouhouDanmakufu/Common/StgCommon.hpp
+++ b/source/TouhouDanmakufu/Common/StgCommon.hpp
@@ -1,10 +1,10 @@
 #ifndef __TOUHOUDANMAKUFU_DNHSTG_COMMON__
 #define __TOUHOUDANMAKUFU_DNHSTG_COMMON__
 
-#include"DnhCommon.hpp"
-#include"DnhGcLibImpl.hpp"
-#include"DnhReplay.hpp"
-#include"DnhScript.hpp"
+#include "DnhCommon.hpp"
+#include "DnhGcLibImpl.hpp"
+#include "DnhReplay.hpp"
+#include "DnhScript.hpp"
 
 class StgSystemController;
 class StgSystemInformation;
@@ -17,166 +17,164 @@ class StgMovePattern;
 /**********************************************************
 //StgMoveObject
 **********************************************************/
-class StgMoveObject
-{
+class StgMoveObject {
 	friend StgMovePattern;
-	private:
-		StgStageController* stageController_;
-	protected:
-		double posX_;
-		double posY_;
-		ref_count_ptr<StgMovePattern>::unsync pattern_;
 
-		int framePattern_;
-		std::map<int, ref_count_ptr<StgMovePattern>::unsync > mapPattern_;
-		virtual void _Move();
-		void _AttachReservedPattern(ref_count_ptr<StgMovePattern>::unsync pattern);
+public:
+	StgMoveObject(StgStageController* stageController);
+	virtual ~StgMoveObject();
 
-	public:
-		StgMoveObject(StgStageController* stageController);
-		virtual ~StgMoveObject();
+	double GetPositionX() { return posX_; }
+	void SetPositionX(double pos) { posX_ = pos; }
+	double GetPositionY() { return posY_; }
+	void SetPositionY(double pos) { posY_ = pos; }
+	double cssn(double s, double ang);
 
-		double GetPositionX(){return posX_;}
-		void SetPositionX(double pos){posX_ = pos;}
-		double GetPositionY(){return posY_;}
-		void SetPositionY(double pos){posY_ = pos;}
-		double cssn(double s, double ang);
+	double GetSpeed();
+	void SetSpeed(double speed);
+	double GetDirectionAngle();
+	void SetDirectionAngle(double angle);
 
-		double GetSpeed();
-		void SetSpeed(double speed);
-		double GetDirectionAngle();
-		void SetDirectionAngle(double angle);
+	void SetSpeedX(double speedX);
+	void SetSpeedY(double sppedY);
 
-		void SetSpeedX(double speedX);
-		void SetSpeedY(double sppedY);
+	ref_count_ptr<StgMovePattern>::unsync GetPattern() { return pattern_; }
+	void SetPattern(ref_count_ptr<StgMovePattern>::unsync pattern) { pattern_ = pattern; }
+	void AddPattern(int frameDelay, ref_count_ptr<StgMovePattern>::unsync pattern);
 
-		ref_count_ptr<StgMovePattern>::unsync GetPattern(){return pattern_;}
-		void SetPattern(ref_count_ptr<StgMovePattern>::unsync pattern){pattern_ = pattern;}
-		void AddPattern(int frameDelay, ref_count_ptr<StgMovePattern>::unsync pattern);
+protected:
+	double posX_;
+	double posY_;
+	ref_count_ptr<StgMovePattern>::unsync pattern_;
+
+	int framePattern_;
+	std::map<int, ref_count_ptr<StgMovePattern>::unsync> mapPattern_;
+	virtual void _Move();
+	void _AttachReservedPattern(ref_count_ptr<StgMovePattern>::unsync pattern);
+
+private:
+	StgStageController* stageController_;
 };
 
 /**********************************************************
 //StgMovePattern
 **********************************************************/
-class StgMovePattern
-{
-	public:
-		enum
-		{
-			TYPE_OTHER,
-			TYPE_ANGLE,
-			TYPE_XY,
-			TYPE_LINE,
+class StgMovePattern {
+public:
+	enum {
+		TYPE_OTHER,
+		TYPE_ANGLE,
+		TYPE_XY,
+		TYPE_LINE,
 
-			NO_CHANGE = -256*256*256,
-		};
+		NO_CHANGE = -256 * 256 * 256,
+	};
 
-	protected:
-		int typeMove_;
-		StgMoveObject* target_;
+public:
+	StgMovePattern(StgMoveObject* target);
+	virtual ~StgMovePattern() {}
+	virtual void Move() = 0;
+	double cssn(double c, double ang);
 
-		int frameWork_;//アクティブになるフレーム。
-		int idShotData_;//弾画像ID(弾オブジェクト専用)
-		
-		StgStageController* _GetStageController(){return target_->stageController_;}
-		ref_count_ptr<StgMoveObject>::unsync _GetMoveObject(int id);
-		virtual void _Activate(){}
-	public:
-		StgMovePattern(StgMoveObject* target);
-		virtual ~StgMovePattern(){}
-		virtual void Move() = 0;
-		double cssn(double c, double ang);
+	int GetType() { return typeMove_; }
 
-		int GetType(){return typeMove_;}
+	virtual double GetSpeed() = 0;
+	virtual double GetDirectionAngle() = 0;
+	int GetShotDataID() { return idShotData_; }
+	void SetShotDataID(int id) { idShotData_ = id; }
 
-		virtual double GetSpeed() = 0;
-		virtual double GetDirectionAngle() = 0;
-		int GetShotDataID(){return idShotData_;}
-		void SetShotDataID(int id){idShotData_ = id;}
+protected:
+	int typeMove_;
+	StgMoveObject* target_;
+
+	int frameWork_; //アクティブになるフレーム。
+	int idShotData_; //弾画像ID(弾オブジェクト専用)
+
+	StgStageController* _GetStageController() { return target_->stageController_; }
+	ref_count_ptr<StgMoveObject>::unsync _GetMoveObject(int id);
+	virtual void _Activate() {}
 };
 
-class StgMovePattern_Angle : public StgMovePattern
-{
-	protected:
-		double speed_;
-		double angDirection_;
-		double acceleration_;
-		double maxSpeed_;
-		double angularVelocity_;
-		int idRalativeID_;
+class StgMovePattern_Angle : public StgMovePattern {
+public:
+	StgMovePattern_Angle(StgMoveObject* target);
+	virtual void Move();
 
-		virtual void _Activate();
-	public:
-		StgMovePattern_Angle(StgMoveObject* target);
-		virtual void Move();
+	virtual double GetSpeed() { return speed_; }
+	virtual double GetDirectionAngle() { return angDirection_; }
 
-		virtual double GetSpeed(){return speed_;}
-		virtual double GetDirectionAngle(){return angDirection_;}
+	void SetSpeed(double speed) { speed_ = speed; }
+	void SetDirectionAngle(double angle) { angDirection_ = angle; }
+	void SetAcceleration(double accel) { acceleration_ = accel; }
+	void SetMaxSpeed(double max) { maxSpeed_ = max; }
+	void SetAngularVelocity(double av) { angularVelocity_ = av; }
+	void SetRelativeObjectID(int id) { idRalativeID_ = id; }
 
-		void SetSpeed(double speed){speed_ = speed;}
-		void SetDirectionAngle(double angle){angDirection_ = angle;}
-		void SetAcceleration(double accel){acceleration_ = accel;}
-		void SetMaxSpeed(double max){maxSpeed_ = max;}
-		void SetAngularVelocity(double av){angularVelocity_ = av;}
-		void SetRelativeObjectID(int id){idRalativeID_ = id;}
+protected:
+	double speed_;
+	double angDirection_;
+	double acceleration_;
+	double maxSpeed_;
+	double angularVelocity_;
+	int idRalativeID_;
+
+	virtual void _Activate();
 };
 
-class StgMovePattern_XY : public StgMovePattern
-{
-	protected:
-		double speedX_;
-		double speedY_;
-		double accelerationX_;
-		double accelerationY_;
-		double maxSpeedX_;
-		double maxSpeedY_;
+class StgMovePattern_XY : public StgMovePattern {
+public:
+	StgMovePattern_XY(StgMoveObject* target);
+	virtual void Move();
 
-	public:
-		StgMovePattern_XY(StgMoveObject* target);
-		virtual void Move();
+	virtual double GetSpeed();
+	virtual double GetDirectionAngle();
 
-		virtual double GetSpeed();
-		virtual double GetDirectionAngle();
+	double GetSpeedX() { return speedX_; }
+	double GetSpeedY() { return speedY_; }
+	void SetSpeedX(double value) { speedX_ = value; }
+	void SetSpeedY(double value) { speedY_ = value; }
+	void SetAccelerationX(double value) { accelerationX_ = value; }
+	void SetAccelerationY(double value) { accelerationY_ = value; }
+	void SetMaxSpeedX(double value) { maxSpeedX_ = value; }
+	void SetMaxSpeedY(double value) { maxSpeedY_ = value; }
 
-		double GetSpeedX(){return speedX_;}
-		double GetSpeedY(){return speedY_;}
-		void SetSpeedX(double value){speedX_ = value;}
-		void SetSpeedY(double value){speedY_ = value;}
-		void SetAccelerationX(double value){accelerationX_ = value;}
-		void SetAccelerationY(double value){accelerationY_ = value;}
-		void SetMaxSpeedX(double value){maxSpeedX_ = value;}
-		void SetMaxSpeedY(double value){maxSpeedY_ = value;}
+protected:
+	double speedX_;
+	double speedY_;
+	double accelerationX_;
+	double accelerationY_;
+	double maxSpeedX_;
+	double maxSpeedY_;
 };
 
-class StgMovePattern_Line : public StgMovePattern
-{
-	protected:
-		enum
-		{
-			TYPE_SPEED,
-			TYPE_FRAME,
-			TYPE_WEIGHT,
-			TYPE_NONE,
-		};
+class StgMovePattern_Line : public StgMovePattern {
+protected:
+	enum {
+		TYPE_SPEED,
+		TYPE_FRAME,
+		TYPE_WEIGHT,
+		TYPE_NONE,
+	};
 
-		int typeLine_;
-		double speed_;
-		double angDirection_;
-		double weight_;
-		double maxSpeed_;
-		int frameStop_;
-		double toX_;
-		double toY_;
+public:
+	StgMovePattern_Line(StgMoveObject* target);
+	virtual void Move();
+	virtual double GetSpeed() { return speed_; }
+	virtual double GetDirectionAngle() { return angDirection_; }
 
-	public:
-		StgMovePattern_Line(StgMoveObject* target);
-		virtual void Move();
-		virtual double GetSpeed(){return speed_;}
-		virtual double GetDirectionAngle(){return angDirection_;}
+	void SetAtSpeed(double tx, double ty, double speed);
+	void SetAtFrame(double tx, double ty, double frame);
+	void SetAtWait(double tx, double ty, double weight, double maxSpeed);
 
-		void SetAtSpeed(double tx, double ty, double speed);
-		void SetAtFrame(double tx, double ty, double frame);
-		void SetAtWait(double tx, double ty, double weight, double maxSpeed);
+protected:
+	int typeLine_;
+	double speed_;
+	double angDirection_;
+	double weight_;
+	double maxSpeed_;
+	int frameStop_;
+	double toX_;
+	double toY_;
 };
 
 #endif

--- a/source/TouhouDanmakufu/Common/StgControlScript.cpp
+++ b/source/TouhouDanmakufu/Common/StgControlScript.cpp
@@ -1,16 +1,14 @@
-#include"StgControlScript.hpp"
-#include"StgSystem.hpp"
+#include "StgControlScript.hpp"
+#include "StgSystem.hpp"
 
 /**********************************************************
 //StgControlScriptManager
 **********************************************************/
 StgControlScriptManager::StgControlScriptManager()
 {
-
 }
 StgControlScriptManager::~StgControlScriptManager()
 {
-
 }
 
 /**********************************************************
@@ -36,124 +34,122 @@ void StgControlScriptInformation::LoadReplayInformation(std::wstring pathMainScr
 	replayManager_->UpdateInformationList(pathMainScript);
 }
 
-
 /**********************************************************
 //StgControlScript
 **********************************************************/
-const function stgControlFunction[] =  
-{
+const function stgControlFunction[] = {
 	//関数：
 	//STG制御共通関数：共通データ
-	{"SaveCommonDataAreaA1", StgControlScript::Func_SaveCommonDataAreaA1, 1},
-	{"LoadCommonDataAreaA1", StgControlScript::Func_LoadCommonDataAreaA1, 1},
-	{"SaveCommonDataAreaA2", StgControlScript::Func_SaveCommonDataAreaA2, 2},
-	{"LoadCommonDataAreaA2", StgControlScript::Func_LoadCommonDataAreaA2, 2},
+	{ "SaveCommonDataAreaA1", StgControlScript::Func_SaveCommonDataAreaA1, 1 },
+	{ "LoadCommonDataAreaA1", StgControlScript::Func_LoadCommonDataAreaA1, 1 },
+	{ "SaveCommonDataAreaA2", StgControlScript::Func_SaveCommonDataAreaA2, 2 },
+	{ "LoadCommonDataAreaA2", StgControlScript::Func_LoadCommonDataAreaA2, 2 },
 
 	//STG制御共通関数：キー系
-	{"AddVirtualKey", StgControlScript::Func_AddVirtualKey, 3},
-	{"AddReplayTargetVirtualKey", StgControlScript::Func_AddReplayTargetVirtualKey, 1},
-	{"SetSkipModeKey", StgControlScript::Func_SetSkipModeKey, 1},
+	{ "AddVirtualKey", StgControlScript::Func_AddVirtualKey, 3 },
+	{ "AddReplayTargetVirtualKey", StgControlScript::Func_AddReplayTargetVirtualKey, 1 },
+	{ "SetSkipModeKey", StgControlScript::Func_SetSkipModeKey, 1 },
 
 	//STG制御共通関数：システム関連
-	{"GetScore", StgControlScript::Func_GetScore, 0},
-	{"AddScore", StgControlScript::Func_AddScore, 1},
-	{"GetGraze", StgControlScript::Func_GetGraze, 0},
-	{"AddGraze", StgControlScript::Func_AddGraze, 1},
-	{"GetPoint", StgControlScript::Func_GetPoint, 0},
-	{"AddPoint", StgControlScript::Func_AddPoint, 1},
-	{"IsReplay", StgControlScript::Func_IsReplay, 0},
-	{"AddArchiveFile", StgControlScript::Func_AddArchiveFile, 1},
-	{"GetCurrentFps", StgControlScript::Func_GetCurrentFps, 0},
-	{"GetStageTime", StgControlScript::Func_GetStageTime, 0},
-	{"GetStageTimeF", StgControlScript::Func_GetStageTimeF, 0},
-	{"GetPackageTime", StgControlScript::Func_GetPackageTime, 0},
+	{ "GetScore", StgControlScript::Func_GetScore, 0 },
+	{ "AddScore", StgControlScript::Func_AddScore, 1 },
+	{ "GetGraze", StgControlScript::Func_GetGraze, 0 },
+	{ "AddGraze", StgControlScript::Func_AddGraze, 1 },
+	{ "GetPoint", StgControlScript::Func_GetPoint, 0 },
+	{ "AddPoint", StgControlScript::Func_AddPoint, 1 },
+	{ "IsReplay", StgControlScript::Func_IsReplay, 0 },
+	{ "AddArchiveFile", StgControlScript::Func_AddArchiveFile, 1 },
+	{ "GetCurrentFps", StgControlScript::Func_GetCurrentFps, 0 },
+	{ "GetStageTime", StgControlScript::Func_GetStageTime, 0 },
+	{ "GetStageTimeF", StgControlScript::Func_GetStageTimeF, 0 },
+	{ "GetPackageTime", StgControlScript::Func_GetPackageTime, 0 },
 
-	{"GetStgFrameLeft", StgControlScript::Func_GetStgFrameLeft, 0},
-	{"GetStgFrameTop", StgControlScript::Func_GetStgFrameTop, 0},
-	{"GetStgFrameWidth", StgControlScript::Func_GetStgFrameWidth, 0},
-	{"GetStgFrameHeight", StgControlScript::Func_GetStgFrameHeight, 0},
+	{ "GetStgFrameLeft", StgControlScript::Func_GetStgFrameLeft, 0 },
+	{ "GetStgFrameTop", StgControlScript::Func_GetStgFrameTop, 0 },
+	{ "GetStgFrameWidth", StgControlScript::Func_GetStgFrameWidth, 0 },
+	{ "GetStgFrameHeight", StgControlScript::Func_GetStgFrameHeight, 0 },
 
-	{"GetMainPackageScriptPath", StgControlScript::Func_GetMainPackageScriptPath, 0},
-	{"GetScriptPathList", StgControlScript::Func_GetScriptPathList, 2},
-	{"GetScriptInfoA1", StgControlScript::Func_GetScriptInfoA1, 2},
+	{ "GetMainPackageScriptPath", StgControlScript::Func_GetMainPackageScriptPath, 0 },
+	{ "GetScriptPathList", StgControlScript::Func_GetScriptPathList, 2 },
+	{ "GetScriptInfoA1", StgControlScript::Func_GetScriptInfoA1, 2 },
 
 	//STG共通関数：描画関連
-	{"ClearInvalidRenderPriority", StgControlScript::Func_ClearInvalidRenderPriority, 0},
-	{"SetInvalidRenderPriorityA1", StgControlScript::Func_SetInvalidRenderPriorityA1, 2},
-	{"GetReservedRenderTargetName", StgControlScript::Func_GetReservedRenderTargetName, 1},
-	{"RenderToTextureA1", StgControlScript::Func_RenderToTextureA1, 4},
-	{"RenderToTextureB1", StgControlScript::Func_RenderToTextureB1, 3},
-	{"SaveSnapShotA1", StgControlScript::Func_SaveSnapShotA1, 1},
-	{"SaveSnapShotA2", StgControlScript::Func_SaveSnapShotA2, 5},
+	{ "ClearInvalidRenderPriority", StgControlScript::Func_ClearInvalidRenderPriority, 0 },
+	{ "SetInvalidRenderPriorityA1", StgControlScript::Func_SetInvalidRenderPriorityA1, 2 },
+	{ "GetReservedRenderTargetName", StgControlScript::Func_GetReservedRenderTargetName, 1 },
+	{ "RenderToTextureA1", StgControlScript::Func_RenderToTextureA1, 4 },
+	{ "RenderToTextureB1", StgControlScript::Func_RenderToTextureB1, 3 },
+	{ "SaveSnapShotA1", StgControlScript::Func_SaveSnapShotA1, 1 },
+	{ "SaveSnapShotA2", StgControlScript::Func_SaveSnapShotA2, 5 },
 
 	//STG制御共通関数：自機関連
-	{"GetPlayerID", StgControlScript::Func_GetPlayerID, 0},
-	{"GetPlayerReplayName", StgControlScript::Func_GetPlayerReplayName, 0},
+	{ "GetPlayerID", StgControlScript::Func_GetPlayerID, 0 },
+	{ "GetPlayerReplayName", StgControlScript::Func_GetPlayerReplayName, 0 },
 
 	//STG制御共通関数：ユーザスクリプト
-	{"SetPauseScriptPath", StgControlScript::Func_SetPauseScriptPath, 1},
-	{"SetEndSceneScriptPath", StgControlScript::Func_SetEndSceneScriptPath, 1},
-	{"SetReplaySaveSceneScriptPath", StgControlScript::Func_SetReplaySaveSceneScriptPath, 1},
+	{ "SetPauseScriptPath", StgControlScript::Func_SetPauseScriptPath, 1 },
+	{ "SetEndSceneScriptPath", StgControlScript::Func_SetEndSceneScriptPath, 1 },
+	{ "SetReplaySaveSceneScriptPath", StgControlScript::Func_SetReplaySaveSceneScriptPath, 1 },
 
 	//STG制御共通関数：自機スクリプト
-	{"GetLoadFreePlayerScriptList", StgControlScript::Func_GetLoadFreePlayerScriptList, 0},
-	{"GetFreePlayerScriptCount", StgControlScript::Func_GetFreePlayerScriptCount, 0},
-	{"GetFreePlayerScriptInfo", StgControlScript::Func_GetFreePlayerScriptInfo, 2},
+	{ "GetLoadFreePlayerScriptList", StgControlScript::Func_GetLoadFreePlayerScriptList, 0 },
+	{ "GetFreePlayerScriptCount", StgControlScript::Func_GetFreePlayerScriptCount, 0 },
+	{ "GetFreePlayerScriptInfo", StgControlScript::Func_GetFreePlayerScriptInfo, 2 },
 
 	//STG制御共通関数：リプレイ関連
-	{"LoadReplayList", StgControlScript::Func_LoadReplayList, 0},
-	{"GetValidReplayIndices", StgControlScript::Func_GetValidReplayIndices, 0},
-	{"IsValidReplayIndex", StgControlScript::Func_IsValidReplayIndex, 1},
-	{"GetReplayInfo", StgControlScript::Func_GetReplayInfo, 2},
-	{"SetReplayInfo", StgControlScript::Func_SetReplayInfo, 2},
-	{"GetReplayUserData", StgControlScript::Func_GetReplayUserData, 2},
-	{"SetReplayUserData", StgControlScript::Func_SetReplayUserData, 2},
-	{"IsReplayUserDataExists", StgControlScript::Func_IsReplayUserDataExists, 2},
-	{"SaveReplay", StgControlScript::Func_SaveReplay, 2},
+	{ "LoadReplayList", StgControlScript::Func_LoadReplayList, 0 },
+	{ "GetValidReplayIndices", StgControlScript::Func_GetValidReplayIndices, 0 },
+	{ "IsValidReplayIndex", StgControlScript::Func_IsValidReplayIndex, 1 },
+	{ "GetReplayInfo", StgControlScript::Func_GetReplayInfo, 2 },
+	{ "SetReplayInfo", StgControlScript::Func_SetReplayInfo, 2 },
+	{ "GetReplayUserData", StgControlScript::Func_GetReplayUserData, 2 },
+	{ "SetReplayUserData", StgControlScript::Func_SetReplayUserData, 2 },
+	{ "IsReplayUserDataExists", StgControlScript::Func_IsReplayUserDataExists, 2 },
+	{ "SaveReplay", StgControlScript::Func_SaveReplay, 2 },
 
 	//定数：
-	{"EV_USER_COUNT", constant<StgControlScript::EV_USER_COUNT>::func, 0},
-	{"EV_USER", constant<StgControlScript::EV_USER>::func, 0},
-	{"EV_USER_SYSTEM", constant<StgControlScript::EV_USER_SYSTEM>::func, 0},
-	{"EV_USER_STAGE", constant<StgControlScript::EV_USER_STAGE>::func, 0},
-	{"EV_USER_PLAYER", constant<StgControlScript::EV_USER_PLAYER>::func, 0},
-	{"EV_USER_PACKAGE", constant<StgControlScript::EV_USER_PACKAGE>::func, 0},
+	{ "EV_USER_COUNT", constant<StgControlScript::EV_USER_COUNT>::func, 0 },
+	{ "EV_USER", constant<StgControlScript::EV_USER>::func, 0 },
+	{ "EV_USER_SYSTEM", constant<StgControlScript::EV_USER_SYSTEM>::func, 0 },
+	{ "EV_USER_STAGE", constant<StgControlScript::EV_USER_STAGE>::func, 0 },
+	{ "EV_USER_PLAYER", constant<StgControlScript::EV_USER_PLAYER>::func, 0 },
+	{ "EV_USER_PACKAGE", constant<StgControlScript::EV_USER_PACKAGE>::func, 0 },
 
-	{"TYPE_SCRIPT_ALL", constant<StgControlScript::TYPE_SCRIPT_ALL>::func, 0},
-	{"TYPE_SCRIPT_PLAYER", constant<StgControlScript::TYPE_SCRIPT_PLAYER>::func, 0},
-	{"TYPE_SCRIPT_SINGLE", constant<StgControlScript::TYPE_SCRIPT_SINGLE>::func, 0},
-	{"TYPE_SCRIPT_PLURAL", constant<StgControlScript::TYPE_SCRIPT_PLURAL>::func, 0},
-	{"TYPE_SCRIPT_STAGE", constant<StgControlScript::TYPE_SCRIPT_STAGE>::func, 0},
-	{"TYPE_SCRIPT_PACKAGE", constant<StgControlScript::TYPE_SCRIPT_PACKAGE>::func, 0},
+	{ "TYPE_SCRIPT_ALL", constant<StgControlScript::TYPE_SCRIPT_ALL>::func, 0 },
+	{ "TYPE_SCRIPT_PLAYER", constant<StgControlScript::TYPE_SCRIPT_PLAYER>::func, 0 },
+	{ "TYPE_SCRIPT_SINGLE", constant<StgControlScript::TYPE_SCRIPT_SINGLE>::func, 0 },
+	{ "TYPE_SCRIPT_PLURAL", constant<StgControlScript::TYPE_SCRIPT_PLURAL>::func, 0 },
+	{ "TYPE_SCRIPT_STAGE", constant<StgControlScript::TYPE_SCRIPT_STAGE>::func, 0 },
+	{ "TYPE_SCRIPT_PACKAGE", constant<StgControlScript::TYPE_SCRIPT_PACKAGE>::func, 0 },
 
-	{"INFO_SCRIPT_TYPE", constant<StgControlScript::INFO_SCRIPT_TYPE>::func, 0},
-	{"INFO_SCRIPT_PATH", constant<StgControlScript::INFO_SCRIPT_PATH>::func, 0},
-	{"INFO_SCRIPT_ID", constant<StgControlScript::INFO_SCRIPT_ID>::func, 0},
-	{"INFO_SCRIPT_TITLE", constant<StgControlScript::INFO_SCRIPT_TITLE>::func, 0},
-	{"INFO_SCRIPT_TEXT", constant<StgControlScript::INFO_SCRIPT_TEXT>::func, 0},
-	{"INFO_SCRIPT_IMAGE", constant<StgControlScript::INFO_SCRIPT_IMAGE>::func, 0},
-	{"INFO_SCRIPT_REPLAY_NAME", constant<StgControlScript::INFO_SCRIPT_REPLAY_NAME>::func, 0},
+	{ "INFO_SCRIPT_TYPE", constant<StgControlScript::INFO_SCRIPT_TYPE>::func, 0 },
+	{ "INFO_SCRIPT_PATH", constant<StgControlScript::INFO_SCRIPT_PATH>::func, 0 },
+	{ "INFO_SCRIPT_ID", constant<StgControlScript::INFO_SCRIPT_ID>::func, 0 },
+	{ "INFO_SCRIPT_TITLE", constant<StgControlScript::INFO_SCRIPT_TITLE>::func, 0 },
+	{ "INFO_SCRIPT_TEXT", constant<StgControlScript::INFO_SCRIPT_TEXT>::func, 0 },
+	{ "INFO_SCRIPT_IMAGE", constant<StgControlScript::INFO_SCRIPT_IMAGE>::func, 0 },
+	{ "INFO_SCRIPT_REPLAY_NAME", constant<StgControlScript::INFO_SCRIPT_REPLAY_NAME>::func, 0 },
 
-	{"REPLAY_FILE_PATH", constant<StgControlScript::REPLAY_FILE_PATH>::func, 0},
-	{"REPLAY_DATE_TIME", constant<StgControlScript::REPLAY_DATE_TIME>::func, 0},
-	{"REPLAY_USER_NAME", constant<StgControlScript::REPLAY_USER_NAME>::func, 0},
-	{"REPLAY_TOTAL_SCORE", constant<StgControlScript::REPLAY_TOTAL_SCORE>::func, 0},
-	{"REPLAY_FPS_AVERAGE", constant<StgControlScript::REPLAY_FPS_AVERAGE>::func, 0},
-	{"REPLAY_PLAYER_NAME", constant<StgControlScript::REPLAY_PLAYER_NAME>::func, 0},
-	{"REPLAY_STAGE_INDEX_LIST", constant<StgControlScript::REPLAY_STAGE_INDEX_LIST>::func, 0},
-	{"REPLAY_STAGE_START_SCORE_LIST", constant<StgControlScript::REPLAY_STAGE_START_SCORE_LIST>::func, 0},
-	{"REPLAY_STAGE_LAST_SCORE_LIST", constant<StgControlScript::REPLAY_STAGE_LAST_SCORE_LIST>::func, 0},
-	{"REPLAY_COMMENT", constant<StgControlScript::REPLAY_COMMENT>::func, 0},
+	{ "REPLAY_FILE_PATH", constant<StgControlScript::REPLAY_FILE_PATH>::func, 0 },
+	{ "REPLAY_DATE_TIME", constant<StgControlScript::REPLAY_DATE_TIME>::func, 0 },
+	{ "REPLAY_USER_NAME", constant<StgControlScript::REPLAY_USER_NAME>::func, 0 },
+	{ "REPLAY_TOTAL_SCORE", constant<StgControlScript::REPLAY_TOTAL_SCORE>::func, 0 },
+	{ "REPLAY_FPS_AVERAGE", constant<StgControlScript::REPLAY_FPS_AVERAGE>::func, 0 },
+	{ "REPLAY_PLAYER_NAME", constant<StgControlScript::REPLAY_PLAYER_NAME>::func, 0 },
+	{ "REPLAY_STAGE_INDEX_LIST", constant<StgControlScript::REPLAY_STAGE_INDEX_LIST>::func, 0 },
+	{ "REPLAY_STAGE_START_SCORE_LIST", constant<StgControlScript::REPLAY_STAGE_START_SCORE_LIST>::func, 0 },
+	{ "REPLAY_STAGE_LAST_SCORE_LIST", constant<StgControlScript::REPLAY_STAGE_LAST_SCORE_LIST>::func, 0 },
+	{ "REPLAY_COMMENT", constant<StgControlScript::REPLAY_COMMENT>::func, 0 },
 
-	{"REPLAY_INDEX_ACTIVE", constant<ReplayInformation::INDEX_ACTIVE>::func, 0},
-	{"REPLAY_INDEX_DIGIT_MIN", constant<ReplayInformation::INDEX_DIGIT_MIN>::func, 0},
-	{"REPLAY_INDEX_DIGIT_MAX", constant<ReplayInformation::INDEX_DIGIT_MAX>::func, 0},
-	{"REPLAY_INDEX_USER", constant<ReplayInformation::INDEX_USER>::func, 0},
+	{ "REPLAY_INDEX_ACTIVE", constant<ReplayInformation::INDEX_ACTIVE>::func, 0 },
+	{ "REPLAY_INDEX_DIGIT_MIN", constant<ReplayInformation::INDEX_DIGIT_MIN>::func, 0 },
+	{ "REPLAY_INDEX_DIGIT_MAX", constant<ReplayInformation::INDEX_DIGIT_MAX>::func, 0 },
+	{ "REPLAY_INDEX_USER", constant<ReplayInformation::INDEX_USER>::func, 0 },
 
-	{"RESULT_CANCEL", constant<StgControlScript::RESULT_CANCEL>::func, 0},
-	{"RESULT_END", constant<StgControlScript::RESULT_END>::func, 0},
-	{"RESULT_RETRY", constant<StgControlScript::RESULT_RETRY>::func, 0},
-	{"RESULT_SAVE_REPLAY", constant<StgControlScript::RESULT_SAVE_REPLAY>::func, 0},
+	{ "RESULT_CANCEL", constant<StgControlScript::RESULT_CANCEL>::func, 0 },
+	{ "RESULT_END", constant<StgControlScript::RESULT_END>::func, 0 },
+	{ "RESULT_RETRY", constant<StgControlScript::RESULT_RETRY>::func, 0 },
+	{ "RESULT_SAVE_REPLAY", constant<StgControlScript::RESULT_SAVE_REPLAY>::func, 0 },
 };
 StgControlScript::StgControlScript(StgSystemController* systemController)
 {
@@ -169,9 +165,8 @@ StgControlScript::StgControlScript(StgSystemController* systemController)
 	commonDataManager_ = systemController->GetCommonDataManager();
 }
 
-
 //STG制御共通関数：共通データ
-gstd::value StgControlScript::Func_SaveCommonDataAreaA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_SaveCommonDataAreaA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
@@ -180,7 +175,7 @@ gstd::value StgControlScript::Func_SaveCommonDataAreaA1(gstd::script_machine* ma
 	std::string sArea = to_mbcs(area);
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 	ref_count_ptr<ScriptCommonData> commonData = commonDataManager->GetData(sArea);
-	if(commonData == NULL)
+	if (commonData == NULL)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	std::wstring pathMain = infoSystem->GetMainScriptInformation()->GetScriptPath();
@@ -189,14 +184,14 @@ gstd::value StgControlScript::Func_SaveCommonDataAreaA1(gstd::script_machine* ma
 
 	File fDir(dirSave);
 	fDir.CreateDirectory();
-	
+
 	RecordBuffer record;
 	commonData->WriteRecord(record);
 	bool res = record.WriteToFile(pathSave);
 
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgControlScript::Func_LoadCommonDataAreaA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_LoadCommonDataAreaA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
@@ -204,12 +199,12 @@ gstd::value StgControlScript::Func_LoadCommonDataAreaA1(gstd::script_machine* ma
 	std::wstring area = argv[0].as_string();
 	std::string sArea = to_mbcs(area);
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
-	
+
 	std::wstring pathMain = infoSystem->GetMainScriptInformation()->GetScriptPath();
 	std::wstring pathSave = EPathProperty::GetCommonDataPath(pathMain, area);
 	RecordBuffer record;
 	bool res = record.ReadFromFile(pathSave);
-	if(!res)
+	if (!res)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	ref_count_ptr<ScriptCommonData> commonData = new ScriptCommonData();
@@ -219,7 +214,7 @@ gstd::value StgControlScript::Func_LoadCommonDataAreaA1(gstd::script_machine* ma
 	return value(machine->get_engine()->get_boolean_type(), true);
 }
 
-gstd::value StgControlScript::Func_SaveCommonDataAreaA2(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_SaveCommonDataAreaA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
@@ -227,7 +222,7 @@ gstd::value StgControlScript::Func_SaveCommonDataAreaA2(gstd::script_machine* ma
 	std::string area = to_mbcs(argv[0].as_string());
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 	ref_count_ptr<ScriptCommonData> commonData = commonDataManager->GetData(area);
-	if(commonData == NULL)
+	if (commonData == NULL)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	std::wstring pathSave = argv[1].as_string();
@@ -235,25 +230,25 @@ gstd::value StgControlScript::Func_SaveCommonDataAreaA2(gstd::script_machine* ma
 
 	File fDir(dirSave);
 	fDir.CreateDirectory();
-	
+
 	RecordBuffer record;
 	commonData->WriteRecord(record);
 	bool res = record.WriteToFile(pathSave);
 
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgControlScript::Func_LoadCommonDataAreaA2(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_LoadCommonDataAreaA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
 
 	std::string area = to_mbcs(argv[0].as_string());
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
-	
+
 	std::wstring pathSave = argv[1].as_string();
 	RecordBuffer record;
 	bool res = record.ReadFromFile(pathSave);
-	if(!res)
+	if (!res)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	ref_count_ptr<ScriptCommonData> commonData = new ScriptCommonData();
@@ -264,11 +259,11 @@ gstd::value StgControlScript::Func_LoadCommonDataAreaA2(gstd::script_machine* ma
 }
 
 //STG制御共通関数：キー系
-gstd::value StgControlScript::Func_AddVirtualKey(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_AddVirtualKey(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	EDirectInput* input = EDirectInput::GetInstance();
 	int padIndex = input->GetPadIndex();
-	
+
 	int id = (int)argv[0].as_real();
 	int key = (int)argv[1].as_real();
 	int padButton = (int)argv[2].as_real();
@@ -278,7 +273,7 @@ gstd::value StgControlScript::Func_AddVirtualKey(gstd::script_machine* machine, 
 
 	return value();
 }
-gstd::value StgControlScript::Func_AddReplayTargetVirtualKey(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_AddReplayTargetVirtualKey(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
@@ -286,15 +281,14 @@ gstd::value StgControlScript::Func_AddReplayTargetVirtualKey(gstd::script_machin
 
 	int id = (int)argv[0].as_real();
 	infoSystem->AddReplayTargetKey(id);
-	if(stageController != NULL)
-	{
+	if (stageController != NULL) {
 		ref_count_ptr<KeyReplayManager> keyReplayManager = stageController->GetKeyReplayManager();
 		keyReplayManager->AddTarget(id);
 	}
 
 	return value();
 }
-gstd::value StgControlScript::Func_SetSkipModeKey(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_SetSkipModeKey(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	int id = (int)argv[0].as_real();
 	EFpsController* fpsController = EFpsController::GetInstance();
@@ -304,77 +298,80 @@ gstd::value StgControlScript::Func_SetSkipModeKey(gstd::script_machine* machine,
 }
 
 //STG制御共通関数：システム関連
-gstd::value StgControlScript::Func_GetScore(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetScore(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if(stageController == NULL)
+	if (stageController == NULL)
 		return value(machine->get_engine()->get_real_type(), (long double)0.0);
 
 	long double res = stageController->GetStageInformation()->GetScore();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgControlScript::Func_AddScore(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_AddScore(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if(stageController == NULL)return value();
+	if (stageController == NULL)
+		return value();
 
 	long double inc = (_int64)argv[0].as_real();
 	stageController->GetStageInformation()->AddScore(inc);
 	return value();
 }
-gstd::value StgControlScript::Func_GetGraze(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetGraze(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if(stageController == NULL)
+	if (stageController == NULL)
 		return value(machine->get_engine()->get_real_type(), (long double)0.0);
 
 	long double res = stageController->GetStageInformation()->GetGraze();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgControlScript::Func_AddGraze(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_AddGraze(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if(stageController == NULL)return value();
+	if (stageController == NULL)
+		return value();
 
 	long double inc = (_int64)argv[0].as_real();
 	stageController->GetStageInformation()->AddGraze(inc);
 	return value();
 }
-gstd::value StgControlScript::Func_GetPoint(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetPoint(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if(stageController == NULL)
+	if (stageController == NULL)
 		return value(machine->get_engine()->get_real_type(), (long double)0.0);
 
 	long double res = stageController->GetStageInformation()->GetPoint();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgControlScript::Func_AddPoint(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_AddPoint(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if(stageController == NULL)return value();
+	if (stageController == NULL)
+		return value();
 
 	long double inc = (_int64)argv[0].as_real();
 	stageController->GetStageInformation()->AddPoint(inc);
 	return value();
 }
-gstd::value StgControlScript::Func_IsReplay(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_IsReplay(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if(stageController == NULL)
+	if (stageController == NULL)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	bool res = stageController->GetStageInformation()->IsReplay();
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgControlScript::Func_AddArchiveFile(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_AddArchiveFile(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	FileManager* fileManager = FileManager::GetBase();
 
@@ -382,17 +379,17 @@ gstd::value StgControlScript::Func_AddArchiveFile(gstd::script_machine* machine,
 	bool res = fileManager->AddArchiveFile(path);
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgControlScript::Func_GetCurrentFps(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetCurrentFps(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	EFpsController* fpsController = EFpsController::GetInstance();
 	long double res = fpsController->GetCurrentWorkFps();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgControlScript::Func_GetStageTime(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetStageTime(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if(stageController == NULL)
+	if (stageController == NULL)
 		return value(machine->get_engine()->get_real_type(), (long double)0);
 
 	ref_count_ptr<StgStageInformation> infoStage = stageController->GetStageInformation();
@@ -402,22 +399,22 @@ gstd::value StgControlScript::Func_GetStageTime(gstd::script_machine* machine, i
 	long double res = timeStart > 0 ? time - timeStart : 0;
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgControlScript::Func_GetStageTimeF(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetStageTimeF(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if(stageController == NULL)
+	if (stageController == NULL)
 		return value(machine->get_engine()->get_real_type(), (long double)0);
 
 	ref_count_ptr<StgStageInformation> infoStage = stageController->GetStageInformation();
 	long double res = infoStage->GetCurrentFrame();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgControlScript::Func_GetPackageTime(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetPackageTime(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgPackageController* packageController = script->systemController_->GetPackageController();
-	if(packageController == NULL)
+	if (packageController == NULL)
 		return value(machine->get_engine()->get_real_type(), (long double)0);
 
 	ref_count_ptr<StgPackageInformation> infoPackage = packageController->GetPackageInformation();
@@ -428,75 +425,69 @@ gstd::value StgControlScript::Func_GetPackageTime(gstd::script_machine* machine,
 	return value(machine->get_engine()->get_real_type(), res);
 }
 
-gstd::value StgControlScript::Func_GetStgFrameLeft(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetStgFrameLeft(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
 
 	long double res = 0;
-	if(stageController != NULL)
-	{
+	if (stageController != NULL) {
 		RECT rect = stageController->GetStageInformation()->GetStgFrameRect();
 		res = rect.left;
 	}
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgControlScript::Func_GetStgFrameTop(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetStgFrameTop(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
 
 	long double res = 0;
-	if(stageController != NULL)
-	{
+	if (stageController != NULL) {
 		RECT rect = stageController->GetStageInformation()->GetStgFrameRect();
 		res = rect.top;
 	}
 	return value(machine->get_engine()->get_real_type(), res);
-}	
-gstd::value StgControlScript::Func_GetStgFrameWidth(gstd::script_machine* machine, int argc, gstd::value const * argv)
+}
+gstd::value StgControlScript::Func_GetStgFrameWidth(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
 
 	long double res = 0;
-	if(stageController != NULL)
-	{
+	if (stageController != NULL) {
 		RECT rect = stageController->GetStageInformation()->GetStgFrameRect();
 		res = res = rect.right - rect.left;
 	}
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgControlScript::Func_GetStgFrameHeight(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetStgFrameHeight(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
 
 	long double res = 0;
-	if(stageController != NULL)
-	{
+	if (stageController != NULL) {
 		RECT rect = stageController->GetStageInformation()->GetStgFrameRect();
 		res = res = rect.bottom - rect.top;
 	}
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgControlScript::Func_GetMainPackageScriptPath(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetMainPackageScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgPackageController* packageController = script->systemController_->GetPackageController();
 
 	std::wstring path = L"";
-	if(packageController != NULL)
-	{
-		ref_count_ptr<ScriptInformation> infoScript = 
-			packageController->GetPackageInformation()->GetMainScriptInformation();
+	if (packageController != NULL) {
+		ref_count_ptr<ScriptInformation> infoScript = packageController->GetPackageInformation()->GetMainScriptInformation();
 		path = infoScript->GetScriptPath();
 	}
 
 	std::wstring res = path;
 	return value(machine->get_engine()->get_string_type(), res);
 }
-gstd::value StgControlScript::Func_GetScriptPathList(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetScriptPathList(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 
@@ -506,18 +497,20 @@ gstd::value StgControlScript::Func_GetScriptPathList(gstd::script_machine* machi
 
 	int typeScript = (int)argv[1].as_real();
 	std::vector<std::wstring> listFile = File::GetFilePathList(dir);
-	for(int iFile = 0 ; iFile < listFile.size() ; iFile++)
-	{
+	for (int iFile = 0; iFile < listFile.size(); iFile++) {
 		std::wstring path = listFile[iFile];
 
 		//明らかに関係なさそうな拡張子は除外
 		std::wstring ext = PathProperty::GetFileExtension(path);
-		if(ScriptInformation::IsExcludeExtention(ext))continue;
+		if (ScriptInformation::IsExcludeExtention(ext))
+			continue;
 
 		path = PathProperty::GetUnique(path);
 		ref_count_ptr<ScriptInformation> infoScript = ScriptInformation::CreateScriptInformation(path, true);
-		if(infoScript == NULL)continue;
-		if(typeScript != TYPE_SCRIPT_ALL && typeScript != infoScript->GetType())continue;
+		if (infoScript == NULL)
+			continue;
+		if (typeScript != TYPE_SCRIPT_ALL && typeScript != infoScript->GetType())
+			continue;
 
 		script->mapScriptInfo_[path] = infoScript;
 		listRes.push_back(path);
@@ -526,7 +519,7 @@ gstd::value StgControlScript::Func_GetScriptPathList(gstd::script_machine* machi
 	gstd::value res = script->CreateStringArrayValue(listRes);
 	return res;
 }
-gstd::value StgControlScript::Func_GetScriptInfoA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetScriptInfoA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 
@@ -534,47 +527,45 @@ gstd::value StgControlScript::Func_GetScriptInfoA1(gstd::script_machine* machine
 	int type = (int)argv[1].as_real();
 
 	ref_count_ptr<ScriptInformation> infoScript = NULL;
-	if(script->mapScriptInfo_.find(path) != script->mapScriptInfo_.end())
+	if (script->mapScriptInfo_.find(path) != script->mapScriptInfo_.end())
 		infoScript = script->mapScriptInfo_[path];
-	else
-	{
+	else {
 		infoScript = ScriptInformation::CreateScriptInformation(path, true);
 		script->mapScriptInfo_[path] = infoScript;
 	}
-	if(infoScript == NULL)
+	if (infoScript == NULL)
 		throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path));
 
 	value res;
-	switch(type)
-	{
-		case INFO_SCRIPT_TYPE:
-			res = script->CreateRealValue(infoScript->GetType());
-			break;
-		case INFO_SCRIPT_PATH:
-			res = script->CreateStringValue(infoScript->GetScriptPath());
-			break;
-		case INFO_SCRIPT_ID:
-			res = script->CreateStringValue(infoScript->GetID());
-			break;
-		case INFO_SCRIPT_TITLE:
-			res = script->CreateStringValue(infoScript->GetTitle());
-			break;
-		case INFO_SCRIPT_TEXT:
-			res = script->CreateStringValue(infoScript->GetText());
-			break;
-		case INFO_SCRIPT_IMAGE:
-			res = script->CreateStringValue(infoScript->GetImagePath());
-			break;
-		case INFO_SCRIPT_REPLAY_NAME:
-			res = script->CreateStringValue(infoScript->GetReplayName());
-			break;
+	switch (type) {
+	case INFO_SCRIPT_TYPE:
+		res = script->CreateRealValue(infoScript->GetType());
+		break;
+	case INFO_SCRIPT_PATH:
+		res = script->CreateStringValue(infoScript->GetScriptPath());
+		break;
+	case INFO_SCRIPT_ID:
+		res = script->CreateStringValue(infoScript->GetID());
+		break;
+	case INFO_SCRIPT_TITLE:
+		res = script->CreateStringValue(infoScript->GetTitle());
+		break;
+	case INFO_SCRIPT_TEXT:
+		res = script->CreateStringValue(infoScript->GetText());
+		break;
+	case INFO_SCRIPT_IMAGE:
+		res = script->CreateStringValue(infoScript->GetImagePath());
+		break;
+	case INFO_SCRIPT_REPLAY_NAME:
+		res = script->CreateStringValue(infoScript->GetReplayName());
+		break;
 	}
 
 	return res;
 }
 
 //STG共通関数：描画関連
-gstd::value StgControlScript::Func_ClearInvalidRenderPriority(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_ClearInvalidRenderPriority(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgSystemController* systemController = script->systemController_;
@@ -583,7 +574,8 @@ gstd::value StgControlScript::Func_ClearInvalidRenderPriority(gstd::script_machi
 
 	return value();
 }
-gstd::value StgControlScript::Func_SetInvalidRenderPriorityA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+
+gstd::value StgControlScript::Func_SetInvalidRenderPriorityA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgSystemController* systemController = script->systemController_;
@@ -596,7 +588,7 @@ gstd::value StgControlScript::Func_SetInvalidRenderPriorityA1(gstd::script_machi
 	return value();
 }
 
-gstd::value StgControlScript::Func_GetReservedRenderTargetName(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetReservedRenderTargetName(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 
@@ -606,7 +598,8 @@ gstd::value StgControlScript::Func_GetReservedRenderTargetName(gstd::script_mach
 
 	return value(machine->get_engine()->get_string_type(), name);
 }
-gstd::value StgControlScript::Func_RenderToTextureA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+
+gstd::value StgControlScript::Func_RenderToTextureA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ETextureManager* textureManager = ETextureManager::GetInstance();
@@ -619,10 +612,9 @@ gstd::value StgControlScript::Func_RenderToTextureA1(gstd::script_machine* machi
 
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	ref_count_ptr<Texture> texture = script->_GetTexture(name);
-	if(texture == NULL)
+	if (texture == NULL)
 		textureManager->GetTexture(name);
-	if(texture == NULL && textureManager->IsDataExists(name))
-	{
+	if (texture == NULL && textureManager->IsDataExists(name)) {
 		texture = new Texture();
 		texture->CreateRenderTarget(name);
 	}
@@ -640,14 +632,15 @@ gstd::value StgControlScript::Func_RenderToTextureA1(gstd::script_machine* machi
 		std::string path = StringUtility::Format("R:/TEMP/temp_%04d.bmp", count);
 		RECT rect = {0, 0, 640, 480};
 		IDirect3DSurface9* pBackSurface = texture->GetD3DSurface();
-		D3DXSaveSurfaceToFile(path.c_str(), D3DXIFF_BMP, 
+		D3DXSaveSurfaceToFile(path.c_str(), D3DXIFF_BMP,
 								pBackSurface, NULL, &rect );
 		count++;
 	}
 */
 	return value();
 }
-gstd::value StgControlScript::Func_RenderToTextureB1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+
+gstd::value StgControlScript::Func_RenderToTextureB1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ETextureManager* textureManager = ETextureManager::GetInstance();
@@ -657,15 +650,15 @@ gstd::value StgControlScript::Func_RenderToTextureB1(gstd::script_machine* machi
 	bool bClear = argv[2].as_boolean();
 
 	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	ref_count_ptr<Texture> texture = script->_GetTexture(name);
-	if(texture == NULL)
+	if (texture == NULL)
 		textureManager->GetTexture(name);
 
-	if(texture == NULL && textureManager->IsDataExists(name))
-	{
+	if (texture == NULL && textureManager->IsDataExists(name)) {
 		texture = new Texture();
 		texture->CreateRenderTarget(name);
 	}
@@ -681,7 +674,7 @@ gstd::value StgControlScript::Func_RenderToTextureB1(gstd::script_machine* machi
 	return value();
 }
 
-gstd::value StgControlScript::Func_SaveSnapShotA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_SaveSnapShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ETextureManager* textureManager = ETextureManager::GetInstance();
@@ -704,13 +697,14 @@ gstd::value StgControlScript::Func_SaveSnapShotA1(gstd::script_machine* machine,
 
 	//保存
 	IDirect3DSurface9* pSurface = texture->GetD3DSurface();
-	RECT rect = {0, 0, graphics->GetScreenWidth(), graphics->GetScreenHeight()};
-	HRESULT hr = D3DXSaveSurfaceToFile(path.c_str(), D3DXIFF_BMP, 
-							pSurface, NULL, &rect );
+	RECT rect = { 0, 0, graphics->GetScreenWidth(), graphics->GetScreenHeight() };
+	HRESULT hr = D3DXSaveSurfaceToFile(path.c_str(), D3DXIFF_BMP,
+		pSurface, NULL, &rect);
 
 	return value();
 }
-gstd::value StgControlScript::Func_SaveSnapShotA2(gstd::script_machine* machine, int argc, gstd::value const * argv)
+
+gstd::value StgControlScript::Func_SaveSnapShotA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ETextureManager* textureManager = ETextureManager::GetInstance();
@@ -738,37 +732,36 @@ gstd::value StgControlScript::Func_SaveSnapShotA2(gstd::script_machine* machine,
 
 	//保存
 	IDirect3DSurface9* pSurface = texture->GetD3DSurface();
-	RECT rect = {rcLeft, rcTop, rcRight, rcBottom};
-	HRESULT hr = D3DXSaveSurfaceToFile(path.c_str(), D3DXIFF_BMP, 
-							pSurface, NULL, &rect );
+	RECT rect = { rcLeft, rcTop, rcRight, rcBottom };
+	HRESULT hr = D3DXSaveSurfaceToFile(path.c_str(), D3DXIFF_BMP,
+		pSurface, NULL, &rect);
 	return value();
 }
 
 //STG制御共通関数：自機関連
-gstd::value StgControlScript::Func_GetPlayerID(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetPlayerID(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if(stageController == NULL)
+	if (stageController == NULL)
 		return value(machine->get_engine()->get_string_type(), std::wstring());
 
 	std::wstring id = stageController->GetStageInformation()->GetPlayerScriptInformation()->GetID();
 	return value(machine->get_engine()->get_string_type(), id);
 }
-gstd::value StgControlScript::Func_GetPlayerReplayName(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetPlayerReplayName(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if(stageController == NULL)
+	if (stageController == NULL)
 		return value(machine->get_engine()->get_string_type(), std::wstring());
 
 	std::wstring replayName = stageController->GetStageInformation()->GetPlayerScriptInformation()->GetReplayName();
 	return value(machine->get_engine()->get_string_type(), replayName);
 }
 
-
 //STG制御共通関数：ユーザスクリプト
-gstd::value StgControlScript::Func_SetPauseScriptPath(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_SetPauseScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> info = script->systemController_->GetSystemInformation();
@@ -778,7 +771,7 @@ gstd::value StgControlScript::Func_SetPauseScriptPath(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgControlScript::Func_SetEndSceneScriptPath(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_SetEndSceneScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> info = script->systemController_->GetSystemInformation();
@@ -788,7 +781,7 @@ gstd::value StgControlScript::Func_SetEndSceneScriptPath(gstd::script_machine* m
 
 	return value();
 }
-gstd::value StgControlScript::Func_SetReplaySaveSceneScriptPath(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_SetReplaySaveSceneScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> info = script->systemController_->GetSystemInformation();
@@ -800,65 +793,63 @@ gstd::value StgControlScript::Func_SetReplaySaveSceneScriptPath(gstd::script_mac
 }
 
 //STG制御共通関数：自機スクリプト
-gstd::value StgControlScript::Func_GetLoadFreePlayerScriptList(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetLoadFreePlayerScriptList(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
 
 	infoControlScript->LoadFreePlayerList();
-	std::vector<ref_count_ptr<ScriptInformation> > listFreePlayer = infoControlScript->GetFreePlayerList();
+	std::vector<ref_count_ptr<ScriptInformation>> listFreePlayer = infoControlScript->GetFreePlayerList();
 	int res = listFreePlayer.size();
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgControlScript::Func_GetFreePlayerScriptCount(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetFreePlayerScriptCount(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
-	std::vector<ref_count_ptr<ScriptInformation> > listFreePlayer = infoControlScript->GetFreePlayerList();
+	std::vector<ref_count_ptr<ScriptInformation>> listFreePlayer = infoControlScript->GetFreePlayerList();
 
 	int res = listFreePlayer.size();
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgControlScript::Func_GetFreePlayerScriptInfo(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_GetFreePlayerScriptInfo(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
-	std::vector<ref_count_ptr<ScriptInformation> > listFreePlayer = infoControlScript->GetFreePlayerList();
+	std::vector<ref_count_ptr<ScriptInformation>> listFreePlayer = infoControlScript->GetFreePlayerList();
 
 	int index = (int)argv[0].as_real();
 	int type = (int)argv[1].as_real();
-	if(index < 0 || index >= listFreePlayer.size())
+	if (index < 0 || index >= listFreePlayer.size())
 		script->RaiseError(ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_OUTOFRANGE_INDEX));
 
 	ref_count_ptr<ScriptInformation> infoPlayer = listFreePlayer[index];
 	value res;
-	switch(type)
-	{
-		case INFO_SCRIPT_PATH:
-			res = script->CreateStringValue(infoPlayer->GetScriptPath());
-			break;
-		case INFO_SCRIPT_ID:
-			res = script->CreateStringValue(infoPlayer->GetID());
-			break;
-		case INFO_SCRIPT_TITLE:
-			res = script->CreateStringValue(infoPlayer->GetTitle());
-			break;
-		case INFO_SCRIPT_TEXT:
-			res = script->CreateStringValue(infoPlayer->GetText());
-			break;
-		case INFO_SCRIPT_IMAGE:
-			res = script->CreateStringValue(infoPlayer->GetImagePath());
-			break;
-		case INFO_SCRIPT_REPLAY_NAME:
-			res = script->CreateStringValue(infoPlayer->GetReplayName());
-			break;
+	switch (type) {
+	case INFO_SCRIPT_PATH:
+		res = script->CreateStringValue(infoPlayer->GetScriptPath());
+		break;
+	case INFO_SCRIPT_ID:
+		res = script->CreateStringValue(infoPlayer->GetID());
+		break;
+	case INFO_SCRIPT_TITLE:
+		res = script->CreateStringValue(infoPlayer->GetTitle());
+		break;
+	case INFO_SCRIPT_TEXT:
+		res = script->CreateStringValue(infoPlayer->GetText());
+		break;
+	case INFO_SCRIPT_IMAGE:
+		res = script->CreateStringValue(infoPlayer->GetImagePath());
+		break;
+	case INFO_SCRIPT_REPLAY_NAME:
+		res = script->CreateStringValue(infoPlayer->GetReplayName());
+		break;
 	}
-
 	return res;
 }
 
 //STG制御共通関数：リプレイ関連
-gstd::value StgControlScript::Func_LoadReplayList(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_LoadReplayList(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
@@ -868,7 +859,8 @@ gstd::value StgControlScript::Func_LoadReplayList(gstd::script_machine* machine,
 	infoControlScript->LoadReplayInformation(pathMainScript);
 	return gstd::value();
 }
-gstd::value StgControlScript::Func_GetValidReplayIndices(gstd::script_machine* machine, int argc, gstd::value const * argv)
+
+gstd::value StgControlScript::Func_GetValidReplayIndices(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
@@ -876,13 +868,14 @@ gstd::value StgControlScript::Func_GetValidReplayIndices(gstd::script_machine* m
 
 	std::vector<int> listValidIndices = replayInfoManager->GetIndexList();
 	std::vector<long double> list;
-	for(int iList = 0 ; iList < listValidIndices.size(); iList++)
+	for (int iList = 0; iList < listValidIndices.size(); iList++)
 		list.push_back(listValidIndices[iList]);
-		
+
 	gstd::value res = script->CreateRealArrayValue(list);
 	return res;
 }
-gstd::value StgControlScript::Func_IsValidReplayIndex(gstd::script_machine* machine, int argc, gstd::value const * argv)
+
+gstd::value StgControlScript::Func_IsValidReplayIndex(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
@@ -892,7 +885,8 @@ gstd::value StgControlScript::Func_IsValidReplayIndex(gstd::script_machine* mach
 	bool res = replayInfoManager->GetInformation(index) != NULL;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgControlScript::Func_GetReplayInfo(gstd::script_machine* machine, int argc, gstd::value const * argv)
+
+gstd::value StgControlScript::Func_GetReplayInfo(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
@@ -903,103 +897,98 @@ gstd::value StgControlScript::Func_GetReplayInfo(gstd::script_machine* machine, 
 	int type = (int)argv[1].as_real();
 
 	ref_count_ptr<ReplayInformation> replayInfo;
-	if(index == ReplayInformation::INDEX_ACTIVE)replayInfo = infoSystem->GetActiveReplayInformation();
-	else replayInfo = replayInfoManager->GetInformation(index);
+	if (index == ReplayInformation::INDEX_ACTIVE)
+		replayInfo = infoSystem->GetActiveReplayInformation();
+	else
+		replayInfo = replayInfoManager->GetInformation(index);
 
-	if(replayInfo == NULL)
+	if (replayInfo == NULL)
 		script->RaiseError(ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_OUTOFRANGE_INDEX));
 
 	value res;
-	switch(type)
-	{
-		case REPLAY_FILE_PATH:
-			res = script->CreateStringValue(replayInfo->GetPath());
-			break;
-		case REPLAY_DATE_TIME:
-			res = script->CreateStringValue(replayInfo->GetDateAsString());
-			break;
-		case REPLAY_USER_NAME:
-			res = script->CreateStringValue(replayInfo->GetUserName());
-			break;
-		case REPLAY_TOTAL_SCORE:
-			res = script->CreateRealValue(replayInfo->GetTotalScore());
-			break;
-		case REPLAY_FPS_AVERAGE:
-			res = script->CreateRealValue(replayInfo->GetAvarageFps());
-			break;
-		case REPLAY_PLAYER_NAME:
-			res = script->CreateStringValue(replayInfo->GetPlayerScriptReplayName());
-			break;
-		case REPLAY_STAGE_INDEX_LIST:
-		{
-			std::vector<int> listStageI = replayInfo->GetStageIndexList();
-			std::vector<long double> listStageD;
-			for(int iStage = 0 ; iStage < listStageI.size() ; iStage++)
-			{
-				long double stage = listStageI[iStage];
-				listStageD.push_back(stage);
-			}
-			res = script->CreateRealArrayValue(listStageD);
-			break;
+	switch (type) {
+	case REPLAY_FILE_PATH:
+		res = script->CreateStringValue(replayInfo->GetPath());
+		break;
+	case REPLAY_DATE_TIME:
+		res = script->CreateStringValue(replayInfo->GetDateAsString());
+		break;
+	case REPLAY_USER_NAME:
+		res = script->CreateStringValue(replayInfo->GetUserName());
+		break;
+	case REPLAY_TOTAL_SCORE:
+		res = script->CreateRealValue(replayInfo->GetTotalScore());
+		break;
+	case REPLAY_FPS_AVERAGE:
+		res = script->CreateRealValue(replayInfo->GetAvarageFps());
+		break;
+	case REPLAY_PLAYER_NAME:
+		res = script->CreateStringValue(replayInfo->GetPlayerScriptReplayName());
+		break;
+	case REPLAY_STAGE_INDEX_LIST: {
+		std::vector<int> listStageI = replayInfo->GetStageIndexList();
+		std::vector<long double> listStageD;
+		for (int iStage = 0; iStage < listStageI.size(); iStage++) {
+			long double stage = listStageI[iStage];
+			listStageD.push_back(stage);
 		}
-		case REPLAY_STAGE_START_SCORE_LIST:
-		{
-			std::vector<int> listStage = replayInfo->GetStageIndexList();
-			std::vector<long double> listScoreD;
-			for(int iStage = 0 ; iStage < listStage.size() ; iStage++)
-			{
-				int stage = listStage[iStage];
-				ref_count_ptr<ReplayInformation::StageData> data = replayInfo->GetStageData(stage);
-
-				long double score = data->GetStartScore();
-				listScoreD.push_back(score);
-			}
-			res = script->CreateRealArrayValue(listScoreD);
-			break;
-		}
-		case REPLAY_STAGE_LAST_SCORE_LIST:
-		{
-			std::vector<int> listStage = replayInfo->GetStageIndexList();
-			std::vector<long double> listScoreD;
-			for(int iStage = 0 ; iStage < listStage.size() ; iStage++)
-			{
-				int stage = listStage[iStage];
-				ref_count_ptr<ReplayInformation::StageData> data = replayInfo->GetStageData(stage);
-
-				long double score = data->GetLastScore();
-				listScoreD.push_back(score);
-			}
-			res = script->CreateRealArrayValue(listScoreD);
-			break;
-		}
-		case REPLAY_COMMENT:
-			res = script->CreateStringValue(replayInfo->GetComment());
-			break;
+		res = script->CreateRealArrayValue(listStageD);
+		break;
 	}
+	case REPLAY_STAGE_START_SCORE_LIST: {
+		std::vector<int> listStage = replayInfo->GetStageIndexList();
+		std::vector<long double> listScoreD;
+		for (int iStage = 0; iStage < listStage.size(); iStage++) {
+			int stage = listStage[iStage];
+			ref_count_ptr<ReplayInformation::StageData> data = replayInfo->GetStageData(stage);
 
+			long double score = data->GetStartScore();
+			listScoreD.push_back(score);
+		}
+		res = script->CreateRealArrayValue(listScoreD);
+		break;
+	}
+	case REPLAY_STAGE_LAST_SCORE_LIST: {
+		std::vector<int> listStage = replayInfo->GetStageIndexList();
+		std::vector<long double> listScoreD;
+		for (int iStage = 0; iStage < listStage.size(); iStage++) {
+			int stage = listStage[iStage];
+			ref_count_ptr<ReplayInformation::StageData> data = replayInfo->GetStageData(stage);
+
+			long double score = data->GetLastScore();
+			listScoreD.push_back(score);
+		}
+		res = script->CreateRealArrayValue(listScoreD);
+		break;
+	}
+	case REPLAY_COMMENT:
+		res = script->CreateStringValue(replayInfo->GetComment());
+		break;
+	}
 	return res;
 }
-gstd::value StgControlScript::Func_SetReplayInfo(gstd::script_machine* machine, int argc, gstd::value const * argv)
+
+gstd::value StgControlScript::Func_SetReplayInfo(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
 	ref_count_ptr<ReplayInformationManager> replayInfoManager = infoControlScript->GetReplayInformationManager();
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
 	ref_count_ptr<ReplayInformation> replayInfo = infoSystem->GetActiveReplayInformation();
-	if(replayInfo == NULL)
+	if (replayInfo == NULL)
 		script->RaiseError(L"save target replay not found");
 
 	int type = (int)argv[0].as_real();
 
-	switch(type)
-	{
-		case REPLAY_COMMENT:
-			replayInfo->SetComment(argv[1].as_string());
-			break;
+	switch (type) {
+	case REPLAY_COMMENT:
+		replayInfo->SetComment(argv[1].as_string());
+		break;
 	}
 	return value();
 }
-gstd::value StgControlScript::Func_GetReplayUserData(gstd::script_machine* machine, int argc, gstd::value const * argv)
+
+gstd::value StgControlScript::Func_GetReplayUserData(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
@@ -1010,23 +999,26 @@ gstd::value StgControlScript::Func_GetReplayUserData(gstd::script_machine* machi
 	std::string key = to_mbcs(argv[1].as_string());
 
 	ref_count_ptr<ReplayInformation> replayInfo;
-	if(index == ReplayInformation::INDEX_ACTIVE)replayInfo = infoSystem->GetActiveReplayInformation();
-	else replayInfo = replayInfoManager->GetInformation(index);
+	if (index == ReplayInformation::INDEX_ACTIVE)
+		replayInfo = infoSystem->GetActiveReplayInformation();
+	else
+		replayInfo = replayInfoManager->GetInformation(index);
 
-	if(replayInfo == NULL)
+	if (replayInfo == NULL)
 		script->RaiseError(ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_OUTOFRANGE_INDEX));
 
 	gstd::value res = replayInfo->GetUserData(key);
 	return res;
 }
-gstd::value StgControlScript::Func_SetReplayUserData(gstd::script_machine* machine, int argc, gstd::value const * argv)
+
+gstd::value StgControlScript::Func_SetReplayUserData(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
 	ref_count_ptr<ReplayInformationManager> replayInfoManager = infoControlScript->GetReplayInformationManager();
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
 	ref_count_ptr<ReplayInformation> replayInfo = infoSystem->GetActiveReplayInformation();
-	if(replayInfo == NULL)
+	if (replayInfo == NULL)
 		script->RaiseError(L"save target replay not found");
 
 	std::string key = to_mbcs(argv[0].as_string());
@@ -1034,7 +1026,8 @@ gstd::value StgControlScript::Func_SetReplayUserData(gstd::script_machine* machi
 	replayInfo->SetUserData(key, val);
 	return value();
 }
-gstd::value StgControlScript::Func_IsReplayUserDataExists(gstd::script_machine* machine, int argc, gstd::value const * argv)
+
+gstd::value StgControlScript::Func_IsReplayUserDataExists(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
@@ -1045,28 +1038,30 @@ gstd::value StgControlScript::Func_IsReplayUserDataExists(gstd::script_machine* 
 	std::string key = to_mbcs(argv[1].as_string());
 
 	ref_count_ptr<ReplayInformation> replayInfo;
-	if(index == ReplayInformation::INDEX_ACTIVE)replayInfo = infoSystem->GetActiveReplayInformation();
-	else replayInfo = replayInfoManager->GetInformation(index);
+	if (index == ReplayInformation::INDEX_ACTIVE)
+		replayInfo = infoSystem->GetActiveReplayInformation();
+	else
+		replayInfo = replayInfoManager->GetInformation(index);
 
-	if(replayInfo == NULL)
+	if (replayInfo == NULL)
 		script->RaiseError(ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_OUTOFRANGE_INDEX));
 
 	bool res = replayInfo->IsUserDataExists(key);
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
 
-gstd::value StgControlScript::Func_SaveReplay(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgControlScript::Func_SaveReplay(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgControlScript* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
 	ref_count_ptr<ScriptInformation> infoMain = script->systemController_->GetSystemInformation()->GetMainScriptInformation();
 
 	ref_count_ptr<ReplayInformation> replayInfoActive = infoSystem->GetActiveReplayInformation();
-	if(replayInfoActive == NULL)
+	if (replayInfoActive == NULL)
 		script->RaiseError(L"replay information not found");
 
 	int index = (int)argv[0].as_real();
-	if(index <= 0) 
+	if (index <= 0)
 		script->RaiseError(L"replay index error");
 
 	std::wstring userName = argv[1].as_string();
@@ -1076,7 +1071,6 @@ gstd::value StgControlScript::Func_SaveReplay(gstd::script_machine* machine, int
 	bool res = true;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-
 
 /**********************************************************
 //ScriptInfoPanel
@@ -1102,18 +1096,14 @@ void ScriptInfoPanel::LocateParts()
 
 	buttonTerminateScript_.SetBounds(wx + 16, wy + 16, 160, 32);
 }
-LRESULT ScriptInfoPanel::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
+LRESULT ScriptInfoPanel::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	switch (uMsg)
-	{
-		case WM_COMMAND:
-		{
-			int id = wParam & 0xffff;
-			if(id == buttonTerminateScript_.GetWindowId())
-			{
-				_TerminateScriptAll();
-				return FALSE;
-			}
+	switch (uMsg) {
+	case WM_COMMAND:
+		int id = wParam & 0xffff;
+		if (id == buttonTerminateScript_.GetWindowId()) {
+			_TerminateScriptAll();
+			return FALSE;
 		}
 	}
 	return _CallPreviousWindowProcedure(hWnd, uMsg, wParam, lParam);
@@ -1122,14 +1112,11 @@ LRESULT ScriptInfoPanel::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPAR
 void ScriptInfoPanel::_TerminateScriptAll()
 {
 	ETaskManager* taskManager = ETaskManager::GetInstance();
-	std::list<ref_count_ptr<TaskBase> > listTask = taskManager->GetTaskList();
-	std::list<ref_count_ptr<TaskBase> >::iterator itr = listTask.begin();
-	for(; itr != listTask.end() ; itr++)
-	{
-		ref_count_ptr<StgSystemController> systemController = 
-			ref_count_ptr<StgSystemController>::DownCast(*itr);
-		if(systemController != NULL)
-		{
+	std::list<ref_count_ptr<TaskBase>> listTask = taskManager->GetTaskList();
+	std::list<ref_count_ptr<TaskBase>>::iterator itr = listTask.begin();
+	for (; itr != listTask.end(); itr++) {
+		ref_count_ptr<StgSystemController> systemController = ref_count_ptr<StgSystemController>::DownCast(*itr);
+		if (systemController != NULL) {
 			systemController->TerminateScriptAll();
 		}
 	}

--- a/source/TouhouDanmakufu/Common/StgControlScript.hpp
+++ b/source/TouhouDanmakufu/Common/StgControlScript.hpp
@@ -1,183 +1,176 @@
 #ifndef __TOUHOUDANMAKUFU_DNHSTG_CONTROLSCRIPT__
 #define __TOUHOUDANMAKUFU_DNHSTG_CONTROLSCRIPT__
 
-#include"StgCommon.hpp"
+#include "StgCommon.hpp"
 
 class StgControlScript;
 /**********************************************************
 //StgControlScriptManager
 **********************************************************/
-class StgControlScriptManager : public ScriptManager
-{
-	protected:
-
-	public:
-		StgControlScriptManager();
-		virtual ~StgControlScriptManager();
+class StgControlScriptManager : public ScriptManager {
+public:
+	StgControlScriptManager();
+	virtual ~StgControlScriptManager();
 };
 
 /**********************************************************
 //StgControlScriptInformation
 **********************************************************/
-class StgControlScriptInformation 
-{
-		std::vector<ref_count_ptr<ScriptInformation> > listFreePlayer_; //標準自機
-		ref_count_ptr<ReplayInformationManager> replayManager_; //リプレイ情報
+class StgControlScriptInformation {
+public:
+	StgControlScriptInformation();
+	virtual ~StgControlScriptInformation();
+	void LoadFreePlayerList();
+	std::vector<ref_count_ptr<ScriptInformation>>& GetFreePlayerList() { return listFreePlayer_; }
 
-	public:
-		StgControlScriptInformation();
-		virtual ~StgControlScriptInformation();
-		void LoadFreePlayerList();
-		std::vector<ref_count_ptr<ScriptInformation> >& GetFreePlayerList(){return listFreePlayer_;}
+	void LoadReplayInformation(std::wstring pathMainScript);
+	ref_count_ptr<ReplayInformationManager> GetReplayInformationManager() { return replayManager_; }
 
-		void LoadReplayInformation(std::wstring pathMainScript);
-		ref_count_ptr<ReplayInformationManager> GetReplayInformationManager(){return replayManager_;}
+private:
+	std::vector<ref_count_ptr<ScriptInformation>> listFreePlayer_; //標準自機
+	ref_count_ptr<ReplayInformationManager> replayManager_; //リプレイ情報
 };
 
 /**********************************************************
 //StgControlScript
 **********************************************************/
-class StgControlScript : public DnhScript
-{
+class StgControlScript : public DnhScript {
 	friend StgControlScriptManager;
-	public:
-		enum
-		{
-			//イベント
-			EV_USER_COUNT = 100000,
-			EV_USER = 1000000,
-			EV_USER_SYSTEM = 2000000,
-			EV_USER_STAGE = 3000000,
-			EV_USER_PLAYER = 4000000,
-			EV_USER_PACKAGE = 5000000,
 
-			TYPE_SCRIPT_ALL = -1,
-			TYPE_SCRIPT_PLAYER = ScriptInformation::TYPE_PLAYER,
-			TYPE_SCRIPT_SINGLE = ScriptInformation::TYPE_SINGLE,
-			TYPE_SCRIPT_PLURAL = ScriptInformation::TYPE_PLURAL,
-			TYPE_SCRIPT_STAGE = ScriptInformation::TYPE_STAGE,
-			TYPE_SCRIPT_PACKAGE = ScriptInformation::TYPE_PACKAGE,
+public:
+	enum {
+		//イベント
+		EV_USER_COUNT = 100000,
+		EV_USER = 1000000,
+		EV_USER_SYSTEM = 2000000,
+		EV_USER_STAGE = 3000000,
+		EV_USER_PLAYER = 4000000,
+		EV_USER_PACKAGE = 5000000,
 
-			INFO_SCRIPT_TYPE,
-			INFO_SCRIPT_PATH,
-			INFO_SCRIPT_ID,
-			INFO_SCRIPT_TITLE,
-			INFO_SCRIPT_TEXT,
-			INFO_SCRIPT_IMAGE,
-			INFO_SCRIPT_REPLAY_NAME,
+		TYPE_SCRIPT_ALL = -1,
+		TYPE_SCRIPT_PLAYER = ScriptInformation::TYPE_PLAYER,
+		TYPE_SCRIPT_SINGLE = ScriptInformation::TYPE_SINGLE,
+		TYPE_SCRIPT_PLURAL = ScriptInformation::TYPE_PLURAL,
+		TYPE_SCRIPT_STAGE = ScriptInformation::TYPE_STAGE,
+		TYPE_SCRIPT_PACKAGE = ScriptInformation::TYPE_PACKAGE,
 
-			REPLAY_FILE_PATH,
-			REPLAY_DATE_TIME,
-			REPLAY_USER_NAME,
-			REPLAY_TOTAL_SCORE,
-			REPLAY_FPS_AVERAGE,
-			REPLAY_PLAYER_NAME,
-			REPLAY_STAGE_INDEX_LIST,
-			REPLAY_STAGE_START_SCORE_LIST,
-			REPLAY_STAGE_LAST_SCORE_LIST,
-			REPLAY_COMMENT,
+		INFO_SCRIPT_TYPE,
+		INFO_SCRIPT_PATH,
+		INFO_SCRIPT_ID,
+		INFO_SCRIPT_TITLE,
+		INFO_SCRIPT_TEXT,
+		INFO_SCRIPT_IMAGE,
+		INFO_SCRIPT_REPLAY_NAME,
 
-			RESULT_CANCEL,
-			RESULT_END,
-			RESULT_RETRY,
-			RESULT_SAVE_REPLAY,
-		};
-	protected:
-		StgSystemController* systemController_;
+		REPLAY_FILE_PATH,
+		REPLAY_DATE_TIME,
+		REPLAY_USER_NAME,
+		REPLAY_TOTAL_SCORE,
+		REPLAY_FPS_AVERAGE,
+		REPLAY_PLAYER_NAME,
+		REPLAY_STAGE_INDEX_LIST,
+		REPLAY_STAGE_START_SCORE_LIST,
+		REPLAY_STAGE_LAST_SCORE_LIST,
+		REPLAY_COMMENT,
 
-		//スクリプト情報のキャッシュ
-		std::map<std::wstring, ref_count_ptr<ScriptInformation> > mapScriptInfo_;
+		RESULT_CANCEL,
+		RESULT_END,
+		RESULT_RETRY,
+		RESULT_SAVE_REPLAY,
+	};
 
-	public:
-		StgControlScript(StgSystemController* systemController);
+public:
+	StgControlScript(StgSystemController* systemController);
 
-		//STG制御共通関数：共通データ
-		static gstd::value Func_SaveCommonDataAreaA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_LoadCommonDataAreaA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SaveCommonDataAreaA2(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_LoadCommonDataAreaA2(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG制御共通関数：共通データ
+	static gstd::value Func_SaveCommonDataAreaA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_LoadCommonDataAreaA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SaveCommonDataAreaA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_LoadCommonDataAreaA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG制御共通関数：キー系
-		static gstd::value Func_AddVirtualKey(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_AddReplayTargetVirtualKey(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetSkipModeKey(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG制御共通関数：キー系
+	static gstd::value Func_AddVirtualKey(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_AddReplayTargetVirtualKey(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetSkipModeKey(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG制御共通関数：システム関連
-		static gstd::value Func_GetScore(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_AddScore(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetGraze(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_AddGraze(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPoint(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_AddPoint(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_IsReplay(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_AddArchiveFile(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetCurrentFps(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetStageTime(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetStageTimeF(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPackageTime(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG制御共通関数：システム関連
+	static gstd::value Func_GetScore(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_AddScore(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetGraze(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_AddGraze(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPoint(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_AddPoint(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_IsReplay(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_AddArchiveFile(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetCurrentFps(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetStageTime(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetStageTimeF(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPackageTime(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		static gstd::value Func_GetStgFrameLeft(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetStgFrameTop(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetStgFrameWidth(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetStgFrameHeight(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	static gstd::value Func_GetStgFrameLeft(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetStgFrameTop(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetStgFrameWidth(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetStgFrameHeight(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		static gstd::value Func_GetMainPackageScriptPath(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetScriptPathList(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetScriptInfoA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-						
+	static gstd::value Func_GetMainPackageScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetScriptPathList(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetScriptInfoA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG制御共通関数：描画関連
-		static gstd::value Func_ClearInvalidRenderPriority(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetInvalidRenderPriorityA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetReservedRenderTargetName(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_RenderToTextureA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_RenderToTextureB1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SaveSnapShotA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SaveSnapShotA2(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG制御共通関数：描画関連
+	static gstd::value Func_ClearInvalidRenderPriority(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetInvalidRenderPriorityA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetReservedRenderTargetName(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_RenderToTextureA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_RenderToTextureB1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SaveSnapShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SaveSnapShotA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG制御共通関数：自機関連
-		static gstd::value Func_GetPlayerID(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPlayerReplayName(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG制御共通関数：自機関連
+	static gstd::value Func_GetPlayerID(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerReplayName(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG制御共通関数：ユーザスクリプト
-		static gstd::value Func_SetPauseScriptPath(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetEndSceneScriptPath(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetReplaySaveSceneScriptPath(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG制御共通関数：ユーザスクリプト
+	static gstd::value Func_SetPauseScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetEndSceneScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetReplaySaveSceneScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG制御共通関数：自機スクリプト
-		static gstd::value Func_GetLoadFreePlayerScriptList(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetFreePlayerScriptCount(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetFreePlayerScriptInfo(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG制御共通関数：自機スクリプト
+	static gstd::value Func_GetLoadFreePlayerScriptList(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetFreePlayerScriptCount(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetFreePlayerScriptInfo(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG制御共通関数：リプレイ関連
-		static gstd::value Func_LoadReplayList(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetValidReplayIndices(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_IsValidReplayIndex(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetReplayInfo(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetReplayInfo(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetReplayUserData(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetReplayUserData(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_IsReplayUserDataExists(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SaveReplay(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG制御共通関数：リプレイ関連
+	static gstd::value Func_LoadReplayList(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetValidReplayIndices(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_IsValidReplayIndex(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetReplayInfo(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetReplayInfo(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetReplayUserData(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetReplayUserData(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_IsReplayUserDataExists(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SaveReplay(gstd::script_machine* machine, int argc, gstd::value const* argv);
+
+protected:
+	StgSystemController* systemController_;
+
+	//スクリプト情報のキャッシュ
+	std::map<std::wstring, ref_count_ptr<ScriptInformation>> mapScriptInfo_;
 };
-
 
 /**********************************************************
 //ScriptInfoPanel
 **********************************************************/
-class ScriptInfoPanel : public WindowLogger::Panel
-{
-	protected:
-		WButton buttonTerminateScript_;
-		virtual bool _AddedLogger(HWND hTab);
-		virtual LRESULT _WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam);//オーバーライド用プロシージャ
+class ScriptInfoPanel : public WindowLogger::Panel {
+public:
+	ScriptInfoPanel();
+	virtual void LocateParts();
 
-		void _TerminateScriptAll();
+protected:
+	virtual bool _AddedLogger(HWND hTab);
+	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam); //オーバーライド用プロシージャ
+	void _TerminateScriptAll();
 
-	public:
-		ScriptInfoPanel();
-		virtual void LocateParts();
+	WButton buttonTerminateScript_;
 };
 
 #endif
-

--- a/source/TouhouDanmakufu/Common/StgEnemy.cpp
+++ b/source/TouhouDanmakufu/Common/StgEnemy.cpp
@@ -1,5 +1,5 @@
-#include"StgEnemy.hpp"
-#include"StgSystem.hpp"
+#include "StgEnemy.hpp"
+#include "StgSystem.hpp"
 
 /**********************************************************
 //StgEnemyManager
@@ -10,39 +10,32 @@ StgEnemyManager::StgEnemyManager(StgStageController* stageController)
 }
 StgEnemyManager::~StgEnemyManager()
 {
-	std::list<ref_count_ptr<StgEnemyObject>::unsync >::iterator itr = listObj_.begin();
-	for(; itr != listObj_.end(); itr++)
-	{
+	std::list<ref_count_ptr<StgEnemyObject>::unsync>::iterator itr = listObj_.begin();
+	for (; itr != listObj_.end(); itr++) {
 		ref_count_ptr<StgEnemyObject>::unsync obj = (*itr);
-		if(obj != NULL)
-		{
+		if (obj != NULL) {
 			obj->ClearEnemyObject();
 		}
 	}
 }
 void StgEnemyManager::Work()
 {
-	std::list<ref_count_ptr<StgEnemyObject>::unsync >::iterator itr = listObj_.begin();
-	for(; itr != listObj_.end(); )
-	{
+	std::list<ref_count_ptr<StgEnemyObject>::unsync>::iterator itr = listObj_.begin();
+	for (; itr != listObj_.end();) {
 		ref_count_ptr<StgEnemyObject>::unsync obj = (*itr);
-		if(obj->IsDeleted())
-		{
+		if (obj->IsDeleted()) {
 			obj->ClearEnemyObject();
 			itr = listObj_.erase(itr);
-		}
-		else itr++;
+		} else
+			itr++;
 	}
-
 }
 void StgEnemyManager::RegistIntersectionTarget()
 {
-	std::list<ref_count_ptr<StgEnemyObject>::unsync >::iterator itr = listObj_.begin();
-	for(; itr != listObj_.end(); itr++)
-	{
+	std::list<ref_count_ptr<StgEnemyObject>::unsync>::iterator itr = listObj_.begin();
+	for (; itr != listObj_.end(); itr++) {
 		ref_count_ptr<StgEnemyObject>::unsync obj = (*itr);
-		if(!obj->IsDeleted())
-		{
+		if (!obj->IsDeleted()) {
 			obj->ClearIntersectedIdList();
 			obj->RegistIntersectionTarget();
 		}
@@ -50,7 +43,7 @@ void StgEnemyManager::RegistIntersectionTarget()
 }
 void StgEnemyManager::SetBossSceneObject(ref_count_ptr<StgEnemyBossSceneObject>::unsync obj)
 {
-	if(objBossScene_ != NULL && !objBossScene_->IsDeleted())
+	if (objBossScene_ != NULL && !objBossScene_->IsDeleted())
 		throw gstd::wexception(L"すでにEnemyBossSceneオブジェクトが存在します");
 
 	objBossScene_ = obj;
@@ -58,7 +51,7 @@ void StgEnemyManager::SetBossSceneObject(ref_count_ptr<StgEnemyBossSceneObject>:
 ref_count_ptr<StgEnemyBossSceneObject>::unsync StgEnemyManager::GetBossSceneObject()
 {
 	ref_count_ptr<StgEnemyBossSceneObject>::unsync res = NULL;
-	if(objBossScene_ != NULL && !objBossScene_->IsDeleted())
+	if (objBossScene_ != NULL && !objBossScene_->IsDeleted())
 		res = objBossScene_;
 	return res;
 }
@@ -66,11 +59,12 @@ ref_count_ptr<StgEnemyBossSceneObject>::unsync StgEnemyManager::GetBossSceneObje
 /**********************************************************
 //StgEnemyObject
 **********************************************************/
-StgEnemyObject::StgEnemyObject(StgStageController* stageController) : StgMoveObject(stageController)
+StgEnemyObject::StgEnemyObject(StgStageController* stageController)
+	: StgMoveObject(stageController)
 {
 	stageController_ = stageController;
 	typeObject_ = StgStageScript::OBJ_ENEMY;
-	
+
 	SetRenderPriority(0.40);
 
 	life_ = 0;
@@ -78,7 +72,7 @@ StgEnemyObject::StgEnemyObject(StgStageController* stageController) : StgMoveObj
 	rateDamageSpell_ = 100;
 	intersectedPlayerShotCount_ = 0;
 }
-StgEnemyObject:: ~StgEnemyObject()
+StgEnemyObject::~StgEnemyObject()
 {
 }
 void StgEnemyObject::Work()
@@ -107,24 +101,19 @@ void StgEnemyObject::Activate()
 void StgEnemyObject::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget)
 {
 	double damage = 0;
-	if(otherTarget->GetTargetType() == StgIntersectionTarget::TYPE_PLAYER_SHOT)
-	{
+	if (otherTarget->GetTargetType() == StgIntersectionTarget::TYPE_PLAYER_SHOT) {
 		StgShotObject* shot = (StgShotObject*)otherTarget->GetObject().GetPointer();
-		if(shot != NULL)
-		{
+		if (shot != NULL) {
 			damage = shot->GetDamage();
-			if(shot->IsSpellFactor())
+			if (shot->IsSpellFactor())
 				damage = damage * rateDamageSpell_ / 100;
 			else
 				damage = damage * rateDamageShot_ / 100;
 			intersectedPlayerShotCount_++;
 		}
-	}
-	else if(otherTarget->GetTargetType() == StgIntersectionTarget::TYPE_PLAYER_SPELL)
-	{
+	} else if (otherTarget->GetTargetType() == StgIntersectionTarget::TYPE_PLAYER_SPELL) {
 		StgPlayerSpellObject* spell = (StgPlayerSpellObject*)otherTarget->GetObject().GetPointer();
-		if(spell != NULL)
-		{
+		if (spell != NULL) {
 			damage = spell->GetDamage();
 			damage = damage * rateDamageSpell_ / 100;
 		}
@@ -143,7 +132,8 @@ ref_count_ptr<StgEnemyObject>::unsync StgEnemyObject::GetOwnObject()
 /**********************************************************
 //StgEnemyBossObject
 **********************************************************/
-StgEnemyBossObject::StgEnemyBossObject(StgStageController* stageController) : StgEnemyObject(stageController)
+StgEnemyBossObject::StgEnemyBossObject(StgStageController* stageController)
+	: StgEnemyObject(stageController)
 {
 	typeObject_ = StgStageScript::OBJ_ENEMY_BOSS;
 }
@@ -163,44 +153,41 @@ StgEnemyBossSceneObject::StgEnemyBossSceneObject(StgStageController* stageContro
 }
 bool StgEnemyBossSceneObject::_NextStep()
 {
-	if(dataStep_ >= listData_.size())return false;
+	if (dataStep_ >= listData_.size())
+		return false;
 
 	StgStageScriptManager* scriptManager = stageController_->GetScriptManagerP();
 
 	//現ステップ終了通知
-	if(activeData_ != NULL)
-	{
+	if (activeData_ != NULL) {
 		scriptManager->RequestEventAll(StgStageScript::EV_END_BOSS_STEP);
 	}
 
 	dataIndex_++;
-	if(dataIndex_ >= listData_[dataStep_].size())
-	{
+	if (dataIndex_ >= listData_[dataStep_].size()) {
 		dataIndex_ = 0;
-		while(true)
-		{
+		while (true) {
 			dataStep_++;
-			if(dataStep_ >= listData_.size())return false;
-			if(listData_[dataStep_].size() > 0)break;
+			if (dataStep_ >= listData_.size())
+				return false;
+			if (listData_[dataStep_].size() > 0)
+				break;
 		}
 	}
-	
+
 	ref_count_ptr<StgEnemyBossSceneData>::unsync oldActiveData = activeData_;
 
 	//敵登録
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 	activeData_ = listData_[dataStep_][dataIndex_];
-	std::vector<ref_count_ptr<StgEnemyBossObject>::unsync >& listEnemy = activeData_->GetEnemyObjectList();
+	std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& listEnemy = activeData_->GetEnemyObjectList();
 	std::vector<double>& listLife = activeData_->GetLifeList();
-	for(int iEnemy = 0 ; iEnemy < listEnemy.size() ; iEnemy++)
-	{
+	for (int iEnemy = 0; iEnemy < listEnemy.size(); iEnemy++) {
 		ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemy[iEnemy];
 		obj->SetLife(listLife[iEnemy]);
-		if(oldActiveData != NULL)
-		{
-			std::vector<ref_count_ptr<StgEnemyBossObject>::unsync > listOldEnemyObject = oldActiveData->GetEnemyObjectList();
-			if(iEnemy < listOldEnemyObject.size())
-			{
+		if (oldActiveData != NULL) {
+			std::vector<ref_count_ptr<StgEnemyBossObject>::unsync> listOldEnemyObject = oldActiveData->GetEnemyObjectList();
+			if (iEnemy < listOldEnemyObject.size()) {
 				ref_count_ptr<StgEnemyBossObject>::unsync objOld = listOldEnemyObject[iEnemy];
 				obj->SetPositionX(objOld->GetPositionX());
 				obj->SetPositionY(objOld->GetPositionY());
@@ -220,22 +207,18 @@ bool StgEnemyBossSceneObject::_NextStep()
 }
 void StgEnemyBossSceneObject::Work()
 {
-	if(activeData_->IsReadyNext())
-	{
+	if (activeData_->IsReadyNext()) {
 		//次ステップ遷移可能
 		bool bEnemyExists = false;
-		std::vector<ref_count_ptr<StgEnemyBossObject>::unsync > listEnemy = activeData_->GetEnemyObjectList();
-		for(int iEnemy = 0 ; iEnemy < listEnemy.size() ; iEnemy++)
-		{
+		std::vector<ref_count_ptr<StgEnemyBossObject>::unsync> listEnemy = activeData_->GetEnemyObjectList();
+		for (int iEnemy = 0; iEnemy < listEnemy.size(); iEnemy++) {
 			ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemy[iEnemy];
 			bEnemyExists |= (!obj->IsDeleted());
 		}
 
-		if(!bEnemyExists)
-		{
+		if (!bEnemyExists) {
 			bool bNext = _NextStep();
-			if(!bNext)
-			{
+			if (!bNext) {
 				//終了
 				StgEnemyManager* enemyManager = stageController_->GetEnemyManager();
 				ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
@@ -245,41 +228,33 @@ void StgEnemyBossSceneObject::Work()
 			}
 		}
 
-	}
-	else if(!activeData_->IsReadyNext())
-	{
+	} else if (!activeData_->IsReadyNext()) {
 		//タイマー監視
 		bool bZeroTimer = false;
 		int timer = activeData_->GetSpellTimer();
-		if(timer > 0)
-		{
+		if (timer > 0) {
 			timer--;
 			activeData_->SetSpellTimer(timer);
-			if(timer == 0)
-			{
+			if (timer == 0) {
 				bZeroTimer = true;
 			}
 		}
 
 		//ラストスペル監視
 		bool bEndLastSpell = false;
-		if(activeData_->IsLastSpell())
-		{
+		if (activeData_->IsLastSpell()) {
 			bEndLastSpell = activeData_->GetPlayerShootDownCount() > 0;
 		}
 
-		if(bZeroTimer || bEndLastSpell)
-		{
+		if (bZeroTimer || bEndLastSpell) {
 			//タイマー0なら敵のライフを0にする
-			std::vector<ref_count_ptr<StgEnemyBossObject>::unsync >& listEnemy = activeData_->GetEnemyObjectList();
-			for(int iEnemy = 0 ; iEnemy < listEnemy.size() ; iEnemy++)
-			{
+			std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& listEnemy = activeData_->GetEnemyObjectList();
+			for (int iEnemy = 0; iEnemy < listEnemy.size(); iEnemy++) {
 				ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemy[iEnemy];
 				obj->SetLife(0);
 			}
 
-			if(bZeroTimer)
-			{
+			if (bZeroTimer) {
 				//タイムアウト通知
 				StgStageScriptManager* scriptManager = stageController_->GetScriptManagerP();
 				scriptManager->RequestEventAll(StgStageScript::EV_TIMEOUT);
@@ -288,18 +263,15 @@ void StgEnemyBossSceneObject::Work()
 
 		//次シーンへの遷移フラグ設定
 		bool bReadyNext = true;
-		std::vector<ref_count_ptr<StgEnemyBossObject>::unsync >& listEnemy = activeData_->GetEnemyObjectList();
-		for(int iEnemy = 0 ; iEnemy < listEnemy.size() ; iEnemy++)
-		{
+		std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& listEnemy = activeData_->GetEnemyObjectList();
+		for (int iEnemy = 0; iEnemy < listEnemy.size(); iEnemy++) {
 			ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemy[iEnemy];
-			if(obj->GetLife() > 0)
+			if (obj->GetLife() > 0)
 				bReadyNext = false;
 		}
 
-		if(bReadyNext)
-		{
-			if(activeData_->IsSpellCard())
-			{
+		if (bReadyNext) {
+			if (activeData_->IsSpellCard()) {
 				//スペルカード取得
 				//・タイマー0／スペル使用／被弾時は取得不可
 				//・耐久の場合はタイマー0でも取得可能
@@ -308,8 +280,7 @@ void StgEnemyBossSceneObject::Work()
 				bGrain &= (activeData_->GetPlayerSpellCount() == 0);
 				bGrain &= (activeData_->IsDurable() || activeData_->GetSpellTimer() > 0);
 
-				if(bGrain)
-				{
+				if (bGrain) {
 					StgStageScriptManager* scriptManager = stageController_->GetScriptManagerP();
 					_int64 score = activeData_->GetCurrentSpellScore();
 					scriptManager->RequestEventAll(StgStageScript::EV_GAIN_SPELL);
@@ -317,106 +288,86 @@ void StgEnemyBossSceneObject::Work()
 			}
 			activeData_->SetReadyNext();
 		}
-
 	}
 }
 void StgEnemyBossSceneObject::Activate()
 {
 	//スクリプトを読み込んでいなかったら読み込む。
-	if(!bLoad_)
+	if (!bLoad_)
 		LoadAllScriptInThread();
 
 	StgStageScriptManager* scriptManager = stageController_->GetScriptManagerP();
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
-	for(int iStep = 0 ; iStep < listData_.size() ; iStep++)
-	{
-		for(int iData = 0 ; iData < listData_[iStep].size() ; iData++)
-		{
+	for (int iStep = 0; iStep < listData_.size(); iStep++) {
+		for (int iData = 0; iData < listData_[iStep].size(); iData++) {
 			ref_count_ptr<StgEnemyBossSceneData>::unsync data = listData_[iStep][iData];
 			_int64 idScript = data->GetScriptID();
 			ref_count_ptr<ManagedScript> script = scriptManager->GetScript(idScript);
-			if(script == NULL)
+			if (script == NULL)
 				throw gstd::wexception(StringUtility::Format(L"読み込まれていないスクリプト：%s", data->GetPath().c_str()).c_str());
-			if(!script->IsLoad())
-			{
+			if (!script->IsLoad()) {
 				int count = 0;
-				while(!script->IsLoad())
-				{
-					if(count % 1000 == 999)
-					{
-						std::wstring log = 
-							StringUtility::Format(L"読み込み完了待機(StgEnemyBossSceneObject)：[%d, %d] %s", iStep, iData, data->GetPath().c_str());
+				while (!script->IsLoad()) {
+					if (count % 1000 == 999) {
+						std::wstring log = StringUtility::Format(L"読み込み完了待機(StgEnemyBossSceneObject)：[%d, %d] %s", iStep, iData, data->GetPath().c_str());
 						Logger::WriteTop(log);
-
 					}
 					Sleep(1);
 					count++;
 				}
 			}
 
-			if(stageController_->GetSystemInformation()->IsError())continue;
+			if (stageController_->GetSystemInformation()->IsError())
+				continue;
 
 			//ライフ読み込み
 			std::vector<double> listLife;
 			gstd::value vLife = script->RequestEvent(StgStageScript::EV_REQUEST_LIFE);
-			if(script->IsRealValue(vLife))
-			{
+			if (script->IsRealValue(vLife)) {
 				double life = vLife.as_real();
 				listLife.push_back(life);
-			}
-			else if(script->IsRealArrayValue(vLife))
-			{
+			} else if (script->IsRealArrayValue(vLife)) {
 				int count = vLife.length_as_array();
-				for(int iLife = 0 ; iLife < count ; iLife++)
-				{
+				for (int iLife = 0; iLife < count; iLife++) {
 					double life = vLife.index_as_array(iLife).as_real();
 					listLife.push_back(life);
 				}
 			}
 
-			if(listLife.size() == 0)
+			if (listLife.size() == 0)
 				throw gstd::wexception(StringUtility::Format(L"敵ライフを適切に返していません。(%s)", data->GetPath().c_str()).c_str());
 			data->SetLifeList(listLife);
 
 			//タイマー読み込み
 			gstd::value vTimer = script->RequestEvent(StgStageScript::EV_REQUEST_TIMER);
-			if(script->IsRealValue(vTimer))
-			{
+			if (script->IsRealValue(vTimer)) {
 				data->SetOriginalSpellTimer(vTimer.as_real() * STANDARD_FPS);
 			}
 
 			//スペル
 			gstd::value vSpell = script->RequestEvent(StgStageScript::EV_REQUEST_IS_SPELL);
-			if(script->IsBooleanValue(vSpell))
-			{
+			if (script->IsBooleanValue(vSpell)) {
 				data->SetSpellCard(vSpell.as_boolean());
 			}
 
 			{
 				//スコア、ラストスペル、耐久スペルを読み込む
 				gstd::value vScore = script->RequestEvent(StgStageScript::EV_REQUEST_SPELL_SCORE);
-				if(script->IsRealValue(vScore))
-				{
+				if (script->IsRealValue(vScore))
 					data->SetSpellScore(vScore.as_real());
-				}
 
 				gstd::value vLast = script->RequestEvent(StgStageScript::EV_REQUEST_IS_LAST_SPELL);
-				if(script->IsBooleanValue(vLast))
-				{
+				if (script->IsBooleanValue(vLast))
 					data->SetLastSpell(vLast.as_boolean());
-				}
 
 				gstd::value vDurable = script->RequestEvent(StgStageScript::EV_REQUEST_IS_DURABLE_SPELL);
-				if(script->IsBooleanValue(vDurable))
-				{
+				if (script->IsBooleanValue(vDurable))
 					data->SetDurable(vDurable.as_boolean());
-				}
 			}
 
 			//敵オブジェクト作成
-			std::vector<ref_count_ptr<StgEnemyBossObject>::unsync > listEnemyObject;
-			for(int iEnemy = 0 ; iEnemy < listLife.size() ; iEnemy++)
-			{
+			std::vector<ref_count_ptr<StgEnemyBossObject>::unsync> listEnemyObject;
+			for (int iEnemy = 0; iEnemy < listLife.size(); iEnemy++) {
 				ref_count_ptr<StgEnemyBossObject>::unsync obj = new StgEnemyBossObject(stageController_);
 				int idEnemy = objectManager->AddObject(obj, false);
 				listEnemyObject.push_back(obj);
@@ -427,21 +378,18 @@ void StgEnemyBossSceneObject::Activate()
 
 	//登録
 	_NextStep();
-
 }
 void StgEnemyBossSceneObject::AddData(int step, ref_count_ptr<StgEnemyBossSceneData>::unsync data)
 {
-	if(listData_.size() <= step)
+	if (listData_.size() <= step)
 		listData_.resize(step + 1);
 	listData_[step].push_back(data);
 }
 void StgEnemyBossSceneObject::LoadAllScriptInThread()
 {
 	StgStageScriptManager* scriptManager = stageController_->GetScriptManagerP();
-	for(int iStep = 0 ; iStep < listData_.size() ; iStep++)
-	{
-		for(int iData = 0 ; iData < listData_[iStep].size() ; iData++)
-		{
+	for (int iStep = 0; iStep < listData_.size(); iStep++) {
+		for (int iData = 0; iData < listData_[iStep].size(); iData++) {
 			ref_count_ptr<StgEnemyBossSceneData>::unsync data = listData_[iStep][iData];
 			std::wstring path = data->GetPath();
 
@@ -459,54 +407,53 @@ int StgEnemyBossSceneObject::GetRemainStepCount()
 }
 int StgEnemyBossSceneObject::GetActiveStepLifeCount()
 {
-	if(dataStep_ >= listData_.size())return 0;
+	if (dataStep_ >= listData_.size())
+		return 0;
 	return listData_[dataStep_].size();
 }
 double StgEnemyBossSceneObject::GetActiveStepTotalMaxLife()
 {
-	if(dataStep_ >= listData_.size())return 0;
+	if (dataStep_ >= listData_.size())
+		return 0;
 
 	double res = 0;
-	for(int iData = 0 ; iData < listData_[dataStep_].size() ; iData++)
-	{
+	for (int iData = 0; iData < listData_[dataStep_].size(); iData++) {
 		ref_count_ptr<StgEnemyBossSceneData>::unsync data = listData_[dataStep_][iData];
 		std::vector<double>& listLife = data->GetLifeList();
-		for(int iLife = 0 ; iLife < listLife.size() ; iLife++)
+		for (int iLife = 0; iLife < listLife.size(); iLife++)
 			res += listLife[iLife];
 	}
 	return res;
 }
 double StgEnemyBossSceneObject::GetActiveStepTotalLife()
 {
-	if(dataStep_ >= listData_.size())return 0;
+	if (dataStep_ >= listData_.size())
+		return 0;
 
 	double res = 0;
-	for(int iData = dataIndex_ ; iData < listData_[dataStep_].size() ; iData++)
-	{
+	for (int iData = dataIndex_; iData < listData_[dataStep_].size(); iData++) {
 		res += GetActiveStepLife(iData);
 	}
 	return res;
 }
 double StgEnemyBossSceneObject::GetActiveStepLife(int index)
 {
-	if(dataStep_ >= listData_.size())return 0;
-	if(index < dataIndex_)return 0;
+	if (dataStep_ >= listData_.size())
+		return 0;
+	if (index < dataIndex_)
+		return 0;
 
 	double res = 0;
 	ref_count_ptr<StgEnemyBossSceneData>::unsync data = listData_[dataStep_][index];
-	if(index == dataIndex_)
-	{
-		std::vector<ref_count_ptr<StgEnemyBossObject>::unsync >& listEnemyObject = data->GetEnemyObjectList();
-		for(int iEnemy = 0 ; iEnemy < listEnemyObject.size() ; iEnemy++)
-		{
+	if (index == dataIndex_) {
+		std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& listEnemyObject = data->GetEnemyObjectList();
+		for (int iEnemy = 0; iEnemy < listEnemyObject.size(); iEnemy++) {
 			ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemyObject[iEnemy];
 			res += obj->GetLife();
 		}
-	}
-	else
-	{
+	} else {
 		std::vector<double>& listLife = data->GetLifeList();
-		for(int iLife = 0 ; iLife < listLife.size() ; iLife++)
+		for (int iLife = 0; iLife < listLife.size(); iLife++)
 			res += listLife[iLife];
 	}
 	return res;
@@ -517,14 +464,12 @@ std::vector<double> StgEnemyBossSceneObject::GetActiveStepLifeRateList()
 	int count = GetActiveStepLifeCount();
 	double total = GetActiveStepTotalMaxLife();
 	double rate = 0;
-	for(int iData = 0 ; iData < count; iData++)
-	{
+	for (int iData = 0; iData < count; iData++) {
 		ref_count_ptr<StgEnemyBossSceneData>::unsync data = listData_[dataStep_][iData];
 
 		double life = 0;
 		std::vector<double>& listLife = data->GetLifeList();
-		for(int iLife = 0 ; iLife < listLife.size() ; iLife++)
-		{
+		for (int iLife = 0; iLife < listLife.size(); iLife++) {
 			life += listLife[iLife];
 		}
 		rate += life / total;
@@ -534,12 +479,14 @@ std::vector<double> StgEnemyBossSceneObject::GetActiveStepLifeRateList()
 }
 void StgEnemyBossSceneObject::AddPlayerShootDownCount()
 {
-	if(activeData_ == NULL)return;
+	if (activeData_ == NULL)
+		return;
 	activeData_->AddPlayerShootDownCount();
 }
 void StgEnemyBossSceneObject::AddPlayerSpellCount()
 {
-	if(activeData_ == NULL)return;
+	if (activeData_ == NULL)
+		return;
 	activeData_->AddPlayerSpellCount();
 }
 
@@ -559,13 +506,12 @@ StgEnemyBossSceneData::StgEnemyBossSceneData()
 }
 int StgEnemyBossSceneData::GetEnemyBossIdInCreate()
 {
-	if(countCreate_ >= listEnemyObject_.size())
-	{
+	if (countCreate_ >= listEnemyObject_.size()) {
 		std::wstring log = StringUtility::Format(L"EnemyBossオブジェクトはこれ以上作成できません:%d", countCreate_);
 		throw gstd::wexception(log.c_str());
 	}
-		
-	ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemyObject_[countCreate_]; 
+
+	ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemyObject_[countCreate_];
 	countCreate_++;
 
 	return obj->GetObjectID();
@@ -573,12 +519,9 @@ int StgEnemyBossSceneData::GetEnemyBossIdInCreate()
 _int64 StgEnemyBossSceneData::GetCurrentSpellScore()
 {
 	_int64 res = scoreSpell_;
-	if(!bDurable_)
-	{
+	if (!bDurable_) {
 		double rate = (double)timerSpell_ / (double)timerSpellOrg_;
 		res = scoreSpell_ * rate;
 	}
 	return res;
 }
-
-

--- a/source/TouhouDanmakufu/Common/StgEnemy.hpp
+++ b/source/TouhouDanmakufu/Common/StgEnemy.hpp
@@ -1,175 +1,194 @@
 #ifndef __TOUHOUDANMAKUFU_DNHSTG_ENEMY__
 #define __TOUHOUDANMAKUFU_DNHSTG_ENEMY__
 
-#include"StgCommon.hpp"
-#include"StgIntersection.hpp"
+#include "StgCommon.hpp"
+#include "StgIntersection.hpp"
 
 class StgEnemyObject;
 class StgEnemyBossSceneObject;
 /**********************************************************
 //StgEnemyManager
 **********************************************************/
-class StgEnemyManager
-{
-		StgStageController* stageController_;
-		std::list<ref_count_ptr<StgEnemyObject>::unsync > listObj_;
-		ref_count_ptr<StgEnemyBossSceneObject>::unsync objBossScene_;
-	public:
-		StgEnemyManager(StgStageController* stageController);
-		virtual ~StgEnemyManager();
-		void Work();
-		void RegistIntersectionTarget();
+class StgEnemyManager {
+public:
+	StgEnemyManager(StgStageController* stageController);
+	virtual ~StgEnemyManager();
+	void Work();
+	void RegistIntersectionTarget();
 
-		void AddEnemy(ref_count_ptr<StgEnemyObject>::unsync obj){listObj_.push_back(obj);}
-		int GetEnemyCount(){return listObj_.size();}
+	void AddEnemy(ref_count_ptr<StgEnemyObject>::unsync obj) { listObj_.push_back(obj); }
+	int GetEnemyCount() { return listObj_.size(); }
 
-		void SetBossSceneObject(ref_count_ptr<StgEnemyBossSceneObject>::unsync obj);
-		ref_count_ptr<StgEnemyBossSceneObject>::unsync GetBossSceneObject();
-		std::list<ref_count_ptr<StgEnemyObject>::unsync >& GetEnemyList(){return listObj_;}
+	void SetBossSceneObject(ref_count_ptr<StgEnemyBossSceneObject>::unsync obj);
+	ref_count_ptr<StgEnemyBossSceneObject>::unsync GetBossSceneObject();
+	std::list<ref_count_ptr<StgEnemyObject>::unsync>& GetEnemyList() { return listObj_; }
 
+private:
+	StgStageController* stageController_;
+	std::list<ref_count_ptr<StgEnemyObject>::unsync> listObj_;
+	ref_count_ptr<StgEnemyBossSceneObject>::unsync objBossScene_;
 };
 
 /**********************************************************
 //StgEnemyObject
 **********************************************************/
-class StgEnemyObject : public DxScriptSpriteObject2D, public StgMoveObject, public StgIntersectionObject
-{
-	protected:
-		StgStageController* stageController_;
+class StgEnemyObject : public DxScriptSpriteObject2D, public StgMoveObject, public StgIntersectionObject {
+public:
+	StgEnemyObject(StgStageController* stageController);
+	virtual ~StgEnemyObject();
 
-		double life_;
-		double rateDamageShot_;
-		double rateDamageSpell_;
-		int intersectedPlayerShotCount_;
+	virtual void Work();
+	virtual void Activate();
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	virtual void ClearEnemyObject() { ClearIntersectionRelativeTarget(); }
+	virtual void RegistIntersectionTarget();
 
-		virtual void _Move();
-		virtual void _AddRelativeIntersection();
-	public:
-		StgEnemyObject(StgStageController* stageController);
-		virtual ~StgEnemyObject();
+	virtual void SetX(double x)
+	{
+		posX_ = x;
+		DxScriptRenderObject::SetX(x);
+	}
+	virtual void SetY(double y)
+	{
+		posY_ = y;
+		DxScriptRenderObject::SetY(y);
+	}
 
-		virtual void Work();
-		virtual void Activate();
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
-		virtual void ClearEnemyObject(){ClearIntersectionRelativeTarget();}
-		virtual void RegistIntersectionTarget();
+	ref_count_ptr<StgEnemyObject>::unsync GetOwnObject();
+	double GetLife() { return life_; }
+	void SetLife(double life) { life_ = life; }
+	void AddLife(double inc)
+	{
+		life_ += inc;
+		life_ = max(life_, 0);
+	}
+	void SetDamageRate(double rateShot, double rateSpell)
+	{
+		rateDamageShot_ = rateShot;
+		rateDamageSpell_ = rateSpell;
+	}
+	double GetShotDamageRate() { return rateDamageShot_; }
+	double GetSpellDamageRate() { return rateDamageSpell_; }
+	int GetIntersectedPlayerShotCount() { return intersectedPlayerShotCount_; }
 
-		virtual void SetX(double x){posX_ = x; DxScriptRenderObject::SetX(x);}
-		virtual void SetY(double y){posY_ = y; DxScriptRenderObject::SetY(y);}
+protected:
+	virtual void _Move();
+	virtual void _AddRelativeIntersection();
 
-		ref_count_ptr<StgEnemyObject>::unsync GetOwnObject();
-		double GetLife(){return life_;}
-		void SetLife(double life){life_ = life;}
-		void AddLife(double inc){life_ += inc; life_ = max(life_, 0);}
-		void SetDamageRate(double rateShot, double rateSpell){rateDamageShot_ = rateShot; rateDamageSpell_ = rateSpell;}
-		double GetShotDamageRate(){return rateDamageShot_;}
-		double GetSpellDamageRate(){return rateDamageSpell_;}
-		int GetIntersectedPlayerShotCount(){return intersectedPlayerShotCount_;}
+	StgStageController* stageController_;
+
+	double life_;
+	double rateDamageShot_;
+	double rateDamageSpell_;
+	int intersectedPlayerShotCount_;
 };
 
 /**********************************************************
 //StgEnemyBossObject
 **********************************************************/
-class StgEnemyBossObject : public StgEnemyObject
-{
-	private:
-		int timeSpellCard_;
-	public:
-		StgEnemyBossObject(StgStageController* stageController);
+class StgEnemyBossObject : public StgEnemyObject {
+public:
+	StgEnemyBossObject(StgStageController* stageController);
+
+private:
+	int timeSpellCard_;
 };
 
 /**********************************************************
 //StgEnemyBossSceneObject
 **********************************************************/
 class StgEnemyBossSceneData;
-class StgEnemyBossSceneObject : public DxScriptObjectBase
-{
-	private:
-		StgStageController* stageController_;
-		volatile bool bLoad_;
+class StgEnemyBossSceneObject : public DxScriptObjectBase {
+public:
+	StgEnemyBossSceneObject(StgStageController* stageController);
+	virtual void Work();
+	virtual void Activate();
+	virtual void Render() {} //何もしない
+	virtual void SetRenderState() {} //何もしない
 
-		int dataStep_;
-		int dataIndex_;
-		ref_count_ptr<StgEnemyBossSceneData>::unsync activeData_;
-		std::vector<std::vector<ref_count_ptr<StgEnemyBossSceneData>::unsync > > listData_;
+	void AddData(int step, ref_count_ptr<StgEnemyBossSceneData>::unsync data);
+	ref_count_ptr<StgEnemyBossSceneData>::unsync GetActiveData() { return activeData_; }
+	void LoadAllScriptInThread();
 
-		bool _NextStep();
-	public:
-		StgEnemyBossSceneObject(StgStageController* stageController);
-		virtual void Work();
-		virtual void Activate();
-		virtual void Render(){}//何もしない
-		virtual void SetRenderState(){}//何もしない
+	int GetRemainStepCount();
+	int GetActiveStepLifeCount();
+	double GetActiveStepTotalMaxLife();
+	double GetActiveStepTotalLife();
+	double GetActiveStepLife(int index);
+	std::vector<double> GetActiveStepLifeRateList();
+	int GetDataStep() { return dataStep_; }
+	int GetDataIndex() { return dataIndex_; }
 
-		void AddData(int step, ref_count_ptr<StgEnemyBossSceneData>::unsync data);
-		ref_count_ptr<StgEnemyBossSceneData>::unsync GetActiveData(){return activeData_;}
-		void LoadAllScriptInThread();
+	void AddPlayerShootDownCount();
+	void AddPlayerSpellCount();
 
-		int GetRemainStepCount();
-		int GetActiveStepLifeCount();
-		double GetActiveStepTotalMaxLife();
-		double GetActiveStepTotalLife();
-		double GetActiveStepLife(int index);
-		std::vector<double> GetActiveStepLifeRateList();
-		int GetDataStep(){return dataStep_;}
-		int GetDataIndex(){return dataIndex_;}
+private:
+	bool _NextStep();
 
-		void AddPlayerShootDownCount();
-		void AddPlayerSpellCount();
+	StgStageController* stageController_;
+	volatile bool bLoad_;
+
+	int dataStep_;
+	int dataIndex_;
+	ref_count_ptr<StgEnemyBossSceneData>::unsync activeData_;
+	std::vector<std::vector<ref_count_ptr<StgEnemyBossSceneData>::unsync>> listData_;
 };
 
-class StgEnemyBossSceneData
-{
-	private:
-		std::wstring path_;
-		_int64 isScript_;
-		std::vector<double> listLife_;
-		std::vector<ref_count_ptr<StgEnemyBossObject>::unsync > listEnemyObject_;
-		int countCreate_;//ボス生成数。listEnemyObject_を超えて生成しようとしたらエラー。
-		bool bReadyNext_;
+class StgEnemyBossSceneData {
+public:
+	StgEnemyBossSceneData();
+	virtual ~StgEnemyBossSceneData() {}
+	std::wstring GetPath() { return path_; }
+	void SetPath(std::wstring path) { path_ = path; }
+	_int64 GetScriptID() { return isScript_; }
+	void SetScriptID(_int64 id) { isScript_ = id; }
+	std::vector<double>& GetLifeList() { return listLife_; }
+	void SetLifeList(std::vector<double>& list) { listLife_ = list; }
+	std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& GetEnemyObjectList() { return listEnemyObject_; }
+	void SetEnemyObjectList(std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& list) { listEnemyObject_ = list; }
+	int GetEnemyBossIdInCreate();
+	bool IsReadyNext() { return bReadyNext_; }
+	void SetReadyNext() { bReadyNext_ = true; }
 
-		bool bSpell_;//スペルカード
-		bool bLastSpell_;//ラストスペル
-		bool bDurable_;//耐久スペル
-		_int64 scoreSpell_;
-		int timerSpellOrg_;//初期タイマー フレーム単位 -1で無効
-		int timerSpell_;//タイマー フレーム単位 -1で無効
-		int countPlayerShootDown_;//自機撃破数
-		int countPlayerSpell_;//自機スペル使用数
+	_int64 GetCurrentSpellScore();
+	_int64 GetSpellScore() { return scoreSpell_; }
+	void SetSpellScore(_int64 score) { scoreSpell_ = score; }
+	int GetSpellTimer() { return timerSpell_; }
+	void SetSpellTimer(int timer) { timerSpell_ = timer; }
+	int GetOriginalSpellTimer() { return timerSpellOrg_; }
+	void SetOriginalSpellTimer(int timer)
+	{
+		timerSpellOrg_ = timer;
+		timerSpell_ = timer;
+	}
+	bool IsSpellCard() { return bSpell_; }
+	void SetSpellCard(bool b) { bSpell_ = b; }
+	bool IsLastSpell() { return bLastSpell_; }
+	void SetLastSpell(bool b) { bLastSpell_ = b; }
+	bool IsDurable() { return bDurable_; }
+	void SetDurable(bool b) { bDurable_ = b; }
 
-	public:
-		StgEnemyBossSceneData();
-		virtual ~StgEnemyBossSceneData(){}
-		std::wstring GetPath(){return path_;}
-		void SetPath(std::wstring path){path_ = path;}
-		_int64 GetScriptID(){return isScript_;}
-		void SetScriptID(_int64 id){isScript_ = id;}
-		std::vector<double>& GetLifeList(){return listLife_;}
-		void SetLifeList(std::vector<double>& list){listLife_ = list;}
-		std::vector<ref_count_ptr<StgEnemyBossObject>::unsync >& GetEnemyObjectList(){return listEnemyObject_;}
-		void SetEnemyObjectList(std::vector<ref_count_ptr<StgEnemyBossObject>::unsync >& list){listEnemyObject_ = list;}
-		int GetEnemyBossIdInCreate();
-		bool IsReadyNext(){return bReadyNext_;}
-		void SetReadyNext(){bReadyNext_ = true;}
+	void AddPlayerShootDownCount() { countPlayerShootDown_++; }
+	int GetPlayerShootDownCount() { return countPlayerShootDown_; }
+	void AddPlayerSpellCount() { countPlayerSpell_++; }
+	int GetPlayerSpellCount() { return countPlayerSpell_; }
 
-		_int64 GetCurrentSpellScore();
-		_int64 GetSpellScore(){return scoreSpell_;}
-		void SetSpellScore(_int64 score){scoreSpell_ = score;}
-		int GetSpellTimer(){return timerSpell_;}
-		void SetSpellTimer(int timer){timerSpell_ = timer;}
-		int GetOriginalSpellTimer(){return timerSpellOrg_;}
-		void SetOriginalSpellTimer(int timer){timerSpellOrg_ = timer; timerSpell_ = timer;}
-		bool IsSpellCard(){return bSpell_;}
-		void SetSpellCard(bool b){bSpell_ = b;}
-		bool IsLastSpell(){return bLastSpell_;}
-		void SetLastSpell(bool b){bLastSpell_ = b;}
-		bool IsDurable(){return bDurable_;}
-		void SetDurable(bool b){bDurable_ = b;}
+private:
+	std::wstring path_;
+	_int64 isScript_;
+	std::vector<double> listLife_;
+	std::vector<ref_count_ptr<StgEnemyBossObject>::unsync> listEnemyObject_;
+	int countCreate_; //ボス生成数。listEnemyObject_を超えて生成しようとしたらエラー。
+	bool bReadyNext_;
 
-		void AddPlayerShootDownCount(){countPlayerShootDown_++;}
-		int GetPlayerShootDownCount(){return countPlayerShootDown_;}
-		void AddPlayerSpellCount(){countPlayerSpell_++;}
-		int GetPlayerSpellCount(){return countPlayerSpell_;}
+	bool bSpell_; //スペルカード
+	bool bLastSpell_; //ラストスペル
+	bool bDurable_; //耐久スペル
+	_int64 scoreSpell_;
+	int timerSpellOrg_; //初期タイマー フレーム単位 -1で無効
+	int timerSpell_; //タイマー フレーム単位 -1で無効
+	int countPlayerShootDown_; //自機撃破数
+	int countPlayerSpell_; //自機スペル使用数
 };
 
 #endif

--- a/source/TouhouDanmakufu/Common/StgIntersection.cpp
+++ b/source/TouhouDanmakufu/Common/StgIntersection.cpp
@@ -1,7 +1,7 @@
-#include"StgIntersection.hpp"
-#include"StgShot.hpp"
-#include"StgPlayer.hpp"
-#include"StgEnemy.hpp"
+#include "StgIntersection.hpp"
+#include "StgEnemy.hpp"
+#include "StgPlayer.hpp"
+#include "StgShot.hpp"
 
 /**********************************************************
 //StgIntersectionManager
@@ -14,8 +14,7 @@ StgIntersectionManager::StgIntersectionManager()
 
 	_CreatePool(2);
 	listSpace_.resize(3);
-	for(int iSpace = 0 ; iSpace < listSpace_.size() ; iSpace++)
-	{
+	for (int iSpace = 0; iSpace < listSpace_.size(); iSpace++) {
 		StgIntersectionSpace* space = new StgIntersectionSpace();
 		space->Initialize(4, -100, -100, screenWidth + 100, screenHeight + 100);
 		listSpace_[iSpace] = space;
@@ -30,42 +29,37 @@ void StgIntersectionManager::Work()
 	listEnemyTargetPointNext_.clear();
 
 	int totalCheck = 0;
-	std::vector<ref_count_ptr<StgIntersectionSpace> >::iterator itr = listSpace_.begin();
-	for(; itr != listSpace_.end() ; itr++)
-	{
+	std::vector<ref_count_ptr<StgIntersectionSpace>>::iterator itr = listSpace_.begin();
+	for (; itr != listSpace_.end(); itr++) {
 		StgIntersectionSpace* space = (*itr).GetPointer();
 		ref_count_ptr<StgIntersectionCheckList>::unsync listCheck = space->CreateIntersectionCheckList();
 		int countCheck = listCheck->GetCheckCount();
-		for(int iCheck = 0 ; iCheck < countCheck ; iCheck++)
-		{
+		for (int iCheck = 0; iCheck < countCheck; iCheck++) {
 			//Getは1回しか使用できません
 			ref_count_ptr<StgIntersectionTarget>::unsync targetA = listCheck->GetTargetA(iCheck);
 			ref_count_ptr<StgIntersectionTarget>::unsync targetB = listCheck->GetTargetB(iCheck);
 
 			bool bIntersected = IsIntersected(targetA, targetB);
-			if(!bIntersected)continue;
+			if (!bIntersected)
+				continue;
 
 			//Grazeの関係で、先に自機の当たり判定をする必要がある。
 			ref_count_weak_ptr<StgIntersectionObject>::unsync objA = targetA->GetObject();
 			ref_count_weak_ptr<StgIntersectionObject>::unsync objB = targetB->GetObject();
-			if(objA != NULL)
-			{
+			if (objA != NULL) {
 				objA->Intersect(targetA, targetB);
 				objA->SetIntersected();
 
-				if(objB != NULL)
-				{
+				if (objB != NULL) {
 					int idObject = objB->GetDxScriptObjectID();
 					objA->AddIntersectedId(idObject);
 				}
 			}
-			
-			if(objB != NULL)
-			{
+
+			if (objB != NULL) {
 				objB->Intersect(targetB, targetA);
 				objB->SetIntersected();
-				if(objA != NULL)
-				{
+				if (objA != NULL) {
 					int idObject = objA->GetDxScriptObjectID();
 					objB->AddIntersectedId(idObject);
 				}
@@ -79,12 +73,11 @@ void StgIntersectionManager::Work()
 	_ArrangePool();
 
 	ELogger* logger = ELogger::GetInstance();
-	if(logger->IsWindowVisible())
-	{
+	if (logger->IsWindowVisible()) {
 		int countUsed = GetUsedPoolObjectCount();
 		int countCache = GetCachePoolObjectCount();
-		logger->SetInfo(9, L"stg intersection_count", 
-			StringUtility::Format(L"used=%4d, cache=%4d, total=%4d check=%4d", countUsed, countCache, countUsed+countCache, totalCheck ));
+		logger->SetInfo(9, L"stg intersection_count",
+			StringUtility::Format(L"used=%4d, cache=%4d, total=%4d check=%4d", countUsed, countCache, countUsed + countCache, totalCheck));
 	}
 }
 void StgIntersectionManager::AddTarget(ref_count_ptr<StgIntersectionTarget>::unsync target)
@@ -97,72 +90,54 @@ void StgIntersectionManager::AddTarget(ref_count_ptr<StgIntersectionTarget>::uns
 	//target->ClearObjectIntersectedIdList();
 
 	int type = target->GetTargetType();
-	switch(type)
-	{
-		case StgIntersectionTarget::TYPE_PLAYER:
-		{
-			listSpace_[SPACE_PLAYER_ENEMY]->RegistTargetA(target);
-			break;
+	switch (type) {
+	case StgIntersectionTarget::TYPE_PLAYER:
+		listSpace_[SPACE_PLAYER_ENEMY]->RegistTargetA(target);
+		break;
+
+	case StgIntersectionTarget::TYPE_PLAYER_SHOT:
+	case StgIntersectionTarget::TYPE_PLAYER_SPELL: {
+		listSpace_[SPACE_PLAYERSOHT_ENEMY]->RegistTargetA(target);
+
+		//弾消し能力付加なら
+		bool bEraseShot = false;
+		if (type == StgIntersectionTarget::TYPE_PLAYER_SHOT) {
+			StgShotObject* shot = (StgShotObject*)target->GetObject().GetPointer();
+			if (shot != NULL)
+				bEraseShot = shot->IsEraseShot();
+		} else if (type == StgIntersectionTarget::TYPE_PLAYER_SPELL) {
+			StgPlayerSpellObject* spell = (StgPlayerSpellObject*)target->GetObject().GetPointer();
+			if (spell != NULL)
+				bEraseShot = spell->IsEraseShot();
 		}
-		
-		case StgIntersectionTarget::TYPE_PLAYER_SHOT:
-		case StgIntersectionTarget::TYPE_PLAYER_SPELL:
-		{
-			listSpace_[SPACE_PLAYERSOHT_ENEMY]->RegistTargetA(target);
+		if (bEraseShot)
+			listSpace_[SPACE_PLAYERSHOT_ENEMYSHOT]->RegistTargetA(target);
+		break;
+	}
+	case StgIntersectionTarget::TYPE_ENEMY: {
+		listSpace_[SPACE_PLAYER_ENEMY]->RegistTargetB(target);
+		listSpace_[SPACE_PLAYERSOHT_ENEMY]->RegistTargetB(target);
 
-			//弾消し能力付加なら
-			bool bEraseShot = false;
-			if(type == StgIntersectionTarget::TYPE_PLAYER_SHOT)
-			{
-				StgShotObject* shot = (StgShotObject*)target->GetObject().GetPointer();
-				if(shot != NULL)
-					bEraseShot = shot->IsEraseShot();
+		ref_count_ptr<StgIntersectionTarget_Circle>::unsync circle = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(target);
+		if (circle != NULL) {
+			ref_count_weak_ptr<StgEnemyObject>::unsync objEnemy = ref_count_weak_ptr<StgEnemyObject>::unsync::DownCast(target->GetObject());
+			if (objEnemy != NULL) {
+				int idObject = objEnemy->GetObjectID();
+				POINT pos = { (int)circle->GetCircle().GetX(), (int)circle->GetCircle().GetY() };
+				StgIntersectionTargetPoint tp;
+				tp.SetObjectID(idObject);
+				tp.SetPoint(pos);
+				listEnemyTargetPointNext_.push_back(tp);
 			}
-			else if(type == StgIntersectionTarget::TYPE_PLAYER_SPELL)
-			{
-				StgPlayerSpellObject* spell = (StgPlayerSpellObject*)target->GetObject().GetPointer();
-				if(spell != NULL)
-					bEraseShot = spell->IsEraseShot();
-			}
-
-			if(bEraseShot)
-			{
-				listSpace_[SPACE_PLAYERSHOT_ENEMYSHOT]->RegistTargetA(target);
-			}
-			break;
 		}
+		break;
+	}
 
-		case StgIntersectionTarget::TYPE_ENEMY:
-		{
-			listSpace_[SPACE_PLAYER_ENEMY]->RegistTargetB(target);
-			listSpace_[SPACE_PLAYERSOHT_ENEMY]->RegistTargetB(target);
+	case StgIntersectionTarget::TYPE_ENEMY_SHOT:
+		listSpace_[SPACE_PLAYER_ENEMY]->RegistTargetB(target);
+		listSpace_[SPACE_PLAYERSHOT_ENEMYSHOT]->RegistTargetB(target);
+		break;
 
-			ref_count_ptr<StgIntersectionTarget_Circle>::unsync circle =
-				ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(target);
-			if(circle != NULL)
-			{
-				ref_count_weak_ptr<StgEnemyObject>::unsync objEnemy = 
-					ref_count_weak_ptr<StgEnemyObject>::unsync::DownCast(target->GetObject());
-				if(objEnemy != NULL)
-				{
-					int idObject = objEnemy->GetObjectID();
-					POINT pos = {(int)circle->GetCircle().GetX(), (int)circle->GetCircle().GetY()};
-					StgIntersectionTargetPoint tp;
-					tp.SetObjectID(idObject);
-					tp.SetPoint(pos);
-					listEnemyTargetPointNext_.push_back(tp);
-				}
-			}
-
-			break;
-		}
-
-		case StgIntersectionTarget::TYPE_ENEMY_SHOT:
-		{
-			listSpace_[SPACE_PLAYER_ENEMY]->RegistTargetB(target);
-			listSpace_[SPACE_PLAYERSHOT_ENEMYSHOT]->RegistTargetB(target);
-			break;
-		}
 	}
 }
 void StgIntersectionManager::AddEnemyTargetToShot(ref_count_ptr<StgIntersectionTarget>::unsync target)
@@ -171,31 +146,25 @@ void StgIntersectionManager::AddEnemyTargetToShot(ref_count_ptr<StgIntersectionT
 	//target->ClearObjectIntersectedIdList();
 
 	int type = target->GetTargetType();
-	switch(type)
-	{
-		case StgIntersectionTarget::TYPE_ENEMY:
-		{
-			listSpace_[SPACE_PLAYERSOHT_ENEMY]->RegistTargetB(target);
+	switch (type) {
+	case StgIntersectionTarget::TYPE_ENEMY: {
+		listSpace_[SPACE_PLAYERSOHT_ENEMY]->RegistTargetB(target);
 
-			ref_count_ptr<StgIntersectionTarget_Circle>::unsync circle = 
-				ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(target);
-			if(circle != NULL)
-			{
-				ref_count_weak_ptr<StgEnemyObject>::unsync objEnemy = 
-					ref_count_weak_ptr<StgEnemyObject>::unsync::DownCast(target->GetObject());
-				if(objEnemy != NULL)
-				{
-					int idObject = objEnemy->GetObjectID();
-					POINT pos = { (int)circle->GetCircle().GetX(), (int)circle->GetCircle().GetY()};
-					StgIntersectionTargetPoint tp;
-					tp.SetObjectID(idObject);
-					tp.SetPoint(pos);
-					listEnemyTargetPointNext_.push_back(tp);
-				}
+		ref_count_ptr<StgIntersectionTarget_Circle>::unsync circle = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(target);
+		if (circle != NULL) {
+			ref_count_weak_ptr<StgEnemyObject>::unsync objEnemy = ref_count_weak_ptr<StgEnemyObject>::unsync::DownCast(target->GetObject());
+			if (objEnemy != NULL) {
+				int idObject = objEnemy->GetObjectID();
+				POINT pos = { (int)circle->GetCircle().GetX(), (int)circle->GetCircle().GetY() };
+				StgIntersectionTargetPoint tp;
+				tp.SetObjectID(idObject);
+				tp.SetPoint(pos);
+				listEnemyTargetPointNext_.push_back(tp);
 			}
-
-			break;
 		}
+
+		break;
+	}
 	}
 }
 void StgIntersectionManager::AddEnemyTargetToPlayer(ref_count_ptr<StgIntersectionTarget>::unsync target)
@@ -204,13 +173,11 @@ void StgIntersectionManager::AddEnemyTargetToPlayer(ref_count_ptr<StgIntersectio
 	//target->ClearObjectIntersectedIdList();
 
 	int type = target->GetTargetType();
-	switch(type)
-	{
-		case StgIntersectionTarget::TYPE_ENEMY:
-		{
-			listSpace_[SPACE_PLAYER_ENEMY]->RegistTargetB(target);
-			break;
-		}
+	switch (type) {
+	case StgIntersectionTarget::TYPE_ENEMY: {
+		listSpace_[SPACE_PLAYER_ENEMY]->RegistTargetB(target);
+		break;
+	}
 	}
 }
 
@@ -219,38 +186,25 @@ bool StgIntersectionManager::IsIntersected(ref_count_ptr<StgIntersectionTarget>:
 	bool res = false;
 	int shape1 = target1->GetShape();
 	int shape2 = target2->GetShape();
-	if(shape1 == StgIntersectionTarget::SHAPE_CIRCLE && shape2 == StgIntersectionTarget::SHAPE_CIRCLE)
-	{
-		ref_count_ptr<StgIntersectionTarget_Circle>::unsync c1 =
-			ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(target1);
-		ref_count_ptr<StgIntersectionTarget_Circle>::unsync c2 = 
-			ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(target2);
+	if (shape1 == StgIntersectionTarget::SHAPE_CIRCLE && shape2 == StgIntersectionTarget::SHAPE_CIRCLE) {
+		ref_count_ptr<StgIntersectionTarget_Circle>::unsync c1 = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(target1);
+		ref_count_ptr<StgIntersectionTarget_Circle>::unsync c2 = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(target2);
 		res = DxMath::IsIntersected(c1->GetCircle(), c2->GetCircle());
-	}
-	else if((shape1 == StgIntersectionTarget::SHAPE_CIRCLE && shape2 == StgIntersectionTarget::SHAPE_LINE) ||
-		(shape1 == StgIntersectionTarget::SHAPE_LINE && shape2 == StgIntersectionTarget::SHAPE_CIRCLE))
-	{
+	} else if ((shape1 == StgIntersectionTarget::SHAPE_CIRCLE && shape2 == StgIntersectionTarget::SHAPE_LINE) || (shape1 == StgIntersectionTarget::SHAPE_LINE && shape2 == StgIntersectionTarget::SHAPE_CIRCLE)) {
 		ref_count_ptr<StgIntersectionTarget_Circle>::unsync c = NULL;
 		ref_count_ptr<StgIntersectionTarget_Line>::unsync l = NULL;
-		if(shape1 == StgIntersectionTarget::SHAPE_CIRCLE && shape2 == StgIntersectionTarget::SHAPE_LINE)
-		{
+		if (shape1 == StgIntersectionTarget::SHAPE_CIRCLE && shape2 == StgIntersectionTarget::SHAPE_LINE) {
 			c = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(target1);
 			l = ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(target2);
-		}
-		else
-		{
+		} else {
 			c = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(target2);
 			l = ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(target1);
 		}
 
 		res = IsIntersected(c->GetCircle(), l->GetLine());
-	}
-	else if(shape1 == StgIntersectionTarget::SHAPE_LINE && shape2 == StgIntersectionTarget::SHAPE_LINE)
-	{
-		ref_count_ptr<StgIntersectionTarget_Line>::unsync l1 = 
-			ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(target1);
-		ref_count_ptr<StgIntersectionTarget_Line>::unsync l2 =
-			ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(target2);
+	} else if (shape1 == StgIntersectionTarget::SHAPE_LINE && shape2 == StgIntersectionTarget::SHAPE_LINE) {
+		ref_count_ptr<StgIntersectionTarget_Line>::unsync l1 = ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(target1);
+		ref_count_ptr<StgIntersectionTarget_Line>::unsync l2 = ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(target2);
 		res = IsIntersected(l1->GetLine(), l2->GetLine());
 	}
 	return res;
@@ -260,9 +214,9 @@ bool StgIntersectionManager::IsIntersected(DxCircle& circle, DxWidthLine& line)
 	//先端もしくは終端が円内にあるかを調べる
 	{
 		double radius = circle.GetR();
-		double dist1 = pow(pow(circle.GetX()-line.GetX1(),2) + pow(circle.GetY()-line.GetY1(),2), 0.5);
-		double dist2 = pow(pow(circle.GetX()-line.GetX2(),2) + pow(circle.GetY()-line.GetY2(),2), 0.5);
-		if(radius >= dist1 || radius >= dist2)
+		double dist1 = pow(pow(circle.GetX() - line.GetX1(), 2) + pow(circle.GetY() - line.GetY1(), 2), 0.5);
+		double dist2 = pow(pow(circle.GetX() - line.GetX2(), 2) + pow(circle.GetY() - line.GetY2(), 2), 0.5);
+		if (radius >= dist1 || radius >= dist2)
 			return true;
 	}
 
@@ -280,38 +234,38 @@ bool StgIntersectionManager::IsIntersected(DxCircle& circle, DxWidthLine& line)
 		double cy2 = circle.GetY() - line.GetY2();
 		double inner2 = lx2 * cx2 + ly2 * cy2;
 
-		if(inner1 < 0 || inner2 < 0)
+		if (inner1 < 0 || inner2 < 0)
 			return false;
 	}
 
-	if(false)
-	{//tr1:レーザーの長さ、tr2:レーザーの先から判定先までの長さ
-		double radius = circle.GetR();//pow(pow(line.GetX2()-line.GetX1(),2) + pow(line.GetY2()-line.GetY1(),2), 0.5);
-		double dist1 = pow(pow(circle.GetX()-line.GetX1(),2) + pow(circle.GetY()-line.GetY1(),2), 0.5);
-		double dist2 = pow(pow(circle.GetX()-line.GetX2(),2) + pow(circle.GetY()-line.GetY2(),2), 0.5);
+	if (false) { //tr1:レーザーの長さ、tr2:レーザーの先から判定先までの長さ
+		double radius = circle.GetR(); //pow(pow(line.GetX2()-line.GetX1(),2) + pow(line.GetY2()-line.GetY1(),2), 0.5);
+		double dist1 = pow(pow(circle.GetX() - line.GetX1(), 2) + pow(circle.GetY() - line.GetY1(), 2), 0.5);
+		double dist2 = pow(pow(circle.GetX() - line.GetX2(), 2) + pow(circle.GetY() - line.GetY2(), 2), 0.5);
 		//tr1 -= 18;//端を判定しないための補正
 		//if(tr1 < 18)tr1 = 18;
-		if(radius < dist1 && radius < dist2)
+		if (radius < dist1 && radius < dist2)
 			return false;
 	}
 
-	double lx = line.GetX2()-line.GetX1();
-	double ly = line.GetY2()-line.GetY1();
-	double px = circle.GetX()-line.GetX1();
-	double py = circle.GetY()-line.GetY1();
-	double u = pow(pow(lx,2) + pow(ly, 2), 0.5);//直線の距離
-	if(u <= 0)return false;
+	double lx = line.GetX2() - line.GetX1();
+	double ly = line.GetY2() - line.GetY1();
+	double px = circle.GetX() - line.GetX1();
+	double py = circle.GetY() - line.GetY1();
+	double u = pow(pow(lx, 2) + pow(ly, 2), 0.5); //直線の距離
+	if (u <= 0)
+		return false;
 
-	double ux = lx/u;//直線の単位ベクトルx
-	double uy = ly/u;//直線の単位ベクトルz
-	double d = px*ux + py*uy;//直線の単位ベクトルと始点から点までベクトルの内積
-	double qx = d*ux;
-	double qy = d*uy;
-	double rx = px-qx;//点から直線までの最短距離ベクトルx
-	double ry = py-qy;//点から直線までの最短距離ベクトルz
-	double e = pow(pow(rx, 2) + pow(ry, 2),0.5);//直線のと点の距離
+	double ux = lx / u; //直線の単位ベクトルx
+	double uy = ly / u; //直線の単位ベクトルz
+	double d = px * ux + py * uy; //直線の単位ベクトルと始点から点までベクトルの内積
+	double qx = d * ux;
+	double qy = d * uy;
+	double rx = px - qx; //点から直線までの最短距離ベクトルx
+	double ry = py - qy; //点から直線までの最短距離ベクトルz
+	double e = pow(pow(rx, 2) + pow(ry, 2), 0.5); //直線のと点の距離
 	double r = line.GetWidth() + circle.GetR();
-	bool res  = e < r;
+	bool res = e < r;
 	return res;
 }
 bool StgIntersectionManager::IsIntersected(DxWidthLine& line1, DxWidthLine& line2)
@@ -320,40 +274,35 @@ bool StgIntersectionManager::IsIntersected(DxWidthLine& line1, DxWidthLine& line
 }
 void StgIntersectionManager::_ResetPoolObject(gstd::ref_count_ptr<StgIntersectionTarget>::unsync& obj)
 {
-//	ELogger::WriteTop(StringUtility::Format("_ResetPoolObject:start:%s)", obj->GetInfoAsString().c_str()));
+	//	ELogger::WriteTop(StringUtility::Format("_ResetPoolObject:start:%s)", obj->GetInfoAsString().c_str()));
 	obj->obj_ = NULL;
-//	ELogger::WriteTop("_ResetPoolObject:end");
+	//	ELogger::WriteTop("_ResetPoolObject:end");
 }
 gstd::ref_count_ptr<StgIntersectionTarget>::unsync StgIntersectionManager::_CreatePoolObject(int type)
 {
 	gstd::ref_count_ptr<StgIntersectionTarget>::unsync res = NULL;
-	switch(type)
-	{
-		case StgIntersectionTarget::SHAPE_CIRCLE:
-			res = new StgIntersectionTarget_Circle();
-			break;
-		case StgIntersectionTarget::SHAPE_LINE:
-			res = new StgIntersectionTarget_Line();
-			break;
+	switch (type) {
+	case StgIntersectionTarget::SHAPE_CIRCLE:
+		res = new StgIntersectionTarget_Circle();
+		break;
+	case StgIntersectionTarget::SHAPE_LINE:
+		res = new StgIntersectionTarget_Line();
+		break;
 	}
 	return res;
 }
 void StgIntersectionManager::CheckDeletedObject(std::string funcName)
 {
 	int countType = listUsedPool_.size();
-	for(int iType = 0 ; iType < countType ; iType++)
-	{
-		std::list<gstd::ref_count_ptr<StgIntersectionTarget, false> >* listUsed = &listUsedPool_[iType];
-		std::vector<gstd::ref_count_ptr<StgIntersectionTarget, false> >* listCache = &listCachePool_[iType];
-		
-		std::list<gstd::ref_count_ptr<StgIntersectionTarget, false> >::iterator itr = listUsed->begin();
-		for(; itr != listUsed->end() ; itr++)
-		{
+	for (int iType = 0; iType < countType; iType++) {
+		std::list<gstd::ref_count_ptr<StgIntersectionTarget, false>>* listUsed = &listUsedPool_[iType];
+		std::vector<gstd::ref_count_ptr<StgIntersectionTarget, false>>* listCache = &listCachePool_[iType];
+
+		std::list<gstd::ref_count_ptr<StgIntersectionTarget, false>>::iterator itr = listUsed->begin();
+		for (; itr != listUsed->end(); itr++) {
 			gstd::ref_count_ptr<StgIntersectionTarget, false> target = (*itr);
-			ref_count_weak_ptr<DxScriptObjectBase>::unsync dxObj =
-				ref_count_weak_ptr<DxScriptObjectBase>::unsync::DownCast(target->GetObject());
-			if(dxObj != NULL && dxObj->IsDeleted())
-			{
+			ref_count_weak_ptr<DxScriptObjectBase>::unsync dxObj = ref_count_weak_ptr<DxScriptObjectBase>::unsync::DownCast(target->GetObject());
+			if (dxObj != NULL && dxObj->IsDeleted()) {
 				ELogger::WriteTop(StringUtility::Format(L"%s(deleted):%s", funcName.c_str(), target->GetInfoAsString().c_str()));
 			}
 		}
@@ -376,11 +325,10 @@ StgIntersectionSpace::StgIntersectionSpace()
 
 	// 各レベルでの空間数を算出
 	listCountLevel_[0] = 1;
-	for(int iLevel = 1 ; iLevel < MAX_LEVEL + 1 ; iLevel++)
+	for (int iLevel = 1; iLevel < MAX_LEVEL + 1; iLevel++)
 		listCountLevel_[iLevel] = listCountLevel_[iLevel - 1] * 4;
 
 	listCheck_ = new StgIntersectionCheckList();
-
 }
 StgIntersectionSpace::~StgIntersectionSpace()
 {
@@ -388,13 +336,12 @@ StgIntersectionSpace::~StgIntersectionSpace()
 bool StgIntersectionSpace::Initialize(int level, int left, int top, int right, int bottom)
 {
 	// 設定最高レベル以上の空間は作れない
-	if(level >= MAX_LEVEL)
+	if (level >= MAX_LEVEL)
 		return false;
 
 	countCell_ = (listCountLevel_[level + 1] - 1) / 3;
 	listCell_.resize(countCell_);
-	for(int iCell = 0 ; iCell < listCell_.size() ; iCell++) 
-	{
+	for (int iCell = 0; iCell < listCell_.size(); iCell++) {
 		listCell_[iCell].resize(2);
 	}
 
@@ -412,21 +359,18 @@ bool StgIntersectionSpace::Initialize(int level, int left, int top, int right, i
 bool StgIntersectionSpace::RegistTarget(int type, ref_count_ptr<StgIntersectionTarget>::unsync& target)
 {
 	RECT rect = target->GetIntersectionSapceRect();
-	if(rect.right < spaceLeft_ || rect.bottom < spaceTop_ ||
-		rect.left > (spaceLeft_ + spaceWidth_) || rect.top > (spaceTop_ + spaceHeight_))
+	if (rect.right < spaceLeft_ || rect.bottom < spaceTop_ || rect.left > (spaceLeft_ + spaceWidth_) || rect.top > (spaceTop_ + spaceHeight_))
 		return false;
 
 	// オブジェクトの境界範囲から登録モートン番号を算出
 	bool res = false;
 	int index = target->GetMortonNumber();
-	if(index < 0)
-	{
+	if (index < 0) {
 		index = _GetMortonNumber(rect.left, rect.top, rect.right, rect.bottom);
 		target->SetMortonNumber(index);
 	}
 
-	if(index >= 0 && index < countCell_ )
-	{
+	if (index >= 0 && index < countCell_) {
 		listCell_[index][type].push_back(target);
 		res = true;
 	}
@@ -436,10 +380,8 @@ bool StgIntersectionSpace::RegistTarget(int type, ref_count_ptr<StgIntersectionT
 
 void StgIntersectionSpace::ClearTarget()
 {
-	for(int iCell = 0 ; iCell < listCell_.size() ; iCell++) 
-	{
-		for(int iType = 0 ; iType < listCell_[iCell].size() ; iType++)
-		{
+	for (int iCell = 0; iCell < listCell_.size(); iCell++) {
+		for (int iType = 0; iType < listCell_[iCell].size(); iType++) {
 			listCell_[iCell][iType].clear();
 		}
 	}
@@ -448,56 +390,49 @@ ref_count_ptr<StgIntersectionCheckList>::unsync StgIntersectionSpace::CreateInte
 {
 	ref_count_ptr<StgIntersectionCheckList>::unsync res = listCheck_;
 	res->Clear();
-	std::vector<std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > > listStack;
+	std::vector<std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>> listStack;
 	listStack.resize(listCell_[0].size());
 
 	_WriteIntersectionCheckList(0, res, listStack);
 
 	return res;
 }
-void StgIntersectionSpace::_WriteIntersectionCheckList(int indexSpace, ref_count_ptr<StgIntersectionCheckList>::unsync& listCheck, std::vector<std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > > &listStack)
+void StgIntersectionSpace::_WriteIntersectionCheckList(int indexSpace, ref_count_ptr<StgIntersectionCheckList>::unsync& listCheck, std::vector<std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>>& listStack)
 {
-	std::vector<std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > >& listCell = listCell_[indexSpace];
+	std::vector<std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>>& listCell = listCell_[indexSpace];
 	int typeCount = listCell.size();
-	for(int iType1 = 0 ; iType1 < typeCount ; iType1++)
-	{
-		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync >& list1 = listCell[iType1];
-		int iType2 =0;
-		for(iType2 = iType1 + 1 ; iType2 < typeCount ; iType2++)
-		{
-			std::vector<ref_count_ptr<StgIntersectionTarget>::unsync >& list2 = listCell[iType2];
+	for (int iType1 = 0; iType1 < typeCount; iType1++) {
+		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& list1 = listCell[iType1];
+		int iType2 = 0;
+		for (iType2 = iType1 + 1; iType2 < typeCount; iType2++) {
+			std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& list2 = listCell[iType2];
 
 			// ① 空間内のオブジェクト同士の衝突リスト作成
-			std::vector<ref_count_ptr<StgIntersectionTarget>::unsync >::iterator itr1 = list1.begin();
-			for(; itr1 != list1.end() ; itr1++)
-			{
-				std::vector<ref_count_ptr<StgIntersectionTarget>::unsync >::iterator itr2 = list2.begin();
-				for(; itr2 != list2.end() ; itr2++)
-				{
+			std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>::iterator itr1 = list1.begin();
+			for (; itr1 != list1.end(); itr1++) {
+				std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>::iterator itr2 = list2.begin();
+				for (; itr2 != list2.end(); itr2++) {
 					ref_count_ptr<StgIntersectionTarget>::unsync target1 = (*itr1);
 					ref_count_ptr<StgIntersectionTarget>::unsync target2 = (*itr2);
 					listCheck->Add(target1, target2);
 				}
 			}
-
 		}
 
-		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync >& stack = listStack[iType1];
-		for(iType2 = 0; iType2 < typeCount ; iType2++)
-		{
-			if(iType1 == iType2)continue;
-			std::vector<ref_count_ptr<StgIntersectionTarget>::unsync >& list2 = listCell[iType2];
+		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& stack = listStack[iType1];
+		for (iType2 = 0; iType2 < typeCount; iType2++) {
+			if (iType1 == iType2)
+				continue;
+			std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& list2 = listCell[iType2];
 
 			// ② 衝突スタックとの衝突リスト作成
-			std::vector<ref_count_ptr<StgIntersectionTarget>::unsync >::iterator itrStack = stack.begin();
-			for(; itrStack != stack.end() ; itrStack++)
-			{
-				std::vector<ref_count_ptr<StgIntersectionTarget>::unsync >::iterator itr2 = list2.begin();	
-				for(; itr2 != list2.end() ; itr2++)
-				{
+			std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>::iterator itrStack = stack.begin();
+			for (; itrStack != stack.end(); itrStack++) {
+				std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>::iterator itr2 = list2.begin();
+				for (; itr2 != list2.end(); itr2++) {
 					ref_count_ptr<StgIntersectionTarget>::unsync target2 = (*itr2);
 					ref_count_ptr<StgIntersectionTarget>::unsync targetStack = (*itrStack);
-					if(iType1 < iType2)
+					if (iType1 < iType2)
 						listCheck->Add(targetStack, target2);
 					else
 						listCheck->Add(target2, targetStack);
@@ -508,93 +443,85 @@ void StgIntersectionSpace::_WriteIntersectionCheckList(int indexSpace, ref_count
 
 	//空間内のオブジェクトをスタックに追加
 	int iType = 0;
-	for(iType = 0 ; iType < typeCount ; iType++)
-	{
-		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync >& list = listCell[iType];
-		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync >& stack = listStack[iType];
-		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync >::iterator itr = list.begin();
-		for(; itr != list.end() ; itr++)
-		{
+	for (iType = 0; iType < typeCount; iType++) {
+		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& list = listCell[iType];
+		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& stack = listStack[iType];
+		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>::iterator itr = list.begin();
+		for (; itr != list.end(); itr++) {
 			ref_count_ptr<StgIntersectionTarget>::unsync target = (*itr);
 			stack.push_back(target);
 		}
 	}
 
 	// ③ 子空間に移動
-	for(int iChild = 0 ; iChild < 4 ; iChild++)
-	{
+	for (int iChild = 0; iChild < 4; iChild++) {
 		int indexChild = indexSpace * 4 + 1 + iChild;
-		if(indexChild < countCell_)
-		{
+		if (indexChild < countCell_) {
 			_WriteIntersectionCheckList(indexChild, listCheck, listStack);
 		}
 	}
 
 	//スタックから解除
-	for(iType = 0 ; iType < typeCount ; iType++)
-	{
-		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync >& list = listCell[iType];
-		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync >& stack = listStack[iType];
+	for (iType = 0; iType < typeCount; iType++) {
+		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& list = listCell[iType];
+		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& stack = listStack[iType];
 		int count = list.size();
-		for(int iCount = 0 ; iCount < count ; iCount++)
-		{
+		for (int iCount = 0; iCount < count; iCount++) {
 			stack.pop_back();
 		}
 	}
 }
-unsigned int StgIntersectionSpace::_GetMortonNumber( float left, float top, float right, float bottom )
+unsigned int StgIntersectionSpace::_GetMortonNumber(float left, float top, float right, float bottom)
 {
 	// 座標から空間番号を算出
 	// 最小レベルにおける各軸位置を算出
-	unsigned int  LT = _GetPointElem(left, top);
-	unsigned int  RB = _GetPointElem(right, bottom );
+	unsigned int LT = _GetPointElem(left, top);
+	unsigned int RB = _GetPointElem(right, bottom);
 
 	// 空間番号の排他的論理和から
 	// 所属レベルを算出
 	unsigned int def = RB ^ LT;
 	unsigned int hiLevel = 0;
-	for(int iLevel = 0; iLevel<unitLevel_; iLevel++)
-	{
-		DWORD Check = (def>>(iLevel*2)) & 0x3;
-		if( Check != 0 )
-			hiLevel = iLevel+1;
+	for (int iLevel = 0; iLevel < unitLevel_; iLevel++) {
+		DWORD Check = (def >> (iLevel * 2)) & 0x3;
+		if (Check != 0)
+			hiLevel = iLevel + 1;
 	}
-	DWORD spaceIndex = RB>>(hiLevel*2);
+	DWORD spaceIndex = RB >> (hiLevel * 2);
 	DWORD addIndex = (listCountLevel_[unitLevel_ - hiLevel] - 1) / 3;
 	spaceIndex += addIndex;
 
-	if(spaceIndex > countCell_)
+	if (spaceIndex > countCell_)
 		return 0xffffffff;
 
 	return spaceIndex;
 }
-unsigned int StgIntersectionSpace::_BitSeparate32(unsigned int n )
+unsigned int StgIntersectionSpace::_BitSeparate32(unsigned int n)
 {
 	// ビット分割関数
-	n = (n|(n<<8)) & 0x00ff00ff;
-	n = (n|(n<<4)) & 0x0f0f0f0f;
-	n = (n|(n<<2)) & 0x33333333;
-	return (n|(n<<1)) & 0x55555555;
+	n = (n | (n << 8)) & 0x00ff00ff;
+	n = (n | (n << 4)) & 0x0f0f0f0f;
+	n = (n | (n << 2)) & 0x33333333;
+	return (n | (n << 1)) & 0x55555555;
 }
-unsigned short StgIntersectionSpace::_Get2DMortonNumber( unsigned short x, unsigned short y )
+unsigned short StgIntersectionSpace::_Get2DMortonNumber(unsigned short x, unsigned short y)
 {
 	// 2Dモートン空間番号算出関数
-	return (unsigned short)(_BitSeparate32(x) | (_BitSeparate32(y)<<1));
+	return (unsigned short)(_BitSeparate32(x) | (_BitSeparate32(y) << 1));
 }
-unsigned int  StgIntersectionSpace::_GetPointElem(float pos_x, float pos_y )
+unsigned int StgIntersectionSpace::_GetPointElem(float pos_x, float pos_y)
 {
 	// 座標→線形4分木要素番号変換関数
-	float val1 = max(pos_x-spaceLeft_, 0);
-	float val2 = max(pos_y-spaceTop_, 0);
+	float val1 = max(pos_x - spaceLeft_, 0);
+	float val2 = max(pos_y - spaceTop_, 0);
 	return _Get2DMortonNumber(
-		(unsigned short)(val1/unitWidth_), (unsigned short)(val2/unitHeight_) );
+		(unsigned short)(val1 / unitWidth_), (unsigned short)(val2 / unitHeight_));
 }
 
 //StgIntersectionObject
 void StgIntersectionObject::ClearIntersectionRelativeTarget()
 {
-	for(int iTarget = 0 ; iTarget < listRelativeTarget_.size() ; iTarget++)
-	{
+	for (int iTarget = 0; iTarget < listRelativeTarget_.size(); iTarget++) {
 		ref_count_weak_ptr<StgIntersectionTarget>::unsync target = listRelativeTarget_[iTarget];
 		target->SetObject(NULL);
 	}
@@ -604,13 +531,10 @@ void StgIntersectionObject::AddIntersectionRelativeTarget(ref_count_ptr<StgInter
 {
 	listRelativeTarget_.push_back(target);
 	int shape = target->GetShape();
-	if(shape == StgIntersectionTarget::SHAPE_CIRCLE)
-	{
+	if (shape == StgIntersectionTarget::SHAPE_CIRCLE) {
 		StgIntersectionTarget_Circle* tTarget = (StgIntersectionTarget_Circle*)target.GetPointer();
 		listOrgCircle_.push_back(tTarget->GetCircle());
-	}
-	else if(shape == StgIntersectionTarget::SHAPE_LINE)
-	{
+	} else if (shape == StgIntersectionTarget::SHAPE_LINE) {
 		StgIntersectionTarget_Line* tTarget = (StgIntersectionTarget_Line*)target.GetPointer();
 		listOrgLine_.push_back(tTarget->GetLine());
 	}
@@ -619,12 +543,10 @@ void StgIntersectionObject::UpdateIntersectionRelativeTarget(int posX, int posY,
 {
 	int iCircle = 0;
 	int iLine = 0;
-	for(int iTarget = 0 ; iTarget < listRelativeTarget_.size() ; iTarget++)
-	{
+	for (int iTarget = 0; iTarget < listRelativeTarget_.size(); iTarget++) {
 		ref_count_ptr<StgIntersectionTarget>::unsync target = listRelativeTarget_[iTarget];
 		int shape = target->GetShape();
-		if(shape == StgIntersectionTarget::SHAPE_CIRCLE)
-		{
+		if (shape == StgIntersectionTarget::SHAPE_CIRCLE) {
 			StgIntersectionTarget_Circle* tTarget = (StgIntersectionTarget_Circle*)target.GetPointer();
 			DxCircle org = listOrgCircle_[iCircle];
 			int px = org.GetX() + posX;
@@ -635,9 +557,7 @@ void StgIntersectionObject::UpdateIntersectionRelativeTarget(int posX, int posY,
 			circle.SetY(py);
 			tTarget->SetCircle(circle);
 			iCircle++;
-		}
-		else if(shape == StgIntersectionTarget::SHAPE_LINE)
-		{
+		} else if (shape == StgIntersectionTarget::SHAPE_LINE) {
 			StgIntersectionTarget_Line* tTarget = (StgIntersectionTarget_Line*)target.GetPointer();
 			iLine++;
 		}
@@ -645,8 +565,7 @@ void StgIntersectionObject::UpdateIntersectionRelativeTarget(int posX, int posY,
 }
 void StgIntersectionObject::RegistIntersectionRelativeTarget(StgIntersectionManager* manager)
 {
-	for(int iTarget = 0 ; iTarget < listRelativeTarget_.size() ; iTarget++)
-	{
+	for (int iTarget = 0; iTarget < listRelativeTarget_.size(); iTarget++) {
 		ref_count_ptr<StgIntersectionTarget>::unsync target = listRelativeTarget_[iTarget];
 		manager->AddTarget(target);
 	}
@@ -655,8 +574,7 @@ int StgIntersectionObject::GetDxScriptObjectID()
 {
 	int res = DxScript::ID_INVALID;
 	StgEnemyObject* objEnemy = dynamic_cast<StgEnemyObject*>(this);
-	if(objEnemy != NULL)
-	{
+	if (objEnemy != NULL) {
 		res = objEnemy->GetObjectID();
 	}
 
@@ -668,8 +586,7 @@ int StgIntersectionObject::GetDxScriptObjectID()
 **********************************************************/
 void StgIntersectionTarget::ClearObjectIntersectedIdList()
 {
-	if(obj_ != NULL)
-	{
+	if (obj_ != NULL) {
 		obj_->ClearIntersectedIdList();
 	}
 }
@@ -677,39 +594,46 @@ std::wstring StgIntersectionTarget::GetInfoAsString()
 {
 	std::wstring res;
 	res += L"type[";
-	switch(typeTarget_)
-	{
-	case TYPE_PLAYER:res += L"PLAYER";break;
-	case TYPE_PLAYER_SHOT:res += L"PLAYER_SHOT";break;
-	case TYPE_PLAYER_SPELL:res += L"PLAYER_SPELL";break;
-	case TYPE_ENEMY:res += L"ENEMY";break;
-	case TYPE_ENEMY_SHOT:res += L"ENEMY_SHOT";break;
+	switch (typeTarget_) {
+	case TYPE_PLAYER:
+		res += L"PLAYER";
+		break;
+	case TYPE_PLAYER_SHOT:
+		res += L"PLAYER_SHOT";
+		break;
+	case TYPE_PLAYER_SPELL:
+		res += L"PLAYER_SPELL";
+		break;
+	case TYPE_ENEMY:
+		res += L"ENEMY";
+		break;
+	case TYPE_ENEMY_SHOT:
+		res += L"ENEMY_SHOT";
+		break;
 	}
 	res += L"] ";
 
 	res += L"shape[";
-	switch(shape_)
-	{
-	case SHAPE_CIRCLE:res += L"CIRCLE";break;
-	case SHAPE_LINE:res += L"LINE";break;
+	switch (shape_) {
+	case SHAPE_CIRCLE:
+		res += L"CIRCLE";
+		break;
+	case SHAPE_LINE:
+		res += L"LINE";
+		break;
 	}
 	res += L"] ";
 
 	res += StringUtility::Format(L"address[%08x] ", (int)this);
 
 	res += L"obj[";
-	if(obj_ == NULL)
-	{
+	if (obj_ == NULL) {
 		res += L"NULL";
-	}
-	else
-	{
-		ref_count_weak_ptr<DxScriptObjectBase>::unsync dxObj =
-			ref_count_weak_ptr<DxScriptObjectBase>::unsync::DownCast(obj_);
-		if(dxObj == NULL)
+	} else {
+		ref_count_weak_ptr<DxScriptObjectBase>::unsync dxObj = ref_count_weak_ptr<DxScriptObjectBase>::unsync::DownCast(obj_);
+		if (dxObj == NULL)
 			res += L"UNKNOWN";
-		else
-		{
+		else {
 			int address = (int)dxObj.GetPointer();
 			char* className = (char*)typeid(*this).name();
 			res += StringUtility::Format(L"ref=%d, delete=%s, active=%s, class=%s[%08x]",
@@ -723,4 +647,3 @@ std::wstring StgIntersectionTarget::GetInfoAsString()
 
 	return res;
 }
-

--- a/source/TouhouDanmakufu/Common/StgIntersection.hpp
+++ b/source/TouhouDanmakufu/Common/StgIntersection.hpp
@@ -1,7 +1,7 @@
 #ifndef __TOUHOUDANMAKUFU_DNHSTG_INTERSECTION__
 #define __TOUHOUDANMAKUFU_DNHSTG_INTERSECTION__
 
-#include"StgCommon.hpp"
+#include "StgCommon.hpp"
 
 class StgIntersectionSpace;
 class StgIntersectionCheckList;
@@ -14,36 +14,36 @@ class StgIntersectionTargetPoint;
 //下記を参考
 //http://marupeke296.com/COL_2D_No8_QuadTree.html
 **********************************************************/
-class StgIntersectionManager : public ObjectPool<StgIntersectionTarget, false>
-{
-	private:
-		enum
-		{
-			SPACE_PLAYER_ENEMY = 0,//自機-敵、敵弾
-			SPACE_PLAYERSOHT_ENEMY,//自弾,スペル-敵
-			SPACE_PLAYERSHOT_ENEMYSHOT,//自弾,スペル-敵弾
-		};
-		std::vector<ref_count_ptr<StgIntersectionSpace> > listSpace_;
-		std::vector<StgIntersectionTargetPoint> listEnemyTargetPoint_;
-		std::vector<StgIntersectionTargetPoint> listEnemyTargetPointNext_;
+class StgIntersectionManager : public ObjectPool<StgIntersectionTarget, false> {
+	enum {
+		SPACE_PLAYER_ENEMY = 0, //自機-敵、敵弾
+		SPACE_PLAYERSOHT_ENEMY, //自弾,スペル-敵
+		SPACE_PLAYERSHOT_ENEMYSHOT, //自弾,スペル-敵弾
+	};
 
-		virtual void _ResetPoolObject(gstd::ref_count_ptr<StgIntersectionTarget>::unsync& obj);
-		virtual gstd::ref_count_ptr<StgIntersectionTarget>::unsync _CreatePoolObject(int type);
-	public:
-		StgIntersectionManager();
-		virtual ~StgIntersectionManager();
-		void Work();
+public:
+	StgIntersectionManager();
+	virtual ~StgIntersectionManager();
+	void Work();
 
-		void AddTarget(ref_count_ptr<StgIntersectionTarget>::unsync target);
-		void AddEnemyTargetToShot(ref_count_ptr<StgIntersectionTarget>::unsync target);
-		void AddEnemyTargetToPlayer(ref_count_ptr<StgIntersectionTarget>::unsync target);
-		std::vector<StgIntersectionTargetPoint>* GetAllEnemyTargetPoint(){return &listEnemyTargetPoint_;}
+	void AddTarget(ref_count_ptr<StgIntersectionTarget>::unsync target);
+	void AddEnemyTargetToShot(ref_count_ptr<StgIntersectionTarget>::unsync target);
+	void AddEnemyTargetToPlayer(ref_count_ptr<StgIntersectionTarget>::unsync target);
+	std::vector<StgIntersectionTargetPoint>* GetAllEnemyTargetPoint() { return &listEnemyTargetPoint_; }
 
-		void CheckDeletedObject(std::string funcName);
+	void CheckDeletedObject(std::string funcName);
 
-		static bool IsIntersected(ref_count_ptr<StgIntersectionTarget>::unsync& target1, ref_count_ptr<StgIntersectionTarget>::unsync& target2);
-		static bool IsIntersected(DxCircle& circle, DxWidthLine& line);
-		static bool IsIntersected(DxWidthLine& line1, DxWidthLine& line2);
+	static bool IsIntersected(ref_count_ptr<StgIntersectionTarget>::unsync& target1, ref_count_ptr<StgIntersectionTarget>::unsync& target2);
+	static bool IsIntersected(DxCircle& circle, DxWidthLine& line);
+	static bool IsIntersected(DxWidthLine& line1, DxWidthLine& line2);
+
+private:
+	virtual void _ResetPoolObject(gstd::ref_count_ptr<StgIntersectionTarget>::unsync& obj);
+	virtual gstd::ref_count_ptr<StgIntersectionTarget>::unsync _CreatePoolObject(int type);
+
+	std::vector<ref_count_ptr<StgIntersectionSpace>> listSpace_;
+	std::vector<StgIntersectionTargetPoint> listEnemyTargetPoint_;
+	std::vector<StgIntersectionTargetPoint> listEnemyTargetPointNext_;
 };
 
 /**********************************************************
@@ -52,261 +52,276 @@ class StgIntersectionManager : public ObjectPool<StgIntersectionTarget, false>
 //　○×（まるぺけ）つくろーどっとコム
 //　http://marupeke296.com/
 **********************************************************/
-class StgIntersectionSpace
-{
-	enum
-	{
+class StgIntersectionSpace {
+	enum {
 		MAX_LEVEL = 9,
 		TYPE_A = 0,
 		TYPE_B = 1,
 	};
-	protected:
-		//Cell TARGETA/B listTarget
-		std::vector<std::vector<std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > > >listCell_;
-		int listCountLevel_[MAX_LEVEL + 1];	// 各レベルのセル数
-		double spaceWidth_; // 領域のX軸幅
-		double spaceHeight_; // 領域のY軸幅
-		double spaceLeft_; // 領域の左側（X軸最小値）
-		double spaceTop_; // 領域の上側（Y軸最小値）
-		double unitWidth_; // 最小レベル空間の幅単位
-		double unitHeight_; // 最小レベル空間の高単位
-		int countCell_; // 空間の数
-		int unitLevel_; // 最下位レベル
-		ref_count_ptr<StgIntersectionCheckList>::unsync listCheck_;
 
-		unsigned int _GetMortonNumber( float left, float top, float right, float bottom );
-		unsigned int  _BitSeparate32( unsigned int  n );
-		unsigned short _Get2DMortonNumber( unsigned short x, unsigned short y );
-		unsigned int  _GetPointElem( float pos_x, float pos_y );
-		void _WriteIntersectionCheckList(int indexSpace, ref_count_ptr<StgIntersectionCheckList>::unsync& listCheck, std::vector<std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > > &listStack);
-	public:
-		StgIntersectionSpace();
-		virtual ~StgIntersectionSpace();
-		bool Initialize(int level, int left, int top, int right, int bottom);
-		bool RegistTarget(int type, ref_count_ptr<StgIntersectionTarget>::unsync& target);
-		bool RegistTargetA(ref_count_ptr<StgIntersectionTarget>::unsync& target){return RegistTarget(TYPE_A, target);}
-		bool RegistTargetB(ref_count_ptr<StgIntersectionTarget>::unsync& target){return RegistTarget(TYPE_B, target);}
-		void ClearTarget();
-		ref_count_ptr<StgIntersectionCheckList>::unsync CreateIntersectionCheckList();
+public:
+	StgIntersectionSpace();
+	virtual ~StgIntersectionSpace();
+	bool Initialize(int level, int left, int top, int right, int bottom);
+	bool RegistTarget(int type, ref_count_ptr<StgIntersectionTarget>::unsync& target);
+	bool RegistTargetA(ref_count_ptr<StgIntersectionTarget>::unsync& target) { return RegistTarget(TYPE_A, target); }
+	bool RegistTargetB(ref_count_ptr<StgIntersectionTarget>::unsync& target) { return RegistTarget(TYPE_B, target); }
+	void ClearTarget();
+	ref_count_ptr<StgIntersectionCheckList>::unsync CreateIntersectionCheckList();
+
+protected:
+	unsigned int _GetMortonNumber(float left, float top, float right, float bottom);
+	unsigned int _BitSeparate32(unsigned int n);
+	unsigned short _Get2DMortonNumber(unsigned short x, unsigned short y);
+	unsigned int _GetPointElem(float pos_x, float pos_y);
+	void _WriteIntersectionCheckList(int indexSpace, ref_count_ptr<StgIntersectionCheckList>::unsync& listCheck, std::vector<std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>>& listStack);
+
+	// Cell TARGETA/B listTarget
+	std::vector<std::vector<std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>>> listCell_;
+	int listCountLevel_[MAX_LEVEL + 1]; // 各レベルのセル数
+	double spaceWidth_; // 領域のX軸幅
+	double spaceHeight_; // 領域のY軸幅
+	double spaceLeft_; // 領域の左側（X軸最小値）
+	double spaceTop_; // 領域の上側（Y軸最小値）
+	double unitWidth_; // 最小レベル空間の幅単位
+	double unitHeight_; // 最小レベル空間の高単位
+	int countCell_; // 空間の数
+	int unitLevel_; // 最下位レベル
+	ref_count_ptr<StgIntersectionCheckList>::unsync listCheck_;
 };
 
-class StgIntersectionCheckList
-{
-		int count_;
-		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > listTargetA_;
-		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > listTargetB_;
-	public:
-		StgIntersectionCheckList(){count_ = 0;}
-		virtual ~StgIntersectionCheckList(){}
+class StgIntersectionCheckList {
+public:
+	StgIntersectionCheckList() { count_ = 0; }
+	virtual ~StgIntersectionCheckList() {}
 
-		void Clear(){count_ = 0;}
-		int GetCheckCount(){return count_;}
-		void Add(ref_count_ptr<StgIntersectionTarget>::unsync& targetA, ref_count_ptr<StgIntersectionTarget>::unsync& targetB)
-		{
-			if(listTargetA_.size() <= count_)
-			{
-				listTargetA_.push_back(targetA);
-				listTargetB_.push_back(targetB);
-			}
-			else
-			{
-				listTargetA_[count_] = targetA;
-				listTargetB_[count_] = targetB;
-			}
-			count_++;
+	void Clear() { count_ = 0; }
+	int GetCheckCount() { return count_; }
+	void Add(ref_count_ptr<StgIntersectionTarget>::unsync& targetA, ref_count_ptr<StgIntersectionTarget>::unsync& targetB)
+	{
+		if (listTargetA_.size() <= count_) {
+			listTargetA_.push_back(targetA);
+			listTargetB_.push_back(targetB);
+		} else {
+			listTargetA_[count_] = targetA;
+			listTargetB_[count_] = targetB;
 		}
-		ref_count_ptr<StgIntersectionTarget>::unsync GetTargetA(int index){ref_count_ptr<StgIntersectionTarget>::unsync res = listTargetA_[index];listTargetA_[index]=NULL;return res;}
-		ref_count_ptr<StgIntersectionTarget>::unsync GetTargetB(int index){ref_count_ptr<StgIntersectionTarget>::unsync res = listTargetB_[index];listTargetB_[index]=NULL;return res;}
+		count_++;
+	}
+	ref_count_ptr<StgIntersectionTarget>::unsync GetTargetA(int index)
+	{
+		ref_count_ptr<StgIntersectionTarget>::unsync res = listTargetA_[index];
+		listTargetA_[index] = NULL;
+		return res;
+	}
+	ref_count_ptr<StgIntersectionTarget>::unsync GetTargetB(int index)
+	{
+		ref_count_ptr<StgIntersectionTarget>::unsync res = listTargetB_[index];
+		listTargetB_[index] = NULL;
+		return res;
+	}
+
+private:
+	int count_;
+	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> listTargetA_;
+	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> listTargetB_;
 };
 
-class StgIntersectionObject
-{
-	protected:
-		bool bIntersected_;//衝突判定
-		int intersectedCount_;
-		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > listRelativeTarget_;
-		std::vector<DxCircle> listOrgCircle_;
-		std::vector<DxWidthLine> listOrgLine_;
-		std::vector<int> listIntersectedID_;
+class StgIntersectionObject {
+public:
+	StgIntersectionObject()
+	{
+		bIntersected_ = false;
+		intersectedCount_ = 0;
+	}
+	virtual ~StgIntersectionObject() {}
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) = 0;
+	void ClearIntersected()
+	{
+		bIntersected_ = false;
+		intersectedCount_ = 0;
+	}
+	bool IsIntersected() { return bIntersected_; }
+	void SetIntersected()
+	{
+		bIntersected_ = true;
+		intersectedCount_++;
+	}
+	int GetIntersectedCount() { return intersectedCount_; }
+	void ClearIntersectedIdList()
+	{
+		if (listIntersectedID_.size() > 0)
+			listIntersectedID_.clear();
+	}
+	void AddIntersectedId(int id) { listIntersectedID_.push_back(id); }
+	std::vector<int>& GetIntersectedIdList() { return listIntersectedID_; }
 
-	public:
-		StgIntersectionObject(){bIntersected_ = false; intersectedCount_ = 0;}
-		virtual ~StgIntersectionObject(){}
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) = 0;
-		void ClearIntersected(){bIntersected_ = false; intersectedCount_ = 0;}
-		bool IsIntersected(){return bIntersected_;}
-		void SetIntersected(){bIntersected_ = true; intersectedCount_++;}
-		int GetIntersectedCount(){return intersectedCount_;}
-		void ClearIntersectedIdList(){if(listIntersectedID_.size() > 0)listIntersectedID_.clear();}
-		void AddIntersectedId(int id){listIntersectedID_.push_back(id);}
-		std::vector<int>& GetIntersectedIdList(){return listIntersectedID_;}
+	void ClearIntersectionRelativeTarget();
+	void AddIntersectionRelativeTarget(ref_count_ptr<StgIntersectionTarget>::unsync target);
+	ref_count_ptr<StgIntersectionTarget>::unsync GetIntersectionRelativeTarget(int index) { return listRelativeTarget_[index]; }
 
-		void ClearIntersectionRelativeTarget();
-		void AddIntersectionRelativeTarget(ref_count_ptr<StgIntersectionTarget>::unsync target);
-		ref_count_ptr<StgIntersectionTarget>::unsync GetIntersectionRelativeTarget(int index){return listRelativeTarget_[index];}
+	void UpdateIntersectionRelativeTarget(int posX, int posY, double angle);
+	void RegistIntersectionRelativeTarget(StgIntersectionManager* manager);
+	int GetIntersectionRelativeTargetCount() { return listRelativeTarget_.size(); }
+	int GetDxScriptObjectID();
 
-		void UpdateIntersectionRelativeTarget(int posX, int posY, double angle);
-		void RegistIntersectionRelativeTarget(StgIntersectionManager* manager);
-		int GetIntersectionRelativeTargetCount(){return listRelativeTarget_.size();}
-		int GetDxScriptObjectID();
+	virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList() { return std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>(); }
 
-		virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > GetIntersectionTargetList(){return std::vector<ref_count_ptr<StgIntersectionTarget>::unsync >();}
+protected:
+	bool bIntersected_; //衝突判定
+	int intersectedCount_;
+	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> listRelativeTarget_;
+	std::vector<DxCircle> listOrgCircle_;
+	std::vector<DxWidthLine> listOrgLine_;
+	std::vector<int> listIntersectedID_;
 };
 
 /**********************************************************
 //StgIntersectionTarget
 **********************************************************/
-class StgIntersectionTarget : public IStringInfo
-{
+class StgIntersectionTarget : public IStringInfo {
 	friend StgIntersectionManager;
-	public:
-		enum
-		{
-			SHAPE_CIRCLE = 0,
-			SHAPE_LINE = 1,
 
-			TYPE_PLAYER,
-			TYPE_PLAYER_SHOT,
-			TYPE_PLAYER_SPELL,
-			TYPE_ENEMY,
-			TYPE_ENEMY_SHOT,
-		};
+public:
+	enum {
+		SHAPE_CIRCLE = 0,
+		SHAPE_LINE = 1,
 
-	protected:
-		int mortonNo_;
-		int typeTarget_;
-		int shape_;
-		ref_count_weak_ptr<StgIntersectionObject>::unsync obj_;
+		TYPE_PLAYER,
+		TYPE_PLAYER_SHOT,
+		TYPE_PLAYER_SPELL,
+		TYPE_ENEMY,
+		TYPE_ENEMY_SHOT,
+	};
 
-	public:
-		StgIntersectionTarget(){mortonNo_ = -1 ; }
-		virtual ~StgIntersectionTarget(){}
-		virtual RECT GetIntersectionSapceRect() = 0;
+public:
+	StgIntersectionTarget() { mortonNo_ = -1; }
+	virtual ~StgIntersectionTarget() {}
+	virtual RECT GetIntersectionSapceRect() = 0;
 
-		int GetTargetType(){return typeTarget_;}
-		void SetTargetType(int type){typeTarget_ = type;}
-		int GetShape(){return shape_;}
-		ref_count_weak_ptr<StgIntersectionObject>::unsync GetObject(){return obj_;}
-		void SetObject(ref_count_weak_ptr<StgIntersectionObject>::unsync obj){obj_ = obj;}
+	int GetTargetType() { return typeTarget_; }
+	void SetTargetType(int type) { typeTarget_ = type; }
+	int GetShape() { return shape_; }
+	ref_count_weak_ptr<StgIntersectionObject>::unsync GetObject() { return obj_; }
+	void SetObject(ref_count_weak_ptr<StgIntersectionObject>::unsync obj) { obj_ = obj; }
 
-		int GetMortonNumber(){return mortonNo_;}
-		void SetMortonNumber(int no){mortonNo_ = no;}
-		void ClearObjectIntersectedIdList();
+	int GetMortonNumber() { return mortonNo_; }
+	void SetMortonNumber(int no) { mortonNo_ = no; }
+	void ClearObjectIntersectedIdList();
 
-		virtual std::wstring GetInfoAsString();
+	virtual std::wstring GetInfoAsString();
+
+protected:
+	int mortonNo_;
+	int typeTarget_;
+	int shape_;
+	ref_count_weak_ptr<StgIntersectionObject>::unsync obj_;
 };
 
-class StgIntersectionTarget_Circle : public StgIntersectionTarget
-{
+class StgIntersectionTarget_Circle : public StgIntersectionTarget {
 	friend StgIntersectionManager;
-		DxCircle circle_;
-	
-	protected:
 
+public:
+	StgIntersectionTarget_Circle() { shape_ = SHAPE_CIRCLE; }
+	virtual ~StgIntersectionTarget_Circle() {}
+	virtual RECT GetIntersectionSapceRect()
+	{
+		DirectGraphics* graphics = DirectGraphics::GetBase();
+		int screenWidth = graphics->GetScreenWidth();
+		int screenHeight = graphics->GetScreenWidth();
 
-	public:
-		StgIntersectionTarget_Circle(){shape_ = SHAPE_CIRCLE;}
-		virtual ~StgIntersectionTarget_Circle(){}
-		virtual RECT GetIntersectionSapceRect()
-		{
-			DirectGraphics* graphics = DirectGraphics::GetBase();
-			int screenWidth = graphics->GetScreenWidth();
-			int screenHeight = graphics->GetScreenWidth();
+		double x = circle_.GetX();
+		double y = circle_.GetY();
+		double r = circle_.GetR();
+		RECT rect = { (int)(x - r), (int)(y - r), (int)(x + r), (int)(y + r) };
+		rect.left = max(rect.left, 0);
+		rect.left = min(rect.left, screenWidth);
+		rect.top = max(rect.top, 0);
+		rect.top = min(rect.top, screenHeight);
 
-			double x = circle_.GetX();
-			double y = circle_.GetY();
-			double r = circle_.GetR();
-			RECT rect = {(int)(x - r), (int)(y - r), (int)(x + r), (int)(y + r)};
-			rect.left = max(rect.left, 0);
-			rect.left = min(rect.left, screenWidth);
-			rect.top = max(rect.top, 0);
-			rect.top = min(rect.top, screenHeight);
+		rect.right = max(rect.right, 0);
+		rect.right = min(rect.right, screenWidth);
+		rect.bottom = max(rect.bottom, 0);
+		rect.bottom = min(rect.bottom, screenHeight);
+		return rect;
+	}
 
-			rect.right = max(rect.right, 0);
-			rect.right = min(rect.right, screenWidth);
-			rect.bottom = max(rect.bottom, 0);
-			rect.bottom = min(rect.bottom, screenHeight);
-			return rect;
-		}
+	DxCircle& GetCircle() { return circle_; }
+	void SetCircle(DxCircle& circle) { circle_ = circle; }
 
-		DxCircle& GetCircle(){return circle_;}
-		void SetCircle(DxCircle& circle){circle_ = circle;}
-
+private:
+	DxCircle circle_;
 };
 
-class StgIntersectionTarget_Line : public StgIntersectionTarget
-{
+class StgIntersectionTarget_Line : public StgIntersectionTarget {
 	friend StgIntersectionManager;
-		DxWidthLine line_;
 
-	protected:
-		StgIntersectionTarget_Line(){shape_ = SHAPE_LINE;}
+protected:
+	StgIntersectionTarget_Line() { shape_ = SHAPE_LINE; }
 
-	public:
-		virtual ~StgIntersectionTarget_Line(){}
-		virtual RECT GetIntersectionSapceRect()
-		{
-			double x1 = line_.GetX1();
-			double y1 = line_.GetY1();
-			double x2 = line_.GetX2();
-			double y2 = line_.GetY2();
-			double width = line_.GetWidth();
-			if(x1 > x2)
-			{
-				double tx = x1;
-				x1 = x2;
-				x2 = tx;
-			}
-			if(y1 > y2)
-			{
-				double ty = y1;
-				y1 = y2;
-				y2 = ty;
-			}
-
-			x1 -= width;
-			x2 += width;
-			y1 -= width;
-			y2 += width;
-
-			DirectGraphics* graphics = DirectGraphics::GetBase();
-			int screenWidth = graphics->GetScreenWidth();
-			int screenHeight = graphics->GetScreenWidth();
-			x1 = min(x1, screenWidth);
-			x1 = max(x1, 0);
-			x2 = min(x2, screenWidth);
-			x2 = max(x2, 0);
-
-			y1 = min(y1, screenHeight);
-			y1 = max(y1, 0);
-			y2 = min(y2, screenHeight);
-			y2 = max(y2, 0);
-
-			//RECT rect = {x1 - width, y1 - width, x2 + width, y2 + width};
-			RECT rect = {(int)x1, (int)y1, (int)x2, (int)y2};
-			return rect;
+public:
+	virtual ~StgIntersectionTarget_Line() {}
+	virtual RECT GetIntersectionSapceRect()
+	{
+		double x1 = line_.GetX1();
+		double y1 = line_.GetY1();
+		double x2 = line_.GetX2();
+		double y2 = line_.GetY2();
+		double width = line_.GetWidth();
+		if (x1 > x2) {
+			double tx = x1;
+			x1 = x2;
+			x2 = tx;
+		}
+		if (y1 > y2) {
+			double ty = y1;
+			y1 = y2;
+			y2 = ty;
 		}
 
-		DxWidthLine& GetLine(){return line_;}
-		void SetLine(DxWidthLine& line){line_ = line;}
+		x1 -= width;
+		x2 += width;
+		y1 -= width;
+		y2 += width;
 
+		DirectGraphics* graphics = DirectGraphics::GetBase();
+		int screenWidth = graphics->GetScreenWidth();
+		int screenHeight = graphics->GetScreenWidth();
+		x1 = min(x1, screenWidth);
+		x1 = max(x1, 0);
+		x2 = min(x2, screenWidth);
+		x2 = max(x2, 0);
+
+		y1 = min(y1, screenHeight);
+		y1 = max(y1, 0);
+		y2 = min(y2, screenHeight);
+		y2 = max(y2, 0);
+
+		// RECT rect = {x1 - width, y1 - width, x2 + width, y2 + width};
+		RECT rect = { (int)x1, (int)y1, (int)x2, (int)y2 };
+		return rect;
+	}
+
+	DxWidthLine& GetLine() { return line_; }
+	void SetLine(DxWidthLine& line) { line_ = line; }
+
+private:
+	DxWidthLine line_;
 };
 
 /**********************************************************
 //StgIntersectionTargetPoint
 **********************************************************/
-class StgIntersectionTargetPoint
-{
-	private:
-		POINT pos_;
-		int idObject_;
+class StgIntersectionTargetPoint {
+public:
+	POINT& GetPoint() { return pos_; }
+	void SetPoint(POINT& pos) { pos_ = pos; }
+	int GetObjectID() { return idObject_; }
+	void SetObjectID(int id) { idObject_ = id; }
 
-	public:
-		POINT& GetPoint(){return pos_;}
-		void SetPoint(POINT& pos){pos_ = pos;}
-		int GetObjectID(){return idObject_;}
-		void SetObjectID(int id){idObject_ = id;}
+private:
+	POINT pos_;
+	int idObject_;
 };
 
 #endif
-

--- a/source/TouhouDanmakufu/Common/StgItem.cpp
+++ b/source/TouhouDanmakufu/Common/StgItem.cpp
@@ -1,7 +1,7 @@
-#include"StgItem.hpp"
-#include"StgSystem.hpp"
-#include"StgStageScript.hpp"
-#include"StgPlayer.hpp"
+#include "StgItem.hpp"
+#include "StgPlayer.hpp"
+#include "StgStageScript.hpp"
+#include "StgSystem.hpp"
 
 /**********************************************************
 //StgItemManager
@@ -18,7 +18,7 @@ StgItemManager::StgItemManager(StgStageController* stageController)
 	ref_count_ptr<Texture> textureItem = new Texture();
 	textureItem->CreateFromFile(pathItem);
 	listSpriteItem_->SetTexture(textureItem);
-	
+
 	listSpriteDigit_ = new SpriteList2D();
 	std::wstring pathDigit = dir + L"System_Stg_Digit.png";
 	ref_count_ptr<Texture> textureDigit = new Texture();
@@ -27,7 +27,6 @@ StgItemManager::StgItemManager(StgStageController* stageController)
 
 	bDefaultBonusItemEnable_ = true;
 	bAllItemToPlayer_ = false;
-
 }
 StgItemManager::~StgItemManager()
 {
@@ -40,77 +39,61 @@ void StgItemManager::Work()
 	double pr = objPlayer->GetItemIntersectionRadius();
 	int pAutoItemCollectY = objPlayer->GetAutoItemCollectY();
 
-	std::list<ref_count_ptr<StgItemObject>::unsync >::iterator itr = listObj_.begin();
-	for(; itr != listObj_.end(); )
-	{
+	std::list<ref_count_ptr<StgItemObject>::unsync>::iterator itr = listObj_.begin();
+	for (; itr != listObj_.end();) {
 		ref_count_ptr<StgItemObject>::unsync obj = (*itr);
-		if(obj->IsDeleted())
-		{
-			//obj->Clear();
+		if (obj->IsDeleted()) {
+			// obj->Clear();
 			itr = listObj_.erase(itr);
-		}
-		else 
-		{
+		} else {
 			double ix = obj->GetPositionX();
 			double iy = obj->GetPositionY();
-			if(objPlayer->GetState() == StgPlayerObject::STATE_NORMAL)
-			{
+			if (objPlayer->GetState() == StgPlayerObject::STATE_NORMAL) {
 				double radius = pow(pow(px - ix, 2) + pow(py - iy, 2), 0.5);
-				if(radius <= pr)
-				{
+				if (radius <= pr) {
 					obj->Intersect(NULL, NULL);
 				}
 
-				if(bCancelToPlayer_)
-				{
+				if (bCancelToPlayer_) {
 					//自動回収キャンセル
 					obj->SetMoveToPlayer(false);
-				}
-				else if(obj->IsPermitMoveToPlayer())
-				{
+				} else if (obj->IsPermitMoveToPlayer()) {
 					bool bMoveToPlayer = false;
-					if(pAutoItemCollectY >= 0)
-					{
+					if (pAutoItemCollectY >= 0) {
 						//上部自動回収
 						int typeMove = obj->GetMoveType();
-						if(!obj->IsMoveToPlayer() && py <= pAutoItemCollectY)
+						if (!obj->IsMoveToPlayer() && py <= pAutoItemCollectY)
 							bMoveToPlayer = true;
 					}
 
-					if(listItemTypeToPlayer_.size() > 0)
-					{
+					if (listItemTypeToPlayer_.size() > 0) {
 						//自機にアイテムを集める
 						int typeItem = obj->GetItemType();
 						bool bFind = listItemTypeToPlayer_.find(typeItem) != listItemTypeToPlayer_.end();
-						if(bFind)
+						if (bFind)
 							bMoveToPlayer = true;
 					}
 
-					if(listCircleToPlayer_.size() > 0)
-					{
+					if (listCircleToPlayer_.size() > 0) {
 						std::list<DxCircle>::iterator itr = listCircleToPlayer_.begin();
-						for(; itr != listCircleToPlayer_.end() ;itr++)
-						{
+						for (; itr != listCircleToPlayer_.end(); itr++) {
 							DxCircle circle = *itr;
 							double cr = pow(pow(ix - circle.GetX(), 2) + pow(iy - circle.GetY(), 2), 0.5);
-							if(cr <= circle.GetR())
-							{
+							if (cr <= circle.GetR()) {
 								bMoveToPlayer = true;
 								break;
 							}
 						}
 					}
 
-					if(bAllItemToPlayer_)
+					if (bAllItemToPlayer_)
 						bMoveToPlayer = true;
 
-					if(bMoveToPlayer) 
+					if (bMoveToPlayer)
 						obj->SetMoveToPlayer(true);
 				}
 
-			}
-			else
-			{
+			} else {
 				obj->SetMoveToPlayer(false);
 			}
 
@@ -121,7 +104,6 @@ void StgItemManager::Work()
 	listCircleToPlayer_.clear();
 	bAllItemToPlayer_ = false;
 	bCancelToPlayer_ = false;
-
 }
 void StgItemManager::Render(int targetPriority)
 {
@@ -134,49 +116,45 @@ void StgItemManager::Render(int targetPriority)
 	//フォグを解除する
 	DWORD bEnableFog = FALSE;
 	graphics->GetDevice()->GetRenderState(D3DRS_FOGENABLE, &bEnableFog);
-	if(bEnableFog)
+	if (bEnableFog)
 		graphics->SetFogEnable(false);
 
 	//拡大率など計算
 	DxCamera2D* camera = graphics->GetCamera2D().GetPointer();
 	D3DXMATRIX matCamera = camera->GetMatrix();
 
-	std::list<ref_count_ptr<StgItemObject>::unsync >::iterator itr = listObj_.begin();
-	for(; itr != listObj_.end(); itr++)
-	{
+	std::list<ref_count_ptr<StgItemObject>::unsync>::iterator itr = listObj_.begin();
+	for (; itr != listObj_.end(); itr++) {
 		ref_count_ptr<StgItemObject>::unsync obj = (*itr);
-		if(obj->IsDeleted())continue;
-		if(obj->GetRenderPriorityI() != targetPriority)continue;
+		if (obj->IsDeleted())
+			continue;
+		if (obj->GetRenderPriorityI() != targetPriority)
+			continue;
 
 		obj->RenderOnItemManager(matCamera);
 	}
 
 	int countBlendType = StgItemDataList::RENDER_TYPE_COUNT;
-	int blendMode[] = {DirectGraphics::MODE_BLEND_ADD_ARGB, DirectGraphics::MODE_BLEND_ADD_RGB, DirectGraphics::MODE_BLEND_ALPHA};
-	int typeRender[] = {StgShotDataList::RENDER_ADD_ARGB, StgShotDataList::RENDER_ADD_RGB, StgShotDataList::RENDER_ALPHA};
-	ref_count_ptr<SpriteList2D>::unsync listSprite[] = {listSpriteDigit_, listSpriteItem_};
-	for(int iBlend = 0 ; iBlend < countBlendType ; iBlend++)
-	{
+	int blendMode[] = { DirectGraphics::MODE_BLEND_ADD_ARGB, DirectGraphics::MODE_BLEND_ADD_RGB, DirectGraphics::MODE_BLEND_ALPHA };
+	int typeRender[] = { StgShotDataList::RENDER_ADD_ARGB, StgShotDataList::RENDER_ADD_RGB, StgShotDataList::RENDER_ALPHA };
+	ref_count_ptr<SpriteList2D>::unsync listSprite[] = { listSpriteDigit_, listSpriteItem_ };
+	for (int iBlend = 0; iBlend < countBlendType; iBlend++) {
 		graphics->SetBlendMode(blendMode[iBlend]);
-		if(blendMode[iBlend] == DirectGraphics::MODE_BLEND_ADD_ARGB)
-		{
+		if (blendMode[iBlend] == DirectGraphics::MODE_BLEND_ADD_ARGB) {
 			listSpriteDigit_->Render();
 			listSpriteDigit_->ClearVertexCount();
-		}
-		else if(blendMode[iBlend] == DirectGraphics::MODE_BLEND_ALPHA)
-		{
+		} else if (blendMode[iBlend] == DirectGraphics::MODE_BLEND_ALPHA) {
 			listSpriteItem_->Render();
 			listSpriteItem_->ClearVertexCount();
 		}
 
-		std::vector<ref_count_ptr<StgItemRenderer>::unsync >* listRenderer = 
-			listItemData_->GetRendererList(typeRender[iBlend]);
+		std::vector<ref_count_ptr<StgItemRenderer>::unsync>* listRenderer = listItemData_->GetRendererList(typeRender[iBlend]);
 		int iRender = 0;
-		for(iRender = 0 ; iRender < listRenderer->size() ; iRender++)
+		for (iRender = 0; iRender < listRenderer->size(); iRender++)
 			(listRenderer->at(iRender))->Render();
 	}
 
-	if(bEnableFog)
+	if (bEnableFog)
 		graphics->SetFogEnable(true);
 }
 std::vector<bool> StgItemManager::GetValidRenderPriorityList()
@@ -185,11 +163,11 @@ std::vector<bool> StgItemManager::GetValidRenderPriorityList()
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 	res.resize(objectManager->GetRenderBucketCapacity());
 
-	std::list<ref_count_ptr<StgItemObject>::unsync >::iterator itr = listObj_.begin();
-	for(; itr != listObj_.end(); itr++)
-	{
+	std::list<ref_count_ptr<StgItemObject>::unsync>::iterator itr = listObj_.begin();
+	for (; itr != listObj_.end(); itr++) {
 		ref_count_ptr<StgItemObject>::unsync obj = (*itr);
-		if(obj->IsDeleted())continue;
+		if (obj->IsDeleted())
+			continue;
 
 		int pri = obj->GetRenderPriorityI();
 		res[pri] = true;
@@ -205,8 +183,7 @@ bool StgItemManager::LoadItemData(std::wstring path, bool bReload)
 ref_count_ptr<StgItemObject>::unsync StgItemManager::CreateItem(int type)
 {
 	ref_count_ptr<StgItemObject>::unsync res;
-	switch(type)
-	{
+	switch (type) {
 	case StgItemObject::ITEM_1UP:
 	case StgItemObject::ITEM_1UP_S:
 		res = new StgItemObject_1UP(stageController_);
@@ -228,7 +205,6 @@ ref_count_ptr<StgItemObject>::unsync StgItemManager::CreateItem(int type)
 		break;
 	}
 	res->SetItemType(type);
-
 	return res;
 }
 void StgItemManager::CollectItemsAll()
@@ -260,83 +236,76 @@ StgItemDataList::~StgItemDataList()
 }
 bool StgItemDataList::AddItemDataList(std::wstring path, bool bReload)
 {
-	if(!bReload && listReadPath_.find(path) != listReadPath_.end())return true;
+	if (!bReload && listReadPath_.find(path) != listReadPath_.end())
+		return true;
 
 	ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-	if(reader == NULL) throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path).c_str());
-	if(!reader->Open())throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path).c_str());
+	if (reader == NULL)
+		throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path).c_str());
+	if (!reader->Open())
+		throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path).c_str());
 	std::string source = reader->ReadAllString();
 
 	bool res = false;
 	Scanner scanner(source);
-	try
-	{
-		std::vector<ref_count_ptr<StgItemData>::unsync > listData;
+	try {
+		std::vector<ref_count_ptr<StgItemData>::unsync> listData;
 		std::wstring pathImage = L"";
-		RECT rcDelay = {-1, -1, -1, -1};
-		while(scanner.HasNext())
-		{
+		RECT rcDelay = { -1, -1, -1, -1 };
+		while (scanner.HasNext()) {
 			Token& tok = scanner.Next();
-			if(tok.GetType() == Token::TK_EOF)//Eofの識別子が来たらファイルの調査終了
+			if (tok.GetType() == Token::TK_EOF) //Eofの識別子が来たらファイルの調査終了
 			{
 				break;
-			}
-			else if(tok.GetType() == Token::TK_ID)
-			{
+			} else if (tok.GetType() == Token::TK_ID) {
 				std::wstring element = tok.GetElement();
-				if(element == L"ItemData")
-				{
+				if (element == L"ItemData") {
 					_ScanItem(listData, scanner);
-				}
-				else if(element == L"item_image")
-				{
+				} else if (element == L"item_image") {
 					scanner.CheckType(scanner.Next(), Token::TK_EQUAL);
 					pathImage = scanner.Next().GetString();
 				}
 
-				if(scanner.HasNext())
+				if (scanner.HasNext())
 					tok = scanner.Next();
-
 			}
 		}
 
 		//テクスチャ読み込み
-		if(pathImage.size() == 0)throw gstd::wexception(L"画像ファイルが設定されていません。");
+		if (pathImage.size() == 0)
+			throw gstd::wexception(L"画像ファイルが設定されていません。");
 		std::wstring dir = PathProperty::GetFileDirectory(path);
 		pathImage = StringUtility::Replace(pathImage, L"./", dir);
 
 		ref_count_ptr<Texture> texture = new Texture();
 		bool bTexture = texture->CreateFromFile(pathImage);
-		if(!bTexture)throw gstd::wexception(L"画像ファイルが見つかりませんでした。");
+		if (!bTexture)
+			throw gstd::wexception(L"画像ファイルが見つかりませんでした。");
 
 		int textureIndex = -1;
-		for(int iTexture = 0 ;iTexture < listTexture_.size() ; iTexture++)
-		{
+		for (int iTexture = 0; iTexture < listTexture_.size(); iTexture++) {
 			ref_count_ptr<Texture> tSearch = listTexture_[iTexture];
-			if(tSearch->GetName() == texture->GetName())
-			{
+			if (tSearch->GetName() == texture->GetName()) {
 				textureIndex = iTexture;
 				break;
 			}
 		}
-		if(textureIndex < 0)
-		{
+		if (textureIndex < 0) {
 			textureIndex = listTexture_.size();
 			listTexture_.push_back(texture);
-			for(int iRender = 0 ; iRender < listRenderer_.size(); iRender++)
-			{
+			for (int iRender = 0; iRender < listRenderer_.size(); iRender++) {
 				ref_count_ptr<StgItemRenderer>::unsync render = new StgItemRenderer();
 				render->SetTexture(texture);
 				listRenderer_[iRender].push_back(render);
 			}
 		}
 
-		if(listData_.size() < listData.size())
+		if (listData_.size() < listData.size())
 			listData_.resize(listData.size());
-		for(int iData = 0 ; iData < listData.size() ; iData++)
-		{
+		for (int iData = 0; iData < listData.size(); iData++) {
 			ref_count_ptr<StgItemData>::unsync data = listData[iData];
-			if(data == NULL)continue;
+			if (data == NULL)
+				continue;
 			data->indexTexture_ = textureIndex;
 			listData_[iData] = data;
 		}
@@ -344,15 +313,11 @@ bool StgItemDataList::AddItemDataList(std::wstring path, bool bReload)
 		listReadPath_.insert(path);
 		Logger::WriteTop(StringUtility::Format(L"アイテムデータを読み込みました:%s", path.c_str()));
 		res = true;
-	}
-	catch(gstd::wexception& e)
-	{
+	} catch (gstd::wexception& e) {
 		std::wstring log = StringUtility::Format(L"アイテムデータ読み込み失敗:%d行目(%s)", scanner.GetCurrentLine(), e.what());
 		Logger::WriteTop(log);
 		res = NULL;
-	}
-	catch(...)
-	{
+	} catch (...) {
 		std::wstring log = StringUtility::Format(L"アイテムデータ読み込み失敗:%d行目", scanner.GetCurrentLine());
 		Logger::WriteTop(log);
 		res = NULL;
@@ -360,39 +325,31 @@ bool StgItemDataList::AddItemDataList(std::wstring path, bool bReload)
 
 	return res;
 }
-void StgItemDataList::_ScanItem(std::vector<ref_count_ptr<StgItemData>::unsync >& listData, Scanner& scanner)
+void StgItemDataList::_ScanItem(std::vector<ref_count_ptr<StgItemData>::unsync>& listData, Scanner& scanner)
 {
 	Token& tok = scanner.Next();
-	if(tok.GetType() == Token::TK_NEWLINE)tok = scanner.Next();
+	if (tok.GetType() == Token::TK_NEWLINE)
+		tok = scanner.Next();
 	scanner.CheckType(tok, Token::TK_OPENC);
 
 	ref_count_ptr<StgItemData>::unsync data = new StgItemData(this);
 	int id = -1;
 	int typeItem = -1;
 
-	while(true)
-	{
+	while (true) {
 		tok = scanner.Next();
-		if(tok.GetType() == Token::TK_CLOSEC)
-		{
+		if (tok.GetType() == Token::TK_CLOSEC) {
 			break;
-		}
-		else if(tok.GetType() == Token::TK_ID)
-		{
+		} else if (tok.GetType() == Token::TK_ID) {
 			std::wstring element = tok.GetElement();
 
-			if(element == L"id")
-			{
+			if (element == L"id") {
 				scanner.CheckType(scanner.Next(), Token::TK_EQUAL);
 				id = scanner.Next().GetInteger();
-			}
-			else if(element == L"type")
-			{
+			} else if (element == L"type") {
 				scanner.CheckType(scanner.Next(), Token::TK_EQUAL);
 				typeItem = scanner.Next().GetInteger();
-			}
-			else if(element == L"rect")
-			{
+			} else if (element == L"rect") {
 				std::vector<std::wstring> list = _GetArgumentList(scanner);
 				RECT rect;
 				rect.left = StringUtility::ToInteger(list[0]);
@@ -400,9 +357,7 @@ void StgItemDataList::_ScanItem(std::vector<ref_count_ptr<StgItemData>::unsync >
 				rect.right = StringUtility::ToInteger(list[2]);
 				rect.bottom = StringUtility::ToInteger(list[3]);
 				data->rcSrc_ = rect;
-			}
-			else if(element == L"out")
-			{
+			} else if (element == L"out") {
 				std::vector<std::wstring> list = _GetArgumentList(scanner);
 				RECT rect;
 				rect.left = StringUtility::ToInteger(list[0]);
@@ -410,34 +365,27 @@ void StgItemDataList::_ScanItem(std::vector<ref_count_ptr<StgItemData>::unsync >
 				rect.right = StringUtility::ToInteger(list[2]);
 				rect.bottom = StringUtility::ToInteger(list[3]);
 				data->rcOut_ = rect;
-			}
-			else if(element == L"render")
-			{
+			} else if (element == L"render") {
 				scanner.CheckType(scanner.Next(), Token::TK_EQUAL);
 				std::wstring render = scanner.Next().GetElement();
-				if(render == L"ADD" || render == L"ADD_RGB")
+				if (render == L"ADD" || render == L"ADD_RGB")
 					data->typeRender_ = DirectGraphics::MODE_BLEND_ADD_RGB;
-				else if(render == L"ADD_ARGB")
+				else if (render == L"ADD_ARGB")
 					data->typeRender_ = DirectGraphics::MODE_BLEND_ADD_ARGB;
-			}
-			else if(element == L"alpha")
-			{
+			} else if (element == L"alpha") {
 				scanner.CheckType(scanner.Next(), Token::TK_EQUAL);
 				data->alpha_ = scanner.Next().GetInteger();
-			}
-			else if(element == L"AnimationData")
-			{
+			} else if (element == L"AnimationData") {
 				_ScanAnimation(data, scanner);
 			}
 		}
 	}
 
-	if(id >= 0) 
-	{
-		if(listData.size() <= id) 
+	if (id >= 0) {
+		if (listData.size() <= id)
 			listData.resize(id + 1);
 
-		if(typeItem <0)
+		if (typeItem < 0)
 			typeItem = id;
 		data->typeItem_ = typeItem;
 
@@ -447,25 +395,20 @@ void StgItemDataList::_ScanItem(std::vector<ref_count_ptr<StgItemData>::unsync >
 void StgItemDataList::_ScanAnimation(ref_count_ptr<StgItemData>::unsync itemData, Scanner& scanner)
 {
 	Token& tok = scanner.Next();
-	if(tok.GetType() == Token::TK_NEWLINE)tok = scanner.Next();
+	if (tok.GetType() == Token::TK_NEWLINE)
+		tok = scanner.Next();
 	scanner.CheckType(tok, Token::TK_OPENC);
 
-	while(true)
-	{
+	while (true) {
 		tok = scanner.Next();
-		if(tok.GetType() == Token::TK_CLOSEC)
-		{
+		if (tok.GetType() == Token::TK_CLOSEC) {
 			break;
-		}
-		else if(tok.GetType() == Token::TK_ID)
-		{
+		} else if (tok.GetType() == Token::TK_ID) {
 			std::wstring element = tok.GetElement();
 
-			if(element == L"animation_data")
-			{
+			if (element == L"animation_data") {
 				std::vector<std::wstring> list = _GetArgumentList(scanner);
-				if(list.size() == 5) 
-				{
+				if (list.size() == 5) {
 					StgItemData::AnimationData anime;
 					int frame = StringUtility::ToInteger(list[0]);
 					RECT rcSrc = {
@@ -492,22 +435,18 @@ std::vector<std::wstring> StgItemDataList::_GetArgumentList(Scanner& scanner)
 
 	Token& tok = scanner.Next();
 
-	if(tok.GetType() == Token::TK_OPENP)
-	{
-		while(true) 
-		{
+	if (tok.GetType() == Token::TK_OPENP) {
+		while (true) {
 			tok = scanner.Next();
 			int type = tok.GetType();
-			if(type == Token::TK_CLOSEP)break;
-			else if(type != Token::TK_COMMA)
-			{
+			if (type == Token::TK_CLOSEP)
+				break;
+			else if (type != Token::TK_COMMA) {
 				std::wstring str = tok.GetElement();
 				res.push_back(str);
 			}
 		}
-	}
-	else
-	{
+	} else {
 		res.push_back(tok.GetElement());
 	}
 	return res;
@@ -518,8 +457,8 @@ StgItemData::StgItemData(StgItemDataList* listItemData)
 {
 	listItemData_ = listItemData;
 	typeRender_ = DirectGraphics::MODE_BLEND_ALPHA;
-	SetRect(&rcSrc_ , 0, 0, 0, 0);
-	SetRect(&rcOut_ , 0, 0, 0, 0);
+	SetRect(&rcSrc_, 0, 0, 0, 0);
+	SetRect(&rcOut_, 0, 0, 0, 0);
 	alpha_ = 255;
 	totalAnimeFrame_ = 0;
 }
@@ -528,19 +467,17 @@ StgItemData::~StgItemData()
 }
 RECT StgItemData::GetRect(int frame)
 {
-	if(totalAnimeFrame_ == 0) 
+	if (totalAnimeFrame_ == 0)
 		return rcSrc_;
 
 	RECT res;
 	frame = frame % totalAnimeFrame_;
 	int total = 0;
 	std::vector<AnimationData>::iterator itr = listAnime_.begin();
-	for(;itr != listAnime_.end();itr++) 
-	{
-		//AnimationData* anime = itr;
+	for (; itr != listAnime_.end(); itr++) {
+		// AnimationData* anime = itr;
 		total += itr->frame_;
-		if(total >= frame)
-		{
+		if (total >= frame) {
 			res = itr->rcSrc_;
 			break;
 		}
@@ -556,11 +493,11 @@ ref_count_ptr<Texture> StgItemData::GetTexture()
 StgItemRenderer* StgItemData::GetRenderer()
 {
 	StgItemRenderer* res = NULL;
-	if(typeRender_ == DirectGraphics::MODE_BLEND_ALPHA)
+	if (typeRender_ == DirectGraphics::MODE_BLEND_ALPHA)
 		res = listItemData_->GetRenderer(indexTexture_, StgItemDataList::RENDER_ALPHA).GetPointer();
-	else if(typeRender_ == DirectGraphics::MODE_BLEND_ADD_RGB)
+	else if (typeRender_ == DirectGraphics::MODE_BLEND_ADD_RGB)
 		res = listItemData_->GetRenderer(indexTexture_, StgItemDataList::RENDER_ADD_RGB).GetPointer();
-	else if(typeRender_ == DirectGraphics::MODE_BLEND_ADD_ARGB)
+	else if (typeRender_ == DirectGraphics::MODE_BLEND_ADD_ARGB)
 		res = listItemData_->GetRenderer(indexTexture_, StgItemDataList::RENDER_ADD_ARGB).GetPointer();
 	return res;
 }
@@ -576,7 +513,6 @@ StgItemRenderer::StgItemRenderer()
 {
 	countRenderVertex_ = 0;
 	SetVertexCount(256 * 256);
-
 }
 int StgItemRenderer::GetVertexCount()
 {
@@ -589,7 +525,7 @@ void StgItemRenderer::Render()
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	IDirect3DDevice9* device = graphics->GetDevice();
 	ref_count_ptr<Texture>& texture = texture_[0];
-	if(texture != NULL)
+	if (texture != NULL)
 		device->SetTexture(0, texture->GetD3DTexture());
 	else
 		device->SetTexture(0, NULL);
@@ -618,7 +554,8 @@ void StgItemRenderer::AddSquareVertex(VERTEX_TLX* listVertex)
 /**********************************************************
 //StgItemObject
 **********************************************************/
-StgItemObject::StgItemObject(StgStageController* stageController) : StgMoveObject(stageController)
+StgItemObject::StgItemObject(StgStageController* stageController)
+	: StgMoveObject(stageController)
 {
 	stageController_ = stageController;
 	typeObject_ = StgStageScript::OBJ_ITEM;
@@ -638,8 +575,7 @@ StgItemObject::StgItemObject(StgStageController* stageController) : StgMoveObjec
 void StgItemObject::Work()
 {
 	bool bDefaultMovePattern = ref_count_ptr<StgMovePattern_Item>::unsync::DownCast(GetPattern()) != NULL;
-	if(!bDefaultMovePattern && IsMoveToPlayer())
-	{
+	if (!bDefaultMovePattern && IsMoveToPlayer()) {
 		double speed = 8;
 		ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController_->GetPlayerObject();
 		double angle = atan2(objPlayer->GetY() - GetPositionY(), objPlayer->GetX() - GetPositionX());
@@ -656,14 +592,11 @@ void StgItemObject::Work()
 void StgItemObject::RenderOnItemManager(D3DXMATRIX mat)
 {
 	StgItemManager* itemManager = stageController_->GetItemManager();
-	SpriteList2D* renderer = typeItem_ == ITEM_SCORE ?
-		itemManager->GetDigitRenderer() : itemManager->GetItemRenderer();
+	SpriteList2D* renderer = typeItem_ == ITEM_SCORE ? itemManager->GetDigitRenderer() : itemManager->GetItemRenderer();
 
-	if(typeItem_ != ITEM_SCORE)
-	{
+	if (typeItem_ != ITEM_SCORE) {
 		double scale = 1.0;
-		switch(typeItem_)
-		{
+		switch (typeItem_) {
 		case ITEM_1UP:
 		case ITEM_SPELL:
 		case ITEM_POWER:
@@ -681,8 +614,7 @@ void StgItemObject::RenderOnItemManager(D3DXMATRIX mat)
 		}
 
 		RECT rcSrc;
-		switch(typeItem_)
-		{
+		switch (typeItem_) {
 		case ITEM_1UP:
 		case ITEM_1UP_S:
 			SetRect(&rcSrc, 1, 1, 16, 16);
@@ -707,11 +639,9 @@ void StgItemObject::RenderOnItemManager(D3DXMATRIX mat)
 		//上にはみ出している
 		double posY = posY_;
 		D3DCOLOR color = D3DCOLOR_ARGB(255, 255, 255, 255);
-		if(posY_ <= 0)
-		{
+		if (posY_ <= 0) {
 			D3DCOLOR colorOver = D3DCOLOR_ARGB(255, 255, 255, 255);
-			switch(typeItem_)
-			{
+			switch (typeItem_) {
 			case ITEM_1UP:
 			case ITEM_1UP_S:
 				colorOver = D3DCOLOR_ARGB(255, 236, 0, 236);
@@ -729,8 +659,7 @@ void StgItemObject::RenderOnItemManager(D3DXMATRIX mat)
 				colorOver = D3DCOLOR_ARGB(255, 0, 0, 160);
 				break;
 			}
-			if(color != colorOver)
-			{
+			if (color != colorOver) {
 				SetRect(&rcSrc, 113, 1, 126, 10);
 				posY = 6;
 			}
@@ -744,9 +673,7 @@ void StgItemObject::RenderOnItemManager(D3DXMATRIX mat)
 		renderer->SetSourceRect(rcSrcD);
 		renderer->SetDestinationCenter();
 		renderer->AddVertex();
-	}
-	else
-	{
+	} else {
 		renderer->SetScaleXYZ(1.0, 1.0, 1.0);
 		renderer->SetColor(color_);
 		renderer->SetPosition(0, 0, 0);
@@ -754,19 +681,18 @@ void StgItemObject::RenderOnItemManager(D3DXMATRIX mat)
 		int fontSize = 14;
 		_int64 score = score_;
 		std::vector<int> listNum;
-		while(true)
-		{
+		while (true) {
 			int tnum = score % 10;
 			score /= 10;
 			listNum.push_back(tnum);
-			if(score == 0)break;
-		}		
-		for(int iNum = listNum.size() - 1; iNum >= 0 ; iNum--)
-		{
-			RECT_D rcSrc = {(double)(listNum[iNum]*36), 0.,
-				(double)((listNum[iNum]+1)*36-1), 31.};
-			RECT_D rcDest = { (double)(posX_+(listNum.size()-1-iNum)*fontSize/2), (double)posY_,
-				(double)(posX_+(listNum.size()-iNum)*fontSize/2), (double)(posY_+fontSize)};
+			if (score == 0)
+				break;
+		}
+		for (int iNum = listNum.size() - 1; iNum >= 0; iNum--) {
+			RECT_D rcSrc = { (double)(listNum[iNum] * 36), 0.,
+				(double)((listNum[iNum] + 1) * 36 - 1), 31. };
+			RECT_D rcDest = { (double)(posX_ + (listNum.size() - 1 - iNum) * fontSize / 2), (double)posY_,
+				(double)(posX_ + (listNum.size() - iNum) * fontSize / 2), (double)(posY_ + fontSize) };
 			renderer->SetSourceRect(rcSrc);
 			renderer->SetDestinationRect(rcDest);
 			renderer->AddVertex();
@@ -783,7 +709,8 @@ void StgItemObject::_DeleteInAutoClip()
 	rcClip.right = graphics->GetScreenWidth() + 64;
 	rcClip.bottom = graphics->GetScreenHeight() + 64;
 	bool bDelete = (posX_ < rcClip.left || posX_ > rcClip.right || posY_ > rcClip.bottom);
-	if(!bDelete)return;
+	if (!bDelete)
+		return;
 
 	stageController_->GetMainObjectManager()->DeleteObject(GetObjectID());
 }
@@ -804,8 +731,7 @@ void StgItemObject::_NotifyEventToPlayerScript(std::vector<long double>& listVal
 	ref_count_ptr<StgPlayerObject>::unsync player = stageController_->GetPlayerObject();
 	StgStagePlayerScript* scriptPlayer = player->GetPlayerScript();
 	std::vector<gstd::value> listScriptValue;
-	for(int iVal = 0 ; iVal < listValue.size() ; iVal++)
-	{
+	for (int iVal = 0; iVal < listValue.size(); iVal++) {
 		listScriptValue.push_back(scriptPlayer->CreateRealValue(listValue[iVal]));
 	}
 
@@ -816,14 +742,11 @@ void StgItemObject::_NotifyEventToItemScript(std::vector<long double>& listValue
 	//アイテムスクリプトへ通知
 	StgStageScriptManager* stageScriptManager = stageController_->GetScriptManagerP();
 	_int64 idItemScript = stageScriptManager->GetItemScriptID();
-	if(idItemScript != StgControlScriptManager::ID_INVALID)
-	{
+	if (idItemScript != StgControlScriptManager::ID_INVALID) {
 		ref_count_ptr<ManagedScript> scriptItem = stageScriptManager->GetScript(idItemScript);
-		if(scriptItem != NULL)
-		{
+		if (scriptItem != NULL) {
 			std::vector<gstd::value> listScriptValue;
-			for(int iVal = 0 ; iVal < listValue.size() ; iVal++)
-			{
+			for (int iVal = 0; iVal < listValue.size(); iVal++) {
 				listScriptValue.push_back(scriptItem->CreateRealValue(listValue[iVal]));
 			}
 			scriptItem->RequestEvent(StgStageItemScript::EV_GET_ITEM, listScriptValue);
@@ -850,20 +773,20 @@ int StgItemObject::GetMoveType()
 	int res = StgMovePattern_Item::MOVE_NONE;
 
 	StgMovePattern_Item* move = dynamic_cast<StgMovePattern_Item*>(pattern_.GetPointer());
-	if(move != NULL)
+	if (move != NULL)
 		res = move->GetItemMoveType();
 	return res;
 }
 void StgItemObject::SetMoveType(int type)
 {
 	StgMovePattern_Item* move = dynamic_cast<StgMovePattern_Item*>(pattern_.GetPointer());
-	if(move != NULL)
+	if (move != NULL)
 		move->SetItemMoveType(type);
 }
 
-
 //StgItemObject_1UP
-StgItemObject_1UP::StgItemObject_1UP(StgStageController* stageController) : StgItemObject(stageController)
+StgItemObject_1UP::StgItemObject_1UP(StgStageController* stageController)
+	: StgItemObject(stageController)
 {
 	typeItem_ = ITEM_1UP;
 	StgMovePattern_Item* move = (StgMovePattern_Item*)pattern_.GetPointer();
@@ -882,7 +805,8 @@ void StgItemObject_1UP::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync o
 }
 
 //StgItemObject_Bomb
-StgItemObject_Bomb::StgItemObject_Bomb(StgStageController* stageController) : StgItemObject(stageController)
+StgItemObject_Bomb::StgItemObject_Bomb(StgStageController* stageController)
+	: StgItemObject(stageController)
 {
 	typeItem_ = ITEM_SPELL;
 	StgMovePattern_Item* move = (StgMovePattern_Item*)pattern_.GetPointer();
@@ -901,7 +825,8 @@ void StgItemObject_Bomb::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync 
 }
 
 //StgItemObject_Power
-StgItemObject_Power::StgItemObject_Power(StgStageController* stageController) : StgItemObject(stageController)
+StgItemObject_Power::StgItemObject_Power(StgStageController* stageController)
+	: StgItemObject(stageController)
 {
 	typeItem_ = ITEM_POWER;
 	StgMovePattern_Item* move = (StgMovePattern_Item*)pattern_.GetPointer();
@@ -910,7 +835,7 @@ StgItemObject_Power::StgItemObject_Power(StgStageController* stageController) : 
 }
 void StgItemObject_Power::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget)
 {
-	if(bChangeItemScore_)
+	if (bChangeItemScore_)
 		_CreateScoreItem();
 	stageController_->GetStageInformation()->AddScore(score_);
 
@@ -925,7 +850,8 @@ void StgItemObject_Power::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync
 }
 
 //StgItemObject_Point
-StgItemObject_Point::StgItemObject_Point(StgStageController* stageController) : StgItemObject(stageController)
+StgItemObject_Point::StgItemObject_Point(StgStageController* stageController)
+	: StgItemObject(stageController)
 {
 	typeItem_ = ITEM_POINT;
 	StgMovePattern_Item* move = (StgMovePattern_Item*)pattern_.GetPointer();
@@ -933,7 +859,7 @@ StgItemObject_Point::StgItemObject_Point(StgStageController* stageController) : 
 }
 void StgItemObject_Point::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget)
 {
-	if(bChangeItemScore_)
+	if (bChangeItemScore_)
 		_CreateScoreItem();
 	stageController_->GetStageInformation()->AddScore(score_);
 
@@ -948,7 +874,8 @@ void StgItemObject_Point::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync
 }
 
 //StgItemObject_Bonus
-StgItemObject_Bonus::StgItemObject_Bonus(StgStageController* stageController) : StgItemObject(stageController)
+StgItemObject_Bonus::StgItemObject_Bonus(StgStageController* stageController)
+	: StgItemObject(stageController)
 {
 	typeItem_ = ITEM_BONUS;
 	StgMovePattern_Item* move = (StgMovePattern_Item*)pattern_.GetPointer();
@@ -962,8 +889,7 @@ void StgItemObject_Bonus::Work()
 	StgItemObject::Work();
 
 	ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController_->GetPlayerObject();
-	if(objPlayer->GetState() != StgPlayerObject::STATE_NORMAL)
-	{
+	if (objPlayer->GetState() != StgPlayerObject::STATE_NORMAL) {
 		_CreateScoreItem();
 		stageController_->GetStageInformation()->AddScore(score_);
 
@@ -981,7 +907,8 @@ void StgItemObject_Bonus::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync
 }
 
 //StgItemObject_Score
-StgItemObject_Score::StgItemObject_Score(StgStageController* stageController) : StgItemObject(stageController)
+StgItemObject_Score::StgItemObject_Score(StgStageController* stageController)
+	: StgItemObject(stageController)
 {
 	typeItem_ = ITEM_SCORE;
 	StgMovePattern_Item* move = (StgMovePattern_Item*)pattern_.GetPointer();
@@ -997,8 +924,7 @@ void StgItemObject_Score::Work()
 	int alpha = 255 - frameDelete_ * 8;
 	color_ = D3DCOLOR_ARGB(alpha, alpha, alpha, alpha);
 
-	if(frameDelete_ > 30)
-	{
+	if (frameDelete_ > 30) {
 		stageController_->GetMainObjectManager()->DeleteObject(GetObjectID());
 		return;
 	}
@@ -1009,7 +935,8 @@ void StgItemObject_Score::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync
 }
 
 //StgItemObject_User
-StgItemObject_User::StgItemObject_User(StgStageController* stageController) : StgItemObject(stageController)
+StgItemObject_User::StgItemObject_User(StgStageController* stageController)
+	: StgItemObject(stageController)
 {
 	typeItem_ = ITEM_USER;
 	idImage_ = -1;
@@ -1023,8 +950,7 @@ void StgItemObject_User::SetImageID(int id)
 {
 	idImage_ = id;
 	StgItemData* data = _GetItemData();
-	if(data != NULL)
-	{
+	if (data != NULL) {
 		typeItem_ = data->GetItemType();
 	}
 }
@@ -1034,8 +960,7 @@ StgItemData* StgItemObject_User::_GetItemData()
 	StgItemManager* itemManager = stageController_->GetItemManager();
 	StgItemDataList* dataList = itemManager->GetItemDataList();
 
-	if(dataList != NULL)
-	{
+	if (dataList != NULL) {
 		res = dataList->GetData(idImage_).GetPointer();
 	}
 
@@ -1052,8 +977,9 @@ void StgItemObject_User::_SetVertexPosition(VERTEX_TLX& vertex, float x, float y
 void StgItemObject_User::_SetVertexUV(VERTEX_TLX& vertex, float u, float v)
 {
 	StgItemData* itemData = _GetItemData();
-	if(itemData == NULL)return;
-	
+	if (itemData == NULL)
+		return;
+
 	ref_count_ptr<Texture> texture = itemData->GetTexture();
 	int width = texture->GetWidth();
 	int height = texture->GetHeight();
@@ -1071,14 +997,17 @@ void StgItemObject_User::Work()
 }
 void StgItemObject_User::RenderOnItemManager(D3DXMATRIX mat)
 {
-	if(!IsVisible())return;
+	if (!IsVisible())
+		return;
 
 	StgItemData* itemData = _GetItemData();
-	if(itemData == NULL)return;
+	if (itemData == NULL)
+		return;
 
 	int objBlendType = GetBlendType();
 	StgItemRenderer* renderer = itemData->GetRenderer();
-	if(renderer == NULL)return;
+	if (renderer == NULL)
+		return;
 
 	D3DXMATRIX matScale;
 	D3DXMATRIX matRot;
@@ -1089,21 +1018,17 @@ void StgItemObject_User::RenderOnItemManager(D3DXMATRIX mat)
 		//上にはみ出している
 		bool bOutY = false;
 		rcSrc = itemData->GetRect(frameWork_);
-		if(position_.y + (rcSrc.bottom - rcSrc.top) / 2 <= 0)
-		{
+		if (position_.y + (rcSrc.bottom - rcSrc.top) / 2 <= 0) {
 			bOutY = true;
 			rcSrc = itemData->GetOut();
 		}
 
 		double angleZ = angle_.z;
-		if(!bOutY)
-		{
+		if (!bOutY) {
 			D3DXMatrixScaling(&matScale, scale_.x, scale_.y, scale_.z);
 			D3DXMatrixRotationYawPitchRoll(&matRot, D3DXToRadian(angle_.y), D3DXToRadian(angle_.x), D3DXToRadian(angleZ));
 			D3DXMatrixTranslation(&matTrans, position_.x, position_.y, position_.z);
-		}
-		else
-		{
+		} else {
 			D3DXMatrixIdentity(&matScale);
 			D3DXMatrixIdentity(&matRot);
 			D3DXMatrixTranslation(&matTrans, position_.x, (rcSrc.bottom - rcSrc.top) / 2, position_.z);
@@ -1115,10 +1040,9 @@ void StgItemObject_User::RenderOnItemManager(D3DXMATRIX mat)
 
 		color = color_;
 		double alpha = itemData->GetAlpha() / 255.0;
-		if(bBlendAddRGB)
+		if (bBlendAddRGB)
 			color = ColorAccess::ApplyAlpha(color, alpha);
-		else
-		{
+		else {
 			int colorA = ColorAccess::GetColorA(color);
 			color = ColorAccess::SetColorA(color, alpha * colorA);
 		}
@@ -1126,19 +1050,20 @@ void StgItemObject_User::RenderOnItemManager(D3DXMATRIX mat)
 
 	int width = rcSrc.right - rcSrc.left;
 	int height = rcSrc.bottom - rcSrc.top;
-	RECT rcDest = {-width / 2, -height / 2, width / 2, height / 2};
-	if(width % 2 == 1)rcDest.right += 1;
-	if(height % 2 == 1)rcDest.bottom += 1;
+	RECT rcDest = { -width / 2, -height / 2, width / 2, height / 2 };
+	if (width % 2 == 1)
+		rcDest.right += 1;
+	if (height % 2 == 1)
+		rcDest.bottom += 1;
 
 	//if(bIntersected_)color = D3DCOLOR_ARGB(255, 255, 0, 0);//接触テスト
 
 	VERTEX_TLX verts[4];
-	int srcX[] = {rcSrc.left, rcSrc.right, rcSrc.left, rcSrc.right};
-	int srcY[] = {rcSrc.top, rcSrc.top, rcSrc.bottom, rcSrc.bottom};
-	int destX[] = {rcDest.left, rcDest.right, rcDest.left, rcDest.right};
-	int destY[] = {rcDest.top, rcDest.top, rcDest.bottom, rcDest.bottom};
-	for(int iVert = 0 ;iVert < 4 ; iVert++)
-	{
+	int srcX[] = { rcSrc.left, rcSrc.right, rcSrc.left, rcSrc.right };
+	int srcY[] = { rcSrc.top, rcSrc.top, rcSrc.bottom, rcSrc.bottom };
+	int destX[] = { rcDest.left, rcDest.right, rcDest.left, rcDest.right };
+	int destY[] = { rcDest.top, rcDest.top, rcDest.bottom, rcDest.bottom };
+	for (int iVert = 0; iVert < 4; iVert++) {
 		_SetVertexUV(verts[iVert], srcX[iVert], srcY[iVert]);
 		_SetVertexPosition(verts[iVert], destX[iVert], destY[iVert]);
 		_SetVertexColorARGB(verts[iVert], color);
@@ -1154,7 +1079,7 @@ void StgItemObject_User::RenderOnItemManager(D3DXMATRIX mat)
 }
 void StgItemObject_User::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget)
 {
-	if(bChangeItemScore_)
+	if (bChangeItemScore_)
 		_CreateScoreItem();
 	stageController_->GetStageInformation()->AddScore(score_);
 
@@ -1167,11 +1092,11 @@ void StgItemObject_User::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync 
 	objectManager->DeleteObject(GetObjectID());
 }
 
-
 /**********************************************************
 //StgMovePattern_Item
 **********************************************************/
-StgMovePattern_Item::StgMovePattern_Item(StgMoveObject* target) : StgMovePattern(target)
+StgMovePattern_Item::StgMovePattern_Item(StgMoveObject* target)
+	: StgMovePattern(target)
 {
 	frame_ = 0;
 	typeMove_ = MOVE_DOWN;
@@ -1186,15 +1111,12 @@ void StgMovePattern_Item::Move()
 
 	double px = target_->GetPositionX();
 	double py = target_->GetPositionY();
-	if(typeMove_ == MOVE_TOPLAYER || itemObject->IsMoveToPlayer())
-	{
+	if (typeMove_ == MOVE_TOPLAYER || itemObject->IsMoveToPlayer()) {
 		speed_ = 8;
 		ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController->GetPlayerObject();
 		double angle = atan2(objPlayer->GetY() - py, objPlayer->GetX() - px);
 		angDirection_ = Math::RadianToDegree(angle);
-	}
-	else if(typeMove_ == MOVE_TOPOSITION_A)
-	{
+	} else if (typeMove_ == MOVE_TOPOSITION_A) {
 		double tarX = px;
 		double tarY = py;
 
@@ -1204,27 +1126,22 @@ void StgMovePattern_Item::Move()
 
 		double angle = atan2(toY - tarY, toX - tarX);
 		angDirection_ = Math::RadianToDegree(angle);
-		if(frame_ == 60)
-		{
+		if (frame_ == 60) {
 			speed_ = 0;
 			angDirection_ = 90;
 			typeMove_ = MOVE_DOWN;
 		}
-	}
-	else if(typeMove_ == MOVE_DOWN)
-	{
-		speed_ += 3.0f/60.0f;
-		if(speed_ > 2.5f)speed_ = 2.5f;
+	} else if (typeMove_ == MOVE_DOWN) {
+		speed_ += 3.0f / 60.0f;
+		if (speed_ > 2.5f)
+			speed_ = 2.5f;
 		angDirection_ = 90;
-	}
-	else if(typeMove_ == MOVE_SCORE)
-	{
+	} else if (typeMove_ == MOVE_SCORE) {
 		speed_ = 1;
 		angDirection_ = 270;
 	}
 
-	if(typeMove_ != MOVE_NONE)
-	{
+	if (typeMove_ != MOVE_NONE) {
 		double sx = speed_ * cos(Math::DegreeToRadian(angDirection_));
 		double sy = speed_ * sin(Math::DegreeToRadian(angDirection_));
 		px = target_->GetPositionX() + sx;
@@ -1235,4 +1152,3 @@ void StgMovePattern_Item::Move()
 
 	frame_++;
 }
-

--- a/source/TouhouDanmakufu/Common/StgItem.hpp
+++ b/source/TouhouDanmakufu/Common/StgItem.hpp
@@ -1,8 +1,8 @@
 #ifndef __TOUHOUDANMAKUFU_DNHSTG_ITEM__
 #define __TOUHOUDANMAKUFU_DNHSTG_ITEM__
 
-#include"StgCommon.hpp"
-#include"StgIntersection.hpp"
+#include "StgCommon.hpp"
+#include "StgIntersection.hpp"
 
 class StgItemDataList;
 class StgItemObject;
@@ -11,304 +11,304 @@ class StgItemRenderer;
 /**********************************************************
 //StgItemManager
 **********************************************************/
-class StgItemManager
-{
-		StgStageController* stageController_;
-		ref_count_ptr<SpriteList2D>::unsync listSpriteItem_;
-		ref_count_ptr<SpriteList2D>::unsync listSpriteDigit_;
-		ref_count_ptr<StgItemDataList>::unsync listItemData_;
+class StgItemManager {
+public:
+	StgItemManager(StgStageController* stageController);
+	virtual ~StgItemManager();
+	void Work();
+	void Render(int targetPriority);
 
-		std::list<ref_count_ptr<StgItemObject>::unsync > listObj_;
-		std::set<int> listItemTypeToPlayer_;
-		std::list<DxCircle> listCircleToPlayer_;
-		bool bAllItemToPlayer_;
-		bool bCancelToPlayer_;
-		bool bDefaultBonusItemEnable_;
+	void AddItem(ref_count_ptr<StgItemObject>::unsync obj) { listObj_.push_back(obj); }
+	int GetItemCount() { return listObj_.size(); }
 
+	SpriteList2D* GetItemRenderer() { return listSpriteItem_.GetPointer(); }
+	SpriteList2D* GetDigitRenderer() { return listSpriteDigit_.GetPointer(); }
+	std::vector<bool> GetValidRenderPriorityList();
 
-	public:
-		StgItemManager(StgStageController* stageController);
-		virtual ~StgItemManager();
-		void Work();
-		void Render(int targetPriority);
+	StgItemDataList* GetItemDataList() { return listItemData_.GetPointer(); }
+	bool LoadItemData(std::wstring path, bool bReload = false);
 
-		void AddItem(ref_count_ptr<StgItemObject>::unsync obj){listObj_.push_back(obj);}
-		int GetItemCount(){return listObj_.size();}
+	ref_count_ptr<StgItemObject>::unsync CreateItem(int type);
 
-		SpriteList2D* GetItemRenderer(){return listSpriteItem_.GetPointer();}
-		SpriteList2D* GetDigitRenderer(){return listSpriteDigit_.GetPointer();}
-		std::vector<bool> GetValidRenderPriorityList();
+	void CollectItemsAll();
+	void CollectItemsByType(int type);
+	void CollectItemsInCircle(DxCircle circle);
+	void CancelCollectItems();
 
-		StgItemDataList* GetItemDataList(){return listItemData_.GetPointer();}
-		bool LoadItemData(std::wstring path, bool bReload = false);
+	bool IsDefaultBonusItemEnable() { return bDefaultBonusItemEnable_; }
+	void SetDefaultBonusItemEnable(bool bEnable) { bDefaultBonusItemEnable_ = bEnable; }
 
-		ref_count_ptr<StgItemObject>::unsync CreateItem(int type);
+private:
+	StgStageController* stageController_;
+	ref_count_ptr<SpriteList2D>::unsync listSpriteItem_;
+	ref_count_ptr<SpriteList2D>::unsync listSpriteDigit_;
+	ref_count_ptr<StgItemDataList>::unsync listItemData_;
 
-		void CollectItemsAll();
-		void CollectItemsByType(int type);
-		void CollectItemsInCircle(DxCircle circle);
-		void CancelCollectItems();
-
-		bool IsDefaultBonusItemEnable(){return bDefaultBonusItemEnable_;}
-		void SetDefaultBonusItemEnable(bool bEnable){bDefaultBonusItemEnable_ = bEnable;}
+	std::list<ref_count_ptr<StgItemObject>::unsync> listObj_;
+	std::set<int> listItemTypeToPlayer_;
+	std::list<DxCircle> listCircleToPlayer_;
+	bool bAllItemToPlayer_;
+	bool bCancelToPlayer_;
+	bool bDefaultBonusItemEnable_;
 };
 
 /**********************************************************
 //StgItemDataList
 **********************************************************/
-class StgItemDataList
-{
-	public:
-		enum
-		{
-			RENDER_TYPE_COUNT = 3,
-			RENDER_ALPHA = 0,
-			RENDER_ADD_RGB,
-			RENDER_ADD_ARGB,
-		};
-	private:
-		std::set<std::wstring> listReadPath_;
-		std::vector<ref_count_ptr<Texture> > listTexture_;
-		std::vector<std::vector<ref_count_ptr<StgItemRenderer>::unsync > >listRenderer_;
-		std::vector<ref_count_ptr<StgItemData>::unsync > listData_;
+class StgItemDataList {
+public:
+	enum {
+		RENDER_TYPE_COUNT = 3,
+		RENDER_ALPHA = 0,
+		RENDER_ADD_RGB,
+		RENDER_ADD_ARGB,
+	};
 
-		void _ScanItem(std::vector<ref_count_ptr<StgItemData>::unsync >& listData, Scanner& scanner);
-		void _ScanAnimation(ref_count_ptr<StgItemData>::unsync itemData, Scanner& scanner);
-		std::vector<std::wstring> _GetArgumentList(Scanner& scanner);
-	public:
-		StgItemDataList();
-		virtual ~StgItemDataList();
+public:
+	StgItemDataList();
+	virtual ~StgItemDataList();
 
-		int GetTextureCount(){return listTexture_.size();}
-		ref_count_ptr<Texture> GetTexture(int index){return listTexture_[index];}
-		ref_count_ptr<StgItemRenderer>::unsync GetRenderer(int index, int typeRender){return listRenderer_[typeRender][index];}
-		std::vector<ref_count_ptr<StgItemRenderer>::unsync >* GetRendererList(int typeRender){return &listRenderer_[typeRender];}
+	int GetTextureCount() { return listTexture_.size(); }
+	ref_count_ptr<Texture> GetTexture(int index) { return listTexture_[index]; }
+	ref_count_ptr<StgItemRenderer>::unsync GetRenderer(int index, int typeRender) { return listRenderer_[typeRender][index]; }
+	std::vector<ref_count_ptr<StgItemRenderer>::unsync>* GetRendererList(int typeRender) { return &listRenderer_[typeRender]; }
 
-		ref_count_ptr<StgItemData>::unsync GetData(int id){return (id >= 0 && id < listData_.size()) ? listData_[id] : NULL;}
+	ref_count_ptr<StgItemData>::unsync GetData(int id) { return (id >= 0 && id < listData_.size()) ? listData_[id] : NULL; }
 
-		bool AddItemDataList(std::wstring path, bool bReload);
+	bool AddItemDataList(std::wstring path, bool bReload);
+
+private:
+	void _ScanItem(std::vector<ref_count_ptr<StgItemData>::unsync>& listData, Scanner& scanner);
+	void _ScanAnimation(ref_count_ptr<StgItemData>::unsync itemData, Scanner& scanner);
+	std::vector<std::wstring> _GetArgumentList(Scanner& scanner);
+
+	std::set<std::wstring> listReadPath_;
+	std::vector<ref_count_ptr<Texture>> listTexture_;
+	std::vector<std::vector<ref_count_ptr<StgItemRenderer>::unsync>> listRenderer_;
+	std::vector<ref_count_ptr<StgItemData>::unsync> listData_;
+
 };
 
-class StgItemData
-{
+class StgItemData {
 	friend StgItemDataList;
-	private:
-		struct AnimationData
-		{
-			RECT rcSrc_;
-			int frame_;
-		};
 
-		StgItemDataList* listItemData_;
-		int indexTexture_;
-
-		int typeItem_;
-		int typeRender_;
+private:
+	struct AnimationData {
 		RECT rcSrc_;
-		RECT rcOut_;
-		int alpha_;
+		int frame_;
+	};
 
-		std::vector<AnimationData> listAnime_;
-		int totalAnimeFrame_;
+public:
+	StgItemData(StgItemDataList* listItemData);
+	virtual ~StgItemData();
 
-	public:
-		StgItemData(StgItemDataList* listItemData);
-		virtual ~StgItemData();
+	int GetTextureIndex() { return indexTexture_; }
+	int GetItemType() { return typeItem_; }
+	int GetRenderType() { return typeRender_; }
+	RECT GetRect(int frame);
+	RECT GetOut() { return rcOut_; }
+	int GetAlpha() { return alpha_; }
 
-		int GetTextureIndex(){return indexTexture_;}
-		int GetItemType(){return typeItem_;}
-		int GetRenderType(){return typeRender_;}
-		RECT GetRect(int frame);
-		RECT GetOut(){return rcOut_;}
-		int GetAlpha(){return alpha_;}
+	ref_count_ptr<Texture> GetTexture();
+	StgItemRenderer* GetRenderer();
+	StgItemRenderer* GetRenderer(int type);
 
-		ref_count_ptr<Texture> GetTexture();
-		StgItemRenderer* GetRenderer();
-		StgItemRenderer* GetRenderer(int type);
+private:
+	StgItemDataList* listItemData_;
+	int indexTexture_;
+
+	int typeItem_;
+	int typeRender_;
+	RECT rcSrc_;
+	RECT rcOut_;
+	int alpha_;
+
+	std::vector<AnimationData> listAnime_;
+	int totalAnimeFrame_;
 };
 
 /**********************************************************
 //StgItemRenderer
 **********************************************************/
-class StgItemRenderer : public RenderObjectTLX
-{
-		int countRenderVertex_;
-	public:
-		StgItemRenderer();
-		virtual int GetVertexCount();
-		virtual void Render();
-		void AddVertex(VERTEX_TLX& vertex);
-		void AddSquareVertex(VERTEX_TLX* listVertex);
+class StgItemRenderer : public RenderObjectTLX {
+public:
+	StgItemRenderer();
+	virtual int GetVertexCount();
+	virtual void Render();
+	void AddVertex(VERTEX_TLX& vertex);
+	void AddSquareVertex(VERTEX_TLX* listVertex);
+
+private:
+	int countRenderVertex_;
 };
-
-
 
 /**********************************************************
 //StgItemObject
 **********************************************************/
-class StgItemObject : public DxScriptRenderObject, public StgMoveObject, public StgIntersectionObject
-{
-	public:
-		enum
-		{
-			ITEM_1UP = -256*256,
-			ITEM_1UP_S,
-			ITEM_SPELL,
-			ITEM_SPELL_S,
-			ITEM_POWER,
-			ITEM_POWER_S,
-			ITEM_POINT,
-			ITEM_POINT_S,
+class StgItemObject : public DxScriptRenderObject, public StgMoveObject, public StgIntersectionObject {
+public:
+	enum {
+		ITEM_1UP = -256 * 256,
+		ITEM_1UP_S,
+		ITEM_SPELL,
+		ITEM_SPELL_S,
+		ITEM_POWER,
+		ITEM_POWER_S,
+		ITEM_POINT,
+		ITEM_POINT_S,
 
-			ITEM_SCORE,
-			ITEM_BONUS,
+		ITEM_SCORE,
+		ITEM_BONUS,
 
-			ITEM_USER = 0,
-		};
-	protected:
-		StgStageController* stageController_;
-		int typeItem_;
-		D3DCOLOR color_;
+		ITEM_USER = 0,
+	};
 
-		_int64 score_;
-		bool bMoveToPlayer_; //自機移動フラグ
-		bool bPermitMoveToPlayer_; //自機自動回収許可
-		bool bChangeItemScore_;
+public:
+	StgItemObject(StgStageController* stageController);
+	virtual void Work();
+	virtual void Render() {} //一括で描画するためオブジェクト管理での描画はしない
+	virtual void RenderOnItemManager(D3DXMATRIX mat);
+	virtual void SetRenderState() {}
+	virtual void Activate() {}
 
-		void _DeleteInAutoClip();
-		void _CreateScoreItem();
-		void _NotifyEventToPlayerScript(std::vector<long double>& listValue);
-		void _NotifyEventToItemScript(std::vector<long double>& listValue);
-	public:
-		StgItemObject(StgStageController* stageController);
-		virtual void Work();
-		virtual void Render(){}//一括で描画するためオブジェクト管理での描画はしない
-		virtual void RenderOnItemManager(D3DXMATRIX mat);
-		virtual void SetRenderState(){}
-		virtual void Activate(){}
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) = 0;
 
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) = 0;
+	virtual void SetX(double x)
+	{
+		posX_ = x;
+		DxScriptRenderObject::SetX(x);
+	}
+	virtual void SetY(double y)
+	{
+		posY_ = y;
+		DxScriptRenderObject::SetY(y);
+	}
+	virtual void SetColor(int r, int g, int b);
+	virtual void SetAlpha(int alpha);
+	void SetToPosition(POINT pos);
 
-		virtual void SetX(double x){posX_ = x; DxScriptRenderObject::SetX(x);}
-		virtual void SetY(double y){posY_ = y; DxScriptRenderObject::SetY(y);}
-		virtual void SetColor(int r, int g, int b);
-		virtual void SetAlpha(int alpha);
-		void SetToPosition(POINT pos);
+	_int64 GetScore() { return score_; }
+	void SetScore(_int64 score) { score_ = score; }
+	bool IsMoveToPlayer() { return bMoveToPlayer_; }
+	void SetMoveToPlayer(bool b) { bMoveToPlayer_ = b; }
+	bool IsPermitMoveToPlayer() { return bPermitMoveToPlayer_; }
+	void SetPermitMoveToPlayer(bool bPermit) { bPermitMoveToPlayer_ = bPermit; }
+	void SetChangeItemScore(bool b) { bChangeItemScore_ = b; }
 
-		_int64 GetScore(){return score_;}
-		void SetScore(_int64 score){score_ = score;}
-		bool IsMoveToPlayer(){return bMoveToPlayer_;}
-		void SetMoveToPlayer(bool b){bMoveToPlayer_ = b;}
-		bool IsPermitMoveToPlayer(){return bPermitMoveToPlayer_;}
-		void SetPermitMoveToPlayer(bool bPermit){bPermitMoveToPlayer_ = bPermit;}
-		void SetChangeItemScore(bool b){bChangeItemScore_ = b;}
+	int GetMoveType();
+	void SetMoveType(int type);
 
-		int GetMoveType();
-		void SetMoveType(int type);
+	int GetItemType() { return typeItem_; }
+	void SetItemType(int type) { typeItem_ = type; }
+	StgStageController* GetStageController() { return stageController_; }
 
-		int GetItemType(){return typeItem_;}
-		void SetItemType(int type){typeItem_ = type;}
-		StgStageController* GetStageController(){return stageController_;}
+protected:
+	void _DeleteInAutoClip();
+	void _CreateScoreItem();
+	void _NotifyEventToPlayerScript(std::vector<long double>& listValue);
+	void _NotifyEventToItemScript(std::vector<long double>& listValue);
+
+	StgStageController* stageController_;
+	int typeItem_;
+	D3DCOLOR color_;
+
+	_int64 score_;
+	bool bMoveToPlayer_; //自機移動フラグ
+	bool bPermitMoveToPlayer_; //自機自動回収許可
+	bool bChangeItemScore_;
 };
 
-class StgItemObject_1UP : public StgItemObject
-{
-	public:
-		StgItemObject_1UP(StgStageController* stageController);
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+class StgItemObject_1UP : public StgItemObject {
+public:
+	StgItemObject_1UP(StgStageController* stageController);
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
 };
 
-class StgItemObject_Bomb : public StgItemObject
-{
-	public:
-		StgItemObject_Bomb(StgStageController* stageController);
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+class StgItemObject_Bomb : public StgItemObject {
+public:
+	StgItemObject_Bomb(StgStageController* stageController);
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
 };
 
-class StgItemObject_Power : public StgItemObject
-{
-	public:
-		StgItemObject_Power(StgStageController* stageController);
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+class StgItemObject_Power : public StgItemObject {
+public:
+	StgItemObject_Power(StgStageController* stageController);
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
 };
 
-class StgItemObject_Point : public StgItemObject
-{
-	public:
-		StgItemObject_Point(StgStageController* stageController);
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+class StgItemObject_Point : public StgItemObject {
+public:
+	StgItemObject_Point(StgStageController* stageController);
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
 };
 
-class StgItemObject_Bonus : public StgItemObject
-{
-	public:
-		StgItemObject_Bonus(StgStageController* stageController);
-		virtual void Work();
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+class StgItemObject_Bonus : public StgItemObject {
+public:
+	StgItemObject_Bonus(StgStageController* stageController);
+	virtual void Work();
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
 };
 
-class StgItemObject_Score : public StgItemObject
-{
-		int frameDelete_;
-	public:
-		StgItemObject_Score(StgStageController* stageController);
-		virtual void Work();
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+class StgItemObject_Score : public StgItemObject {
+public:
+	StgItemObject_Score(StgStageController* stageController);
+	virtual void Work();
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+
+private:
+	int frameDelete_;
 };
 
-class StgItemObject_User : public StgItemObject
-{
-		int frameWork_;
-		int idImage_;
+class StgItemObject_User : public StgItemObject {
+public:
+	StgItemObject_User(StgStageController* stageController);
+	virtual void Work();
+	virtual void RenderOnItemManager(D3DXMATRIX mat);
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
 
-		StgItemData* _GetItemData();
-		void _SetVertexPosition(VERTEX_TLX& vertex, float x, float y, float z = 1.0f, float w = 1.0f);
-		void _SetVertexUV(VERTEX_TLX& vertex, float u, float v);
-		void _SetVertexColorARGB(VERTEX_TLX& vertex, D3DCOLOR color);
-	public:
-		StgItemObject_User(StgStageController* stageController);
-		virtual void Work();
-		virtual void RenderOnItemManager(D3DXMATRIX mat);
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	void SetImageID(int id);
 
-		void SetImageID(int id);
+private:
+	StgItemData* _GetItemData();
+	void _SetVertexPosition(VERTEX_TLX& vertex, float x, float y, float z = 1.0f, float w = 1.0f);
+	void _SetVertexUV(VERTEX_TLX& vertex, float u, float v);
+	void _SetVertexColorARGB(VERTEX_TLX& vertex, D3DCOLOR color);
+
+	int frameWork_;
+	int idImage_;
 };
 
 /**********************************************************
 //StgMovePattern_Item
 **********************************************************/
-class StgMovePattern_Item : public StgMovePattern
-{
-	public:
-		enum
-		{
-			MOVE_NONE,
-			MOVE_TOPOSITION_A,//指定ポイントへの移動(60フレーム)
-			MOVE_DOWN,//下降
-			MOVE_TOPLAYER,//自機へ移動
-			MOVE_SCORE,//得点(上昇)
-		};
+class StgMovePattern_Item : public StgMovePattern {
+public:
+	enum {
+		MOVE_NONE,
+		MOVE_TOPOSITION_A, //指定ポイントへの移動(60フレーム)
+		MOVE_DOWN, //下降
+		MOVE_TOPLAYER, //自機へ移動
+		MOVE_SCORE, //得点(上昇)
+	};
 
-	protected:
-		int frame_;
-		int typeMove_;
-		double speed_;
-		double angDirection_;
+public:
+	StgMovePattern_Item(StgMoveObject* target);
+	virtual void Move();
+	int GetType() { return TYPE_OTHER; }
+	virtual double GetSpeed() { return 0; }
+	virtual double GetDirectionAngle() { return 0; }
+	void SetToPosition(POINT pos) { posTo_ = pos; }
 
-		POINT posTo_;
+	int GetItemMoveType() { return typeMove_; }
+	void SetItemMoveType(int type) { typeMove_ = type; }
 
-	public:
-		StgMovePattern_Item(StgMoveObject* target);
-		virtual void Move();
-		int GetType(){return TYPE_OTHER;}
-		virtual double GetSpeed(){return 0;}
-		virtual double GetDirectionAngle(){return 0;}
-		void SetToPosition(POINT pos){posTo_ = pos;}
+protected:
+	int frame_;
+	int typeMove_;
+	double speed_;
+	double angDirection_;
 
-		int GetItemMoveType(){return typeMove_;}
-		void SetItemMoveType(int type){typeMove_ = type;}
+	POINT posTo_;
 };
 
-
 #endif
-

--- a/source/TouhouDanmakufu/Common/StgPackageController.cpp
+++ b/source/TouhouDanmakufu/Common/StgPackageController.cpp
@@ -1,5 +1,5 @@
-#include"StgPackageController.hpp"
-#include"StgSystem.hpp"
+#include "StgPackageController.hpp"
+#include "StgSystem.hpp"
 
 /**********************************************************
 //StgPackageController
@@ -7,7 +7,6 @@
 StgPackageController::StgPackageController(StgSystemController* systemController)
 {
 	systemController_ = systemController;
-
 }
 StgPackageController::~StgPackageController()
 {
@@ -33,12 +32,12 @@ void StgPackageController::Work()
 {
 	scriptManager_->Work();
 	//スクリプトが閉じられた場合は再度実行(描画の継ぎ目を目立たなくする)
-	if(scriptManager_->IsHasCloseScliptWork()) 
+	if (scriptManager_->IsHasCloseScliptWork())
 		scriptManager_->Work();
 }
 void StgPackageController::Render()
 {
-	//scriptManager_->Render();
+	// scriptManager_->Render();
 }
 void StgPackageController::RenderToTransitionTexture()
 {
@@ -89,5 +88,4 @@ void StgPackageInformation::FinishCurrentStage()
 
 	ref_count_ptr<StgPlayerInformation> infoPlayer = currentStageInfo->GetPlayerObjectInformation();
 	nextStageStartData_->SetPrevPlayerInformation(infoPlayer);
-
 }

--- a/source/TouhouDanmakufu/Common/StgPackageController.hpp
+++ b/source/TouhouDanmakufu/Common/StgPackageController.hpp
@@ -1,69 +1,68 @@
 #ifndef __TOUHOUDANMAKUFU_DNHSTG_PACKAGECONTROLLER__
 #define __TOUHOUDANMAKUFU_DNHSTG_PACKAGECONTROLLER__
 
-#include"StgCommon.hpp"
-#include"StgPackageScript.hpp"
+#include "StgCommon.hpp"
+#include "StgPackageScript.hpp"
 
 class StgPackageInformation;
 /**********************************************************
 //StgPackageController
 **********************************************************/
-class StgPackageController
-{
-	private:
-		StgSystemController* systemController_;
-		ref_count_ptr<StgPackageInformation> infoPackage_;
-		ref_count_ptr<StgPackageScriptManager> scriptManager_;
+class StgPackageController {
+public:
+	StgPackageController(StgSystemController* systemController);
+	virtual ~StgPackageController();
+	void Initialize();
 
-	public:
-		StgPackageController(StgSystemController* systemController);
-		virtual ~StgPackageController();
-		void Initialize();
+	void Work();
+	void Render();
+	void RenderToTransitionTexture();
 
-		void Work();
-		void Render();
-		void RenderToTransitionTexture();
+	StgSystemController* GetSystemController() { return systemController_; }
+	ref_count_ptr<StgPackageInformation> GetPackageInformation() { return infoPackage_; }
 
-		StgSystemController* GetSystemController(){return systemController_;}
-		ref_count_ptr<StgPackageInformation> GetPackageInformation(){return infoPackage_;}
+	ref_count_ptr<StgPackageScriptManager> GetScriptManager() { return scriptManager_; }
+	ref_count_ptr<DxScriptObjectManager> GetMainObjectManager() { return scriptManager_->GetObjectManager(); }
 
-		ref_count_ptr<StgPackageScriptManager> GetScriptManager(){return scriptManager_;}
-		ref_count_ptr<DxScriptObjectManager> GetMainObjectManager(){return scriptManager_->GetObjectManager();}
+private:
+	StgSystemController* systemController_;
+	ref_count_ptr<StgPackageInformation> infoPackage_;
+	ref_count_ptr<StgPackageScriptManager> scriptManager_;
 };
 
 /**********************************************************
 //StgPackageInformation
 **********************************************************/
-class StgPackageInformation
-{
-		bool bEndPackage_;
-		ref_count_ptr<StgStageStartData> nextStageStartData_;
-		ref_count_ptr<ReplayInformation> infoReplay_;
-		std::vector<ref_count_ptr<StgStageStartData> > listStageData_;
-		ref_count_ptr<ScriptInformation> infoMainScript_;
-		int timeStart_;
+class StgPackageInformation {
+public:
+	StgPackageInformation();
+	virtual ~StgPackageInformation();
 
-	public:
-		StgPackageInformation();
-		virtual ~StgPackageInformation();
+	bool IsEnd() { return bEndPackage_; }
+	void SetEnd() { bEndPackage_ = true; }
 
-		bool IsEnd(){return bEndPackage_;}
-		void SetEnd(){bEndPackage_ = true;}
+	void InitializeStageData();
+	void FinishCurrentStage();
+	ref_count_ptr<StgStageStartData> GetNextStageData() { return nextStageStartData_; }
+	void SetNextStageData(ref_count_ptr<StgStageStartData> data) { nextStageStartData_ = data; }
+	std::vector<ref_count_ptr<StgStageStartData>>& GetStageDataList() { return listStageData_; }
 
-		void InitializeStageData();
-		void FinishCurrentStage();
-		ref_count_ptr<StgStageStartData> GetNextStageData(){return nextStageStartData_;}
-		void SetNextStageData(ref_count_ptr<StgStageStartData> data){nextStageStartData_ = data;}
-		std::vector<ref_count_ptr<StgStageStartData> >& GetStageDataList(){return listStageData_;}
+	ref_count_ptr<ReplayInformation> GetReplayInformation() { return infoReplay_; }
+	void SetReplayInformation(ref_count_ptr<ReplayInformation> info) { infoReplay_ = info; }
 
-		ref_count_ptr<ReplayInformation> GetReplayInformation(){return infoReplay_;}
-		void SetReplayInformation(ref_count_ptr<ReplayInformation> info){infoReplay_ = info;}
+	ref_count_ptr<ScriptInformation> GetMainScriptInformation() { return infoMainScript_; }
+	void SetMainScriptInformation(ref_count_ptr<ScriptInformation> info) { infoMainScript_ = info; }
 
-		ref_count_ptr<ScriptInformation> GetMainScriptInformation(){return infoMainScript_;}
-		void SetMainScriptInformation(ref_count_ptr<ScriptInformation> info){infoMainScript_ = info;}
+	int GetPackageStartTime() { return timeStart_; }
+	void SetPackageStartTime(int time) { timeStart_ = time; }
 
-		int GetPackageStartTime(){return timeStart_;}
-		void SetPackageStartTime(int time){timeStart_ = time;}
+private:
+	bool bEndPackage_;
+	ref_count_ptr<StgStageStartData> nextStageStartData_;
+	ref_count_ptr<ReplayInformation> infoReplay_;
+	std::vector<ref_count_ptr<StgStageStartData>> listStageData_;
+	ref_count_ptr<ScriptInformation> infoMainScript_;
+	int timeStart_;
 };
 
 #endif

--- a/source/TouhouDanmakufu/Common/StgPackageScript.cpp
+++ b/source/TouhouDanmakufu/Common/StgPackageScript.cpp
@@ -1,6 +1,6 @@
-#include"StgPackageScript.hpp"
-#include"StgSystem.hpp"
-#include"StgPackageController.hpp"
+#include "StgPackageScript.hpp"
+#include "StgPackageController.hpp"
+#include "StgSystem.hpp"
 
 /**********************************************************
 //StgPackageScriptManager
@@ -15,16 +15,12 @@ StgPackageScriptManager::~StgPackageScriptManager()
 }
 void StgPackageScriptManager::Work()
 {
-	if(!IsError())
-	{
+	if (!IsError()) {
 		StgControlScriptManager::Work();
 		objectManager_->WorkObject();
-	}
-	else
-	{
+	} else {
 		systemController_->GetSystemInformation()->SetError(error_);
 	}
-
 }
 void StgPackageScriptManager::Render()
 {
@@ -33,15 +29,13 @@ void StgPackageScriptManager::Render()
 ref_count_ptr<ManagedScript> StgPackageScriptManager::Create(int type)
 {
 	ref_count_ptr<ManagedScript> res;
-	switch(type)
-	{
-		case StgPackageScript::TYPE_PACKAGE_MAIN:
-			res = new StgPackageScript(systemController_->GetPackageController());
-			break;
+	switch (type) {
+	case StgPackageScript::TYPE_PACKAGE_MAIN:
+		res = new StgPackageScript(systemController_->GetPackageController());
+		break;
 	}
 
-	if(res != NULL)
-	{
+	if (res != NULL) {
 		res->SetObjectManager(objectManager_);
 		res->SetScriptManager(this);
 	}
@@ -49,37 +43,36 @@ ref_count_ptr<ManagedScript> StgPackageScriptManager::Create(int type)
 	return res;
 }
 
-
 /**********************************************************
 //StgPackageScript
 **********************************************************/
-const function stgPackageFunction[] =  
-{
+const function stgPackageFunction[] = {
 	//パッケージ共通関数：パッケージ操作
-	{"ClosePackage", StgPackageScript::Func_ClosePackage, 0},
+	{ "ClosePackage", StgPackageScript::Func_ClosePackage, 0 },
 
 	//パッケージ共通関数：ステージ操作
-	{"InitializeStageScene", StgPackageScript::Func_InitializeStageScene, 0},
-	{"FinalizeStageScene", StgPackageScript::Func_FinalizeStageScene, 0},
-	{"StartStageScene", StgPackageScript::Func_StartStageScene, 0},
-	{"SetStageIndex", StgPackageScript::Func_SetStageIndex, 1},
-	{"SetStageMainScript", StgPackageScript::Func_SetStageMainScript, 1},
-	{"SetStagePlayerScript", StgPackageScript::Func_SetStagePlayerScript, 1},
-	{"SetStageReplayFile", StgPackageScript::Func_SetStageReplayFile, 1},
-	{"GetStageSceneState", StgPackageScript::Func_GetStageSceneState, 0},
-	{"GetStageSceneResult", StgPackageScript::Func_GetStageSceneResult, 0},
-	{"PauseStageScene", StgPackageScript::Func_PauseStageScene, 1},
-	{"TerminateStageScene", StgPackageScript::Func_TerminateStageScene, 0},
+	{ "InitializeStageScene", StgPackageScript::Func_InitializeStageScene, 0 },
+	{ "FinalizeStageScene", StgPackageScript::Func_FinalizeStageScene, 0 },
+	{ "StartStageScene", StgPackageScript::Func_StartStageScene, 0 },
+	{ "SetStageIndex", StgPackageScript::Func_SetStageIndex, 1 },
+	{ "SetStageMainScript", StgPackageScript::Func_SetStageMainScript, 1 },
+	{ "SetStagePlayerScript", StgPackageScript::Func_SetStagePlayerScript, 1 },
+	{ "SetStageReplayFile", StgPackageScript::Func_SetStageReplayFile, 1 },
+	{ "GetStageSceneState", StgPackageScript::Func_GetStageSceneState, 0 },
+	{ "GetStageSceneResult", StgPackageScript::Func_GetStageSceneResult, 0 },
+	{ "PauseStageScene", StgPackageScript::Func_PauseStageScene, 1 },
+	{ "TerminateStageScene", StgPackageScript::Func_TerminateStageScene, 0 },
 
 	//定数：
-	{"STAGE_STATE_FINISHED", constant<StgPackageScript::STAGE_STATE_FINISHED>::func, 0},
+	{ "STAGE_STATE_FINISHED", constant<StgPackageScript::STAGE_STATE_FINISHED>::func, 0 },
 
-	{"STAGE_RESULT_BREAK_OFF", constant<StgStageInformation::RESULT_BREAK_OFF>::func, 0},
-	{"STAGE_RESULT_PLAYER_DOWN", constant<StgStageInformation::RESULT_PLAYER_DOWN>::func, 0},
-	{"STAGE_RESULT_CLEARED", constant<StgStageInformation::RESULT_CLEARED>::func, 0},
+	{ "STAGE_RESULT_BREAK_OFF", constant<StgStageInformation::RESULT_BREAK_OFF>::func, 0 },
+	{ "STAGE_RESULT_PLAYER_DOWN", constant<StgStageInformation::RESULT_PLAYER_DOWN>::func, 0 },
+	{ "STAGE_RESULT_CLEARED", constant<StgStageInformation::RESULT_CLEARED>::func, 0 },
 
 };
-StgPackageScript::StgPackageScript(StgPackageController* packageController) : StgControlScript(packageController->GetSystemController())
+StgPackageScript::StgPackageScript(StgPackageController* packageController)
+	: StgControlScript(packageController->GetSystemController())
 {
 	_AddFunction(stgPackageFunction, sizeof(stgPackageFunction) / sizeof(function));
 
@@ -90,23 +83,24 @@ void StgPackageScript::_CheckNextStageExists()
 {
 	ref_count_ptr<StgPackageInformation> infoPackage = packageController_->GetPackageInformation();
 	ref_count_ptr<StgStageStartData> nextStageData = infoPackage->GetNextStageData();
-	if(nextStageData == NULL)RaiseError(L"not initialized stage data");
+	if (nextStageData == NULL)
+		RaiseError(L"not initialized stage data");
 }
 
 //パッケージ共通関数：パッケージ操作
-gstd::value StgPackageScript::Func_ClosePackage(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgPackageScript::Func_ClosePackage(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgPackageScript* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 
 	ref_count_ptr<StgPackageInformation> infoPackage = packageController->GetPackageInformation();
 	infoPackage->SetEnd();
-	
+
 	return value();
 }
 
 //パッケージ共通関数：ステージ操作
-gstd::value StgPackageScript::Func_InitializeStageScene(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgPackageScript::Func_InitializeStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgPackageScript* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
@@ -117,10 +111,10 @@ gstd::value StgPackageScript::Func_InitializeStageScene(gstd::script_machine* ma
 
 	ref_count_ptr<StgPackageInformation> infoPackage = packageController->GetPackageInformation();
 	infoPackage->InitializeStageData();
-	
+
 	return value();
 }
-gstd::value StgPackageScript::Func_FinalizeStageScene(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgPackageScript::Func_FinalizeStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgPackageScript* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
@@ -128,24 +122,24 @@ gstd::value StgPackageScript::Func_FinalizeStageScene(gstd::script_machine* mach
 	ref_count_ptr<StgSystemInformation> infoSystem = systemController->GetSystemInformation();
 
 	ref_count_ptr<StgPackageInformation> infoPackage = packageController->GetPackageInformation();
-	if(infoPackage->GetNextStageData() != NULL && infoPackage->GetNextStageData()->GetPrevStageInformation() == NULL)
+	if (infoPackage->GetNextStageData() != NULL && infoPackage->GetNextStageData()->GetPrevStageInformation() == NULL)
 		script->RaiseError(L"not finished stage");
 
-	std::vector<ref_count_ptr<StgStageStartData> > listStage = infoPackage->GetStageDataList();
-	if(listStage.size() > 0)
-	{
+	std::vector<ref_count_ptr<StgStageStartData>> listStage = infoPackage->GetStageDataList();
+	if (listStage.size() > 0) {
 		ref_count_ptr<StgStageStartData> stageData = listStage[listStage.size() - 1];
 		ref_count_ptr<StgStageInformation> infoStage = stageData->GetStageInformation();
 		bool bReplay = infoStage->IsReplay();
-		if(bReplay)return value();
+		if (bReplay)
+			return value();
 	}
 
 	ref_count_ptr<ReplayInformation> infoReplay = systemController->CreateReplayInformation();
-	infoSystem->SetActiveReplayInformation(infoReplay);	
+	infoSystem->SetActiveReplayInformation(infoReplay);
 
 	return value();
 }
-gstd::value StgPackageScript::Func_StartStageScene(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgPackageScript::Func_StartStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgPackageScript* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
@@ -161,22 +155,18 @@ gstd::value StgPackageScript::Func_StartStageScene(gstd::script_machine* machine
 	ref_count_ptr<ReplayInformation> infoReplay = infoPackage->GetReplayInformation();
 	std::wstring replayPlayerID;
 	std::wstring replayPlayerScriptFileName;
-	if(infoReplay != NULL)
-	{
+	if (infoReplay != NULL) {
 		ref_count_ptr<ReplayInformation::StageData> replayStageData = infoReplay->GetStageData(stageIndex);
-		if(replayStageData == NULL)
+		if (replayStageData == NULL)
 			script->RaiseError(L"invalid replay stage index");
 		nextStageData->SetStageReplayData(replayStageData);
 
 		//自機スクリプト
 		replayPlayerID = replayStageData->GetPlayerScriptID();
 		replayPlayerScriptFileName = replayStageData->GetPlayerScriptFileName();
-	}
-	else
-	{
+	} else {
 		ref_count_ptr<ScriptInformation> infoPlayer = infoStage->GetPlayerScriptInformation();
-		if(infoPlayer != NULL)
-		{
+		if (infoPlayer != NULL) {
 			replayPlayerID = infoPlayer->GetID();
 			replayPlayerScriptFileName = PathProperty::GetFileName(infoPlayer->GetScriptPath());
 		}
@@ -185,30 +175,28 @@ gstd::value StgPackageScript::Func_StartStageScene(gstd::script_machine* machine
 	//自機を検索
 	infoStage->SetPlayerScriptInformation(NULL);
 	ref_count_ptr<ScriptInformation> infoMain = infoSystem->GetMainScriptInformation();
-	std::vector<ref_count_ptr<ScriptInformation> > listPlayer;
+	std::vector<ref_count_ptr<ScriptInformation>> listPlayer;
 	std::vector<std::wstring> listPlayerPath = infoMain->GetPlayerList();
-	if(listPlayerPath.size() == 0)
-	{
+	if (listPlayerPath.size() == 0) {
 		std::wstring dir = EPathProperty::GetPlayerScriptRootDirectory();
 		listPlayer = ScriptInformation::FindPlayerScriptInformationList(dir);
-	}
-	else
-	{
+	} else {
 		listPlayer = infoMain->CreatePlayerScriptInformationList();
 	}
 
-	for(int iPlayer = 0 ; iPlayer < listPlayer.size() ; iPlayer++)
-	{
+	for (int iPlayer = 0; iPlayer < listPlayer.size(); iPlayer++) {
 		ref_count_ptr<ScriptInformation> tInfo = listPlayer[iPlayer];
-		if(tInfo->GetID() != replayPlayerID)continue;
+		if (tInfo->GetID() != replayPlayerID)
+			continue;
 		std::wstring tPlayerScriptFileName = PathProperty::GetFileName(tInfo->GetScriptPath());
-		if(tPlayerScriptFileName != replayPlayerScriptFileName)continue;
+		if (tPlayerScriptFileName != replayPlayerScriptFileName)
+			continue;
 
 		infoStage->SetPlayerScriptInformation(tInfo);
 		break;
 	}
 
-	if(infoStage->GetPlayerScriptInformation() == NULL)
+	if (infoStage->GetPlayerScriptInformation() == NULL)
 		script->RaiseError(L"player not found");
 
 	//packageController->RenderToTransitionTexture();
@@ -217,7 +205,7 @@ gstd::value StgPackageScript::Func_StartStageScene(gstd::script_machine* machine
 
 	return value();
 }
-gstd::value StgPackageScript::Func_SetStageIndex(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgPackageScript::Func_SetStageIndex(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgPackageScript* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
@@ -227,21 +215,19 @@ gstd::value StgPackageScript::Func_SetStageIndex(gstd::script_machine* machine, 
 	ref_count_ptr<StgStageStartData> nextStageData = infoPackage->GetNextStageData();
 	ref_count_ptr<StgStageInformation> infoStage = nextStageData->GetStageInformation();
 
-	int stageIndex = (int)argv[0].as_real();	
-	std::vector<ref_count_ptr<StgStageStartData> > listStage = infoPackage->GetStageDataList();
-	for(int iStage = 0 ; iStage < listStage.size() ;iStage++)
-	{
+	int stageIndex = (int)argv[0].as_real();
+	std::vector<ref_count_ptr<StgStageStartData>> listStage = infoPackage->GetStageDataList();
+	for (int iStage = 0; iStage < listStage.size(); iStage++) {
 		ref_count_ptr<StgStageStartData> stageData = listStage[iStage];
-		if(stageIndex == stageData->GetStageInformation()->GetStageIndex())
+		if (stageIndex == stageData->GetStageInformation()->GetStageIndex())
 			script->RaiseError(L"stage index already used");
 	}
 
-
 	infoStage->SetStageIndex(stageIndex);
-	
+
 	return value();
 }
-gstd::value StgPackageScript::Func_SetStageMainScript(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgPackageScript::Func_SetStageMainScript(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgPackageScript* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
@@ -253,8 +239,7 @@ gstd::value StgPackageScript::Func_SetStageMainScript(gstd::script_machine* mach
 
 	std::wstring path = argv[0].as_string();
 	ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-	if(reader == NULL || !reader->Open())
-	{
+	if (reader == NULL || !reader->Open()) {
 		std::wstring error = ErrorUtility::GetFileNotFoundErrorMessage(path);
 		script->RaiseError(error);
 	}
@@ -264,16 +249,15 @@ gstd::value StgPackageScript::Func_SetStageMainScript(gstd::script_machine* mach
 	source.resize(size);
 	reader->Read(&source[0], size);
 
-	ref_count_ptr<ScriptInformation> infoScript = 
-		ScriptInformation::CreateScriptInformation(path, L"", source, false);
-	if(infoScript == NULL)
+	ref_count_ptr<ScriptInformation> infoScript = ScriptInformation::CreateScriptInformation(path, L"", source, false);
+	if (infoScript == NULL)
 		script->RaiseError(ErrorUtility::GetFileNotFoundErrorMessage(path));
 
 	infoStage->SetMainScriptInformation(infoScript);
-	
+
 	return value();
 }
-gstd::value StgPackageScript::Func_SetStagePlayerScript(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgPackageScript::Func_SetStagePlayerScript(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgPackageScript* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
@@ -285,8 +269,7 @@ gstd::value StgPackageScript::Func_SetStagePlayerScript(gstd::script_machine* ma
 
 	std::wstring path = argv[0].as_string();
 	ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-	if(reader == NULL || !reader->Open())
-	{
+	if (reader == NULL || !reader->Open()) {
 		std::wstring error = ErrorUtility::GetFileNotFoundErrorMessage(path);
 		script->RaiseError(error);
 	}
@@ -296,13 +279,12 @@ gstd::value StgPackageScript::Func_SetStagePlayerScript(gstd::script_machine* ma
 	source.resize(size);
 	reader->Read(&source[0], size);
 
-	ref_count_ptr<ScriptInformation> infoScript = 
-		ScriptInformation::CreateScriptInformation(path, L"", source);
+	ref_count_ptr<ScriptInformation> infoScript = ScriptInformation::CreateScriptInformation(path, L"", source);
 	infoStage->SetPlayerScriptInformation(infoScript);
-	
+
 	return value(machine->get_engine()->get_boolean_type(), true);
 }
-gstd::value StgPackageScript::Func_SetStageReplayFile(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgPackageScript::Func_SetStageReplayFile(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgPackageScript* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
@@ -311,17 +293,15 @@ gstd::value StgPackageScript::Func_SetStageReplayFile(gstd::script_machine* mach
 	ref_count_ptr<StgPackageInformation> infoPackage = packageController->GetPackageInformation();
 
 	std::wstring pathReplay = argv[0].as_string();
-	ref_count_ptr<ReplayInformation> infoRepray = 
-		ReplayInformation::CreateFromFile(pathReplay);
-	if(infoRepray == NULL)
-	{
+	ref_count_ptr<ReplayInformation> infoRepray = ReplayInformation::CreateFromFile(pathReplay);
+	if (infoRepray == NULL) {
 		std::wstring path = ErrorUtility::GetFileNotFoundErrorMessage(pathReplay);
 		script->RaiseError(path);
 	}
 	infoPackage->SetReplayInformation(infoRepray);
 	return value();
 }
-gstd::value StgPackageScript::Func_GetStageSceneState(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgPackageScript::Func_GetStageSceneState(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgPackageScript* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
@@ -330,12 +310,12 @@ gstd::value StgPackageScript::Func_GetStageSceneState(gstd::script_machine* mach
 
 	int res = -1;
 	int scene = infoSystem->GetScene();
-	if(scene == StgSystemInformation::SCENE_PACKAGE_CONTROL)
+	if (scene == StgSystemInformation::SCENE_PACKAGE_CONTROL)
 		res = STAGE_STATE_FINISHED;
 
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgPackageScript::Func_GetStageSceneResult(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgPackageScript::Func_GetStageSceneResult(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgPackageScript* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
@@ -343,9 +323,8 @@ gstd::value StgPackageScript::Func_GetStageSceneResult(gstd::script_machine* mac
 
 	int res = StgStageInformation::RESULT_UNKNOWN;
 	ref_count_ptr<StgPackageInformation> infoPackage = packageController->GetPackageInformation();
-	std::vector<ref_count_ptr<StgStageStartData> > listStage = infoPackage->GetStageDataList();
-	if(listStage.size() > 0)
-	{
+	std::vector<ref_count_ptr<StgStageStartData>> listStage = infoPackage->GetStageDataList();
+	if (listStage.size() > 0) {
 		ref_count_ptr<StgStageStartData> stageData = listStage[listStage.size() - 1];
 		ref_count_ptr<StgStageInformation> infoStage = stageData->GetStageInformation();
 		res = infoStage->GetResult();
@@ -353,40 +332,39 @@ gstd::value StgPackageScript::Func_GetStageSceneResult(gstd::script_machine* mac
 
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgPackageScript::Func_PauseStageScene(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgPackageScript::Func_PauseStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgPackageScript* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 	StgSystemController* systemController = packageController->GetSystemController();
 	StgStageController* stageController = systemController->GetStageController();
-	if(stageController == NULL)return gstd::value();
+	if (stageController == NULL)
+		return gstd::value();
 
 	bool bPause = argv[0].as_boolean();
 
 	StgStageScriptManager* stageScriptManager = stageController->GetScriptManagerP();
 	ref_count_ptr<StgStageInformation> infoStage = stageController->GetStageInformation();
-	if(bPause && !infoStage->IsPause())
+	if (bPause && !infoStage->IsPause())
 		stageScriptManager->RequestEventAll(StgStageScript::EV_PAUSE_ENTER);
-	else if(!bPause && infoStage->IsPause())
+	else if (!bPause && infoStage->IsPause())
 		stageScriptManager->RequestEventAll(StgStageScript::EV_PAUSE_LEAVE);
 
 	infoStage->SetPause(bPause);
 
 	return gstd::value();
 }
-gstd::value StgPackageScript::Func_TerminateStageScene(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgPackageScript::Func_TerminateStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgPackageScript* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 	StgSystemController* systemController = packageController->GetSystemController();
 	StgStageController* stageController = systemController->GetStageController();
-	if(stageController == NULL)return gstd::value();
+	if (stageController == NULL)
+		return gstd::value();
 
 	ref_count_ptr<StgStageInformation> infoStage = stageController->GetStageInformation();
 	infoStage->SetResult(StgStageInformation::RESULT_BREAK_OFF);
 	infoStage->SetEnd();
 	return gstd::value();
 }
-
-
-

--- a/source/TouhouDanmakufu/Common/StgPackageScript.hpp
+++ b/source/TouhouDanmakufu/Common/StgPackageScript.hpp
@@ -1,69 +1,62 @@
 #ifndef __TOUHOUDANMAKUFU_DNHSTG_PACKAGESCRIPT__
 #define __TOUHOUDANMAKUFU_DNHSTG_PACKAGESCRIPT__
 
-#include"StgCommon.hpp"
-#include"StgControlScript.hpp"
-#include"StgStageController.hpp"
+#include "StgCommon.hpp"
+#include "StgControlScript.hpp"
+#include "StgStageController.hpp"
 
 /**********************************************************
 //StgPackageScriptManager
 **********************************************************/
 class StgPackageScript;
-class StgPackageScriptManager : public StgControlScriptManager
-{
-	protected:
-		StgSystemController* systemController_;
-		ref_count_ptr<DxScriptObjectManager> objectManager_;
+class StgPackageScriptManager : public StgControlScriptManager {
+public:
+	StgPackageScriptManager(StgSystemController* controller);
+	virtual ~StgPackageScriptManager();
+	virtual void Work();
+	virtual void Render();
+	virtual ref_count_ptr<ManagedScript> Create(int type);
 
-	public:
-		StgPackageScriptManager(StgSystemController* controller);
-		virtual ~StgPackageScriptManager();
-		virtual void Work();
-		virtual void Render();
-		virtual ref_count_ptr<ManagedScript> Create(int type);
+	ref_count_ptr<DxScriptObjectManager> GetObjectManager() { return objectManager_; }
 
-		ref_count_ptr<DxScriptObjectManager> GetObjectManager(){return objectManager_;}
+protected:
+	StgSystemController* systemController_;
+	ref_count_ptr<DxScriptObjectManager> objectManager_;
 };
 
 /**********************************************************
 //StgPackageScript
 **********************************************************/
-class StgPackageScript : public StgControlScript
-{
-	public:
-		enum
-		{
-			TYPE_PACKAGE_MAIN,
+class StgPackageScript : public StgControlScript {
+public:
+	enum {
+		TYPE_PACKAGE_MAIN,
 
-			STAGE_STATE_FINISHED,
-		};
+		STAGE_STATE_FINISHED,
+	};
 
-	private:
-		StgPackageController* packageController_;
-		void _CheckNextStageExists();
+public:
+	StgPackageScript(StgPackageController* packageController);
 
-	public:
-		StgPackageScript(StgPackageController* packageController);
+	//パッケージ共通関数：パッケージ操作
+	static gstd::value Func_ClosePackage(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
+	//パッケージ共通関数：ステージ操作
+	static gstd::value Func_InitializeStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_FinalizeStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_StartStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetStageIndex(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetStageMainScript(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetStagePlayerScript(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetStageReplayFile(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetStageSceneState(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetStageSceneResult(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_PauseStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_TerminateStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//パッケージ共通関数：パッケージ操作
-		static gstd::value Func_ClosePackage(gstd::script_machine* machine, int argc, gstd::value const * argv);
-
-		//パッケージ共通関数：ステージ操作
-		static gstd::value Func_InitializeStageScene(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_FinalizeStageScene(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_StartStageScene(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetStageIndex(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetStageMainScript(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetStagePlayerScript(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetStageReplayFile(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetStageSceneState(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetStageSceneResult(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_PauseStageScene(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_TerminateStageScene(gstd::script_machine* machine, int argc, gstd::value const * argv);
-
-
+private:
+	void _CheckNextStageExists();
+	StgPackageController* packageController_;
 };
 
 #endif
-

--- a/source/TouhouDanmakufu/Common/StgPlayer.cpp
+++ b/source/TouhouDanmakufu/Common/StgPlayer.cpp
@@ -1,11 +1,11 @@
-#include"StgPlayer.hpp"
-#include"StgSystem.hpp"
-
+#include "StgPlayer.hpp"
+#include "StgSystem.hpp"
 
 /**********************************************************
 //StgPlayerObject
 **********************************************************/
-StgPlayerObject::StgPlayerObject(StgStageController* stageController) : StgMoveObject(stageController)
+StgPlayerObject::StgPlayerObject(StgStageController* stageController)
+	: StgMoveObject(stageController)
 {
 	stageController_ = stageController;
 	typeObject_ = StgStageScript::OBJ_PLAYER;
@@ -14,7 +14,7 @@ StgPlayerObject::StgPlayerObject(StgStageController* stageController) : StgMoveO
 	RECT rcStgFrame = stageController_->GetStageInformation()->GetStgFrameRect();
 	int stgWidth = rcStgFrame.right - rcStgFrame.left;
 	int stgHeight = rcStgFrame.bottom - rcStgFrame.top;
-	
+
 	SetRenderPriority(0.30);
 	speedFast_ = 4;
 	speedSlow_ = 1.6;
@@ -48,7 +48,7 @@ void StgPlayerObject::_InitializeRebirth()
 	RECT rcStgFrame = stageController_->GetStageInformation()->GetStgFrameRect();
 	int stgWidth = rcStgFrame.right - rcStgFrame.left;
 	int stgHeight = rcStgFrame.bottom - rcStgFrame.top;
-	
+
 	SetX(stgWidth / 2);
 	SetY(rcStgFrame.bottom - 48);
 }
@@ -61,11 +61,9 @@ void StgPlayerObject::Work()
 	//当たり判定クリア
 	ClearIntersected();
 
-	if(state_ == STATE_NORMAL)
-	{
+	if (state_ == STATE_NORMAL) {
 		//通常時
-		if(hitObjectID_ != DxScript::ID_INVALID)
-		{
+		if (hitObjectID_ != DxScript::ID_INVALID) {
 			state_ = STATE_HIT;
 			frameState_ = infoPlayer_->frameRebirth_;
 
@@ -73,20 +71,14 @@ void StgPlayerObject::Work()
 			std::vector<gstd::value> listScriptValue;
 			listScriptValue.push_back(valueHitObjectID);
 			script_->RequestEvent(StgStagePlayerScript::EV_HIT, listScriptValue);
-		}
-		else
-		{
-			if(listGrazedShot_.size() > 0)
-			{
+		} else {
+			if (listGrazedShot_.size() > 0) {
 				std::vector<value> listValPos;
 				std::vector<long double> listShotID;
 				int grazedShotCount = listGrazedShot_.size();
-				for(int iObj = 0 ; iObj < grazedShotCount ; iObj++)
-				{
-					ref_count_weak_ptr<StgShotObject>::unsync objShot = 
-						ref_count_weak_ptr<StgShotObject>::unsync::DownCast(listGrazedShot_[iObj]);
-					if(objShot != NULL)
-					{
+				for (int iObj = 0; iObj < grazedShotCount; iObj++) {
+					ref_count_weak_ptr<StgShotObject>::unsync objShot = ref_count_weak_ptr<StgShotObject>::unsync::DownCast(listGrazedShot_[iObj]);
+					if (objShot != NULL) {
 						int id = objShot->GetObjectID();
 						listShotID.push_back(id);
 
@@ -105,70 +97,59 @@ void StgPlayerObject::Work()
 
 				ref_count_ptr<StgStageScriptManager> stageScriptManager = stageController_->GetScriptManagerR();
 				ref_count_ptr<ManagedScript> itemScript = stageScriptManager->GetItemScript();
-				if(itemScript != NULL)
-				{
+				if (itemScript != NULL) {
 					itemScript->RequestEvent(StgStagePlayerScript::EV_GRAZE, listScriptValue);
 				}
 			}
-			//_Move();
-			if(input->GetVirtualKeyState(EDirectInput::KEY_BOMB) == KEY_PUSH)
+			// _Move();
+			if (input->GetVirtualKeyState(EDirectInput::KEY_BOMB) == KEY_PUSH)
 				CallSpell();
 
 			_AddIntersection();
 		}
 	}
-	if(state_ == STATE_HIT)
-	{
+	if (state_ == STATE_HIT) {
 		//くらいボム待機
-		if(input->GetVirtualKeyState(EDirectInput::KEY_BOMB) == KEY_PUSH)
-			CallSpell();	
+		if (input->GetVirtualKeyState(EDirectInput::KEY_BOMB) == KEY_PUSH)
+			CallSpell();
 
-		if(state_ == STATE_HIT)
-		{
+		if (state_ == STATE_HIT) {
 			//くらいボム有効フレーム減少
 			frameState_--;
-			if(frameState_ < 0)
-			{
+			if (frameState_ < 0) {
 				//自機ダウン
 				bool bEnemyLastSpell = false;
 				ref_count_ptr<StgEnemyBossSceneObject>::unsync objBossScene = enemyManager->GetBossSceneObject();
-				if(objBossScene != NULL)
-				{
+				if (objBossScene != NULL) {
 					objBossScene->AddPlayerShootDownCount();
-					if(objBossScene->GetActiveData()->IsLastSpell())
+					if (objBossScene->GetActiveData()->IsLastSpell())
 						bEnemyLastSpell = true;
 				}
-				if(!bEnemyLastSpell)
+				if (!bEnemyLastSpell)
 					infoPlayer_->life_--;
 				scriptManager->RequestEventAll(StgStagePlayerScript::EV_PLAYER_SHOOTDOWN);
 
-				if(infoPlayer_->life_ >= 0)
-				{
+				if (infoPlayer_->life_ >= 0) {
 					bVisible_ = false;
 					state_ = STATE_DOWN;
 					frameState_ = frameStateDown_;
-				}
-				else
-				{
+				} else {
 					state_ = STATE_END;
 				}
 			}
 		}
 	}
-	if(state_ == STATE_DOWN)
-	{
+	if (state_ == STATE_DOWN) {
 		//ダウン
 		frameState_--;
-		if(frameState_ <= 0)
-		{
+		if (frameState_ <= 0) {
 			bVisible_ = true;
 			_InitializeRebirth();
 			state_ = STATE_NORMAL;
 			scriptManager->RequestEventAll(StgStageScript::EV_PLAYER_REBIRTH);
 		}
 	}
-	if(state_ == STATE_END)
-	{
+	if (state_ == STATE_END) {
 		bVisible_ = false;
 	}
 
@@ -178,11 +159,9 @@ void StgPlayerObject::Work()
 }
 void StgPlayerObject::Move()
 {
-	if(state_ == STATE_NORMAL)
-	{
+	if (state_ == STATE_NORMAL) {
 		//通常時
-		if(hitObjectID_ == DxScript::ID_INVALID)
-		{
+		if (hitObjectID_ == DxScript::ID_INVALID) {
 			_Move();
 		}
 	}
@@ -199,20 +178,24 @@ void StgPlayerObject::_Move()
 	int keySlow = input->GetVirtualKeyState(EDirectInput::KEY_SLOWMOVE);
 
 	double speed = speedFast_;
-	if(keySlow == KEY_PUSH || keySlow == KEY_HOLD)speed = speedSlow_;
+	if (keySlow == KEY_PUSH || keySlow == KEY_HOLD)
+		speed = speedSlow_;
 
 	bool bKetLeft = keyLeft == KEY_PUSH || keyLeft == KEY_HOLD;
 	bool bKeyRight = keyRight == KEY_PUSH || keyRight == KEY_HOLD;
 	bool bKeyUp = keyUp == KEY_PUSH || keyUp == KEY_HOLD;
 	bool bKeyDown = keyDown == KEY_PUSH || keyDown == KEY_HOLD;
 
-	if(bKetLeft && !bKeyRight)sx += -speed;
-	if(!bKetLeft && bKeyRight)sx += speed;
-	if(bKeyUp && !bKeyDown)sy += -speed;
-	if(!bKeyUp && bKeyDown)sy += speed;
+	if (bKetLeft && !bKeyRight)
+		sx += -speed;
+	if (!bKetLeft && bKeyRight)
+		sx += speed;
+	if (bKeyUp && !bKeyDown)
+		sy += -speed;
+	if (!bKeyUp && bKeyDown)
+		sy += speed;
 
-	if(sx != 0 && sy != 0)
-	{
+	if (sx != 0 && sy != 0) {
 		sx /= 1.41421356;
 		sy /= 1.41421356;
 	}
@@ -231,7 +214,8 @@ void StgPlayerObject::_Move()
 }
 void StgPlayerObject::_AddIntersection()
 {
-	if(frameInvincibility_ > 0)return;
+	if (frameInvincibility_ > 0)
+		return;
 	StgIntersectionManager* intersectionManager = stageController_->GetIntersectionManager();
 
 	UpdateIntersectionRelativeTarget(posX_, posY_, 0);
@@ -246,34 +230,33 @@ bool StgPlayerObject::_IsValidSpell()
 }
 void StgPlayerObject::CallSpell()
 {
-	if(!_IsValidSpell())return;
-	if(!IsPermitSpell())return;
+	if (!_IsValidSpell())
+		return;
+	if (!IsPermitSpell())
+		return;
 
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 	objSpell_ = new StgPlayerSpellManageObject();
 	int idSpell = objectManager->AddObject(objSpell_);
 
 	gstd::value vUse = script_->RequestEvent(StgStagePlayerScript::EV_REQUEST_SPELL);
-	if(!script_->IsBooleanValue(vUse))
+	if (!script_->IsBooleanValue(vUse))
 		throw gstd::wexception(L"@Event(EV_REQUEST_SPELL)内でboolean型の値が返されていません。");
 	bool bUse = vUse.as_boolean();
-	if(!bUse)
-	{
+	if (!bUse) {
 		objSpell_ = NULL;
 		objectManager->DeleteObject(idSpell);
 		return;
 	}
 
-	if(state_ == STATE_HIT)
-	{
+	if (state_ == STATE_HIT) {
 		state_ = STATE_NORMAL;
 		infoPlayer_->frameRebirth_ = max(infoPlayer_->frameRebirth_ - frameRebirthDiff_, 0);
 	}
 
 	StgEnemyManager* enemyManager = stageController_->GetEnemyManager();
 	ref_count_ptr<StgEnemyBossSceneObject>::unsync objBossScene = enemyManager->GetBossSceneObject();
-	if(objBossScene != NULL)
-	{
+	if (objBossScene != NULL) {
 		objBossScene->AddPlayerSpellCount();
 	}
 
@@ -285,45 +268,31 @@ void StgPlayerObject::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync own
 {
 	StgIntersectionTarget_Player* own = (StgIntersectionTarget_Player*)ownTarget.GetPointer();
 	int otherType = otherTarget->GetTargetType();
-	switch(otherType)
-	{
-		case StgIntersectionTarget::TYPE_ENEMY_SHOT:
-		{
-			//敵弾
-			if(own->IsGraze())
-			{
-				StgShotObject* objShot = (StgShotObject*)otherTarget->GetObject().GetPointer();
-				if(objShot != NULL && objShot->IsValidGraze())
-				{
-					listGrazedShot_.push_back(otherTarget->GetObject());
-					stageController_->GetStageInformation()->AddGraze(1);
-				}
+	switch (otherType) {
+	case StgIntersectionTarget::TYPE_ENEMY_SHOT: {
+		//敵弾
+		if (own->IsGraze()) {
+			StgShotObject* objShot = (StgShotObject*)otherTarget->GetObject().GetPointer();
+			if (objShot != NULL && objShot->IsValidGraze()) {
+				listGrazedShot_.push_back(otherTarget->GetObject());
+				stageController_->GetStageInformation()->AddGraze(1);
 			}
-			else 
-			{
-				ref_count_weak_ptr<StgShotObject>::unsync objShot = 
-					ref_count_weak_ptr<StgShotObject>::unsync::DownCast(otherTarget->GetObject());
-				if(objShot != NULL)
-					hitObjectID_ = objShot->GetObjectID();
-			}
+		} else {
+			ref_count_weak_ptr<StgShotObject>::unsync objShot = ref_count_weak_ptr<StgShotObject>::unsync::DownCast(otherTarget->GetObject());
+			if (objShot != NULL)
+				hitObjectID_ = objShot->GetObjectID();
 		}
-		break;
+	} break;
 
-		case StgIntersectionTarget::TYPE_ENEMY:
-		{
-			//敵
-			if(!own->IsGraze())
-			{
-				ref_count_weak_ptr<StgEnemyObject>::unsync objEnemy = 
-					ref_count_weak_ptr<StgEnemyObject>::unsync::DownCast(otherTarget->GetObject());
-				if(objEnemy != NULL)
-					hitObjectID_ = objEnemy->GetObjectID();
-			}
+	case StgIntersectionTarget::TYPE_ENEMY: {
+		//敵
+		if (!own->IsGraze()) {
+			ref_count_weak_ptr<StgEnemyObject>::unsync objEnemy = ref_count_weak_ptr<StgEnemyObject>::unsync::DownCast(otherTarget->GetObject());
+			if (objEnemy != NULL)
+				hitObjectID_ = objEnemy->GetObjectID();
 		}
-		break;
+	} break;
 	}
-
-	
 }
 ref_count_ptr<StgPlayerObject>::unsync StgPlayerObject::GetOwnObject()
 {
@@ -343,10 +312,9 @@ bool StgPlayerObject::IsPermitSpell()
 	StgEnemyManager* enemyManager = stageController_->GetEnemyManager();
 	bool bEnemyLastSpell = false;
 	ref_count_ptr<StgEnemyBossSceneObject>::unsync objBossScene = enemyManager->GetBossSceneObject();
-	if(objBossScene != NULL)
-	{
+	if (objBossScene != NULL) {
 		ref_count_ptr<StgEnemyBossSceneData>::unsync data = objBossScene->GetActiveData();
-		if(data != NULL && data->IsLastSpell())
+		if (data != NULL && data->IsLastSpell())
 			bEnemyLastSpell = true;
 	}
 
@@ -370,9 +338,9 @@ StgPlayerSpellObject::StgPlayerSpellObject(StgStageController* stageController)
 }
 void StgPlayerSpellObject::Work()
 {
-	if(IsDeleted())return;
-	if(life_ <= 0)
-	{
+	if (IsDeleted())
+		return;
+	if (life_ <= 0) {
 		ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 		objectManager->DeleteObject(idObject_);
 	}
@@ -381,17 +349,12 @@ void StgPlayerSpellObject::Intersect(ref_count_ptr<StgIntersectionTarget>::unsyn
 {
 	double damage = 0;
 	int otherType = otherTarget->GetTargetType();
-	switch(otherType)
-	{
-		case StgIntersectionTarget::TYPE_ENEMY:
-		case StgIntersectionTarget::TYPE_ENEMY_SHOT:
-		{
-			damage = 1;
-			break;
-		}
+	switch (otherType) {
+	case StgIntersectionTarget::TYPE_ENEMY:
+	case StgIntersectionTarget::TYPE_ENEMY_SHOT:
+		damage = 1;
+		break;
 	}
 	life_ -= damage;
 	life_ = max(life_, 0);
 }
-
-

--- a/source/TouhouDanmakufu/Common/StgPlayer.hpp
+++ b/source/TouhouDanmakufu/Common/StgPlayer.hpp
@@ -1,9 +1,9 @@
 #ifndef __TOUHOUDANMAKUFU_DNHSTG_PLAYER__
 #define __TOUHOUDANMAKUFU_DNHSTG_PLAYER__
 
-#include"StgCommon.hpp"
-#include"StgStageScript.hpp"
-#include"StgIntersection.hpp"
+#include "StgCommon.hpp"
+#include "StgIntersection.hpp"
+#include "StgStageScript.hpp"
 
 class StgPlayerObject;
 class StgPlayerInformation;
@@ -12,168 +12,178 @@ class StgPlayerSpellObject;
 /**********************************************************
 //StgPlayerObject
 **********************************************************/
-class StgPlayerInformation
-{
+class StgPlayerInformation {
 	friend StgPlayerObject;
-	private:
-		double life_;
-		double countBomb_;
-		double power_;
-		int frameRebirth_;//くらいボム有効フレーム
-	public:
-		StgPlayerInformation(){}
-		virtual ~StgPlayerInformation(){}
 
-		double GetLife(){return life_;}
-		void SetLife(double life){life_ = life;}
-		double GetSpell(){return countBomb_;}
-		void SetSpell(double spell){countBomb_ = spell;}
-		double GetPower(){return power_;}
-		void SetPower(double power){power_ = power;}
+public:
+	StgPlayerInformation() {}
+	virtual ~StgPlayerInformation() {}
 
-		int GetRebirthFrame(){return frameRebirth_;}
-		void SetRebirthFrame(int frame){frameRebirth_ = frame;}
+	double GetLife() { return life_; }
+	void SetLife(double life) { life_ = life; }
+	double GetSpell() { return countBomb_; }
+	void SetSpell(double spell) { countBomb_ = spell; }
+	double GetPower() { return power_; }
+	void SetPower(double power) { power_ = power; }
+
+	int GetRebirthFrame() { return frameRebirth_; }
+	void SetRebirthFrame(int frame) { frameRebirth_ = frame; }
+
+private:
+	double life_;
+	double countBomb_;
+	double power_;
+	int frameRebirth_; //くらいボム有効フレーム
 };
 
-class StgPlayerObject : public DxScriptSpriteObject2D, public StgMoveObject, public StgIntersectionObject
-{
-	public:
-		enum
-		{
-			STATE_NORMAL,
-			STATE_HIT,
-			STATE_DOWN,
-			STATE_END,
-		};
-	protected:
-		StgStageController* stageController_;
-		StgStagePlayerScript* script_;
-		ref_count_ptr<StgPlayerInformation> infoPlayer_;
-		ref_count_ptr<StgPlayerSpellManageObject>::unsync objSpell_;
+class StgPlayerObject : public DxScriptSpriteObject2D, public StgMoveObject, public StgIntersectionObject {
+public:
+	enum {
+		STATE_NORMAL,
+		STATE_HIT,
+		STATE_DOWN,
+		STATE_END,
+	};
 
-		double speedFast_;
-		double speedSlow_;
-		RECT rcClip_;
+public:
+	StgPlayerObject(StgStageController* stageController);
+	virtual ~StgPlayerObject();
+	void Clear() { ClearIntersectionRelativeTarget(); }
+	void SetScript(StgStagePlayerScript* script) { script_ = script; }
 
-		int state_;
-		int frameState_;//各ステートで使用されるフレーム
-		int frameRebirthMax_;//くらいボム有効フレーム初期値
-		int frameRebirthDiff_;//くらいボム減少量
-		int frameStateDown_;
+	virtual void Work();
+	void Move();
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	void CallSpell();
 
-		std::vector<ref_count_weak_ptr<StgIntersectionObject>::unsync > listGrazedShot_;
-		int hitObjectID_;
+	virtual void SetX(double x)
+	{
+		posX_ = x;
+		DxScriptRenderObject::SetX(x);
+	}
+	virtual void SetY(double y)
+	{
+		posY_ = y;
+		DxScriptRenderObject::SetY(y);
+	}
 
-		double itemCircle_;
-		int frameInvincibility_;
-		bool bForbidShot_;
-		bool bForbidSpell_;
-		int yAutoItemCollect_;
+	ref_count_ptr<StgPlayerInformation> GetPlayerInformation() { return infoPlayer_; }
+	void SetPlayerInforamtion(ref_count_ptr<StgPlayerInformation> info) { infoPlayer_ = info; }
+	ref_count_ptr<StgPlayerSpellManageObject>::unsync GetSpellManageObject() { return objSpell_; }
 
-		void _InitializeRebirth();
-		void _Move();
-		void _AddIntersection();
-		bool _IsValidSpell();
-	public:
-		StgPlayerObject(StgStageController* stageController);
-		virtual ~StgPlayerObject();
-		void Clear(){ClearIntersectionRelativeTarget();}
-		void SetScript(StgStagePlayerScript* script){script_ = script;}
+	StgStagePlayerScript* GetPlayerScript() { return script_; }
+	ref_count_ptr<StgPlayerObject>::unsync GetOwnObject();
+	double GetX() { return posX_; }
+	double GetY() { return posY_; }
+	double GetFastSpeed() { return speedFast_; }
+	void SetFastSpeed(double speed) { speedFast_ = speed; }
+	double GetSlowSpeed() { return speedSlow_; }
+	void SetSlowSpeed(double speed) { speedSlow_ = speed; }
 
-		virtual void Work();
-		void Move();
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
-		void CallSpell();
+	RECT GetClip() { return rcClip_; }
+	void SetClip(RECT rect) { rcClip_ = rect; }
 
-		virtual void SetX(double x){posX_ = x; DxScriptRenderObject::SetX(x);}
-		virtual void SetY(double y){posY_ = y; DxScriptRenderObject::SetY(y);}
+	int GetState() { return state_; }
+	int GetDownStateFrame() { return frameStateDown_; }
+	void SetDownStateFrame(int frame) { frameStateDown_ = frame; }
+	int GetRebirthFrame() { return infoPlayer_->GetRebirthFrame(); }
+	void SetRebirthFrameMax(int frame) { frameRebirthMax_ = frame; }
+	void SetRebirthFrame(int frame) { infoPlayer_->SetRebirthFrame(frame); }
+	void SetRebirthLossFrame(int frame) { frameRebirthDiff_ = frame; }
+	double GetItemIntersectionRadius() { return itemCircle_; }
+	void SetItemIntersectionRadius(double r) { itemCircle_ = r; }
+	double GetLife() { return infoPlayer_->GetLife(); }
+	void SetLife(double life) { infoPlayer_->SetLife(life); }
+	double GetSpell() { return infoPlayer_->GetSpell(); }
+	void SetSpell(double spell) { infoPlayer_->SetSpell(spell); }
+	double GetPower() { return infoPlayer_->GetPower(); }
+	void SetPower(double power) { infoPlayer_->SetPower(power); }
+	int GetInvincibilityFrame() { return frameInvincibility_; }
+	void SetInvincibilityFrame(int frame) { frameInvincibility_ = frame; }
+	int GetAutoItemCollectY() { return yAutoItemCollect_; }
+	void SetAutoItemCollectY(int y) { yAutoItemCollect_ = y; }
 
-		ref_count_ptr<StgPlayerInformation> GetPlayerInformation(){return infoPlayer_;}
-		void SetPlayerInforamtion(ref_count_ptr<StgPlayerInformation> info){infoPlayer_ = info;}
-		ref_count_ptr<StgPlayerSpellManageObject>::unsync GetSpellManageObject(){return objSpell_;}
+	bool IsPermitShot();
+	void SetForbidShot(bool bForbid) { bForbidShot_ = bForbid; }
+	bool IsPermitSpell();
+	void SetForbidSpell(bool bForbid) { bForbidSpell_ = bForbid; }
+	bool IsWaitLastSpell();
 
-		StgStagePlayerScript* GetPlayerScript(){return script_;}
-		ref_count_ptr<StgPlayerObject>::unsync GetOwnObject();
-		double GetX(){return posX_;}
-		double GetY(){return posY_;}
-		double GetFastSpeed(){return speedFast_;}
-		void SetFastSpeed(double speed){speedFast_ = speed;}
-		double GetSlowSpeed(){return speedSlow_;}
-		void SetSlowSpeed(double speed){speedSlow_ = speed;}
+protected:
+	void _InitializeRebirth();
+	void _Move();
+	void _AddIntersection();
+	bool _IsValidSpell();
 
-		RECT GetClip(){return rcClip_;}
-		void SetClip(RECT rect){rcClip_ = rect;}
+	StgStageController* stageController_;
+	StgStagePlayerScript* script_;
+	ref_count_ptr<StgPlayerInformation> infoPlayer_;
+	ref_count_ptr<StgPlayerSpellManageObject>::unsync objSpell_;
 
-		int GetState(){return state_;}
-		int GetDownStateFrame(){return frameStateDown_;}
-		void SetDownStateFrame(int frame){frameStateDown_ = frame;}
-		int GetRebirthFrame(){return infoPlayer_->GetRebirthFrame();}
-		void SetRebirthFrameMax(int frame){frameRebirthMax_ = frame;}
-		void SetRebirthFrame(int frame){infoPlayer_->SetRebirthFrame(frame);}
-		void SetRebirthLossFrame(int frame){frameRebirthDiff_ = frame;}
-		double GetItemIntersectionRadius(){return itemCircle_;}
-		void SetItemIntersectionRadius(double r){itemCircle_ = r;}
-		double GetLife(){return infoPlayer_->GetLife();}
-		void SetLife(double life){infoPlayer_->SetLife(life);}
-		double GetSpell(){return infoPlayer_->GetSpell();}
-		void SetSpell(double spell){infoPlayer_->SetSpell(spell);}
-		double GetPower(){return infoPlayer_->GetPower();}
-		void SetPower(double power){infoPlayer_->SetPower(power);}
-		int GetInvincibilityFrame(){return frameInvincibility_;}
-		void SetInvincibilityFrame(int frame){frameInvincibility_ = frame;}
-		int GetAutoItemCollectY(){return yAutoItemCollect_;}
-		void SetAutoItemCollectY(int y){yAutoItemCollect_ = y;}
+	double speedFast_;
+	double speedSlow_;
+	RECT rcClip_;
 
-		bool IsPermitShot();
-		void SetForbidShot(bool bForbid){bForbidShot_ = bForbid;}
-		bool IsPermitSpell();
-		void SetForbidSpell(bool bForbid){bForbidSpell_ = bForbid;}
-		bool IsWaitLastSpell();
+	int state_;
+	int frameState_; //各ステートで使用されるフレーム
+	int frameRebirthMax_; //くらいボム有効フレーム初期値
+	int frameRebirthDiff_; //くらいボム減少量
+	int frameStateDown_;
+
+	std::vector<ref_count_weak_ptr<StgIntersectionObject>::unsync> listGrazedShot_;
+	int hitObjectID_;
+
+	double itemCircle_;
+	int frameInvincibility_;
+	bool bForbidShot_;
+	bool bForbidSpell_;
+	int yAutoItemCollect_;
 };
 
+class StgIntersectionTarget_Player : public StgIntersectionTarget_Circle {
+public:
+	StgIntersectionTarget_Player(bool bGraze)
+	{
+		typeTarget_ = TYPE_PLAYER;
+		bGraze_ = bGraze;
+	}
+	bool IsGraze() { return bGraze_; }
 
-class StgIntersectionTarget_Player : public StgIntersectionTarget_Circle
-{
-		bool bGraze_;
-	public:
-		StgIntersectionTarget_Player(bool bGraze){typeTarget_ = TYPE_PLAYER; bGraze_ = bGraze;}
-		bool IsGraze(){return bGraze_;}
+private:
+	bool bGraze_;
 };
 
 /**********************************************************
 //StgPlayerSpellManageObject
 **********************************************************/
-class StgPlayerSpellManageObject : public DxScriptObjectBase
-{
-	public:
-		StgPlayerSpellManageObject(){bVisible_ = false;}
-		virtual void Render(){}
-		virtual void SetRenderState(){}
+class StgPlayerSpellManageObject : public DxScriptObjectBase {
+public:
+	StgPlayerSpellManageObject() { bVisible_ = false; }
+	virtual void Render() {}
+	virtual void SetRenderState() {}
 };
 
 /**********************************************************
 //StgPlayerSpellObject
 **********************************************************/
-class StgPlayerSpellObject : public DxScriptPrimitiveObject2D, public StgIntersectionObject
-{
-	protected:
-		StgStageController* stageController_;
-		double damage_;
-		bool bEraseShot_;
-		double life_;//貫通力
+class StgPlayerSpellObject : public DxScriptPrimitiveObject2D, public StgIntersectionObject {
+public:
+	StgPlayerSpellObject(StgStageController* stageController);
+	virtual void Work();
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
 
-	public:
-		StgPlayerSpellObject(StgStageController* stageController);
-		virtual void Work();
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	double GetDamage() { return damage_; }
+	void SetDamage(double damage) { damage_ = damage; }
+	bool IsEraseShot() { return bEraseShot_; }
+	void SetEraseShot(bool b) { bEraseShot_ = b; }
+	double GetLife() { return life_; }
+	void SetLife(double life) { life_ = life; }
 
-		double GetDamage(){return damage_;}
-		void SetDamage(double damage){damage_ = damage;}
-		bool IsEraseShot(){return bEraseShot_;}
-		void SetEraseShot(bool b){bEraseShot_ = b;}
-		double GetLife(){return life_;}
-		void SetLife(double life){life_ = life;}
+protected:
+	StgStageController* stageController_;
+	double damage_;
+	bool bEraseShot_;
+	double life_; //貫通力
 };
-
 
 #endif

--- a/source/TouhouDanmakufu/Common/StgShot.cpp
+++ b/source/TouhouDanmakufu/Common/StgShot.cpp
@@ -1,7 +1,7 @@
-#include"StgShot.hpp"
-#include"StgSystem.hpp"
-#include"StgIntersection.hpp"
-#include"StgItem.hpp"
+#include "StgShot.hpp"
+#include "StgIntersection.hpp"
+#include "StgItem.hpp"
+#include "StgSystem.hpp"
 
 /**********************************************************
 //StgShotManager
@@ -15,34 +15,27 @@ StgShotManager::StgShotManager(StgStageController* stageController)
 }
 StgShotManager::~StgShotManager()
 {
-	std::list<ref_count_ptr<StgShotObject>::unsync >::iterator itr = listObj_.begin();
-	for(; itr != listObj_.end(); itr++)
-	{
+	std::list<ref_count_ptr<StgShotObject>::unsync>::iterator itr = listObj_.begin();
+	for (; itr != listObj_.end(); itr++) {
 		ref_count_ptr<StgShotObject>::unsync obj = (*itr);
-		if(obj != NULL)
-		{
+		if (obj != NULL) {
 			obj->ClearShotObject();
 		}
 	}
 }
 void StgShotManager::Work()
 {
-	std::list<ref_count_ptr<StgShotObject>::unsync >::iterator itr = listObj_.begin();
-	for(; itr != listObj_.end(); )
-	{
+	std::list<ref_count_ptr<StgShotObject>::unsync>::iterator itr = listObj_.begin();
+	for (; itr != listObj_.end();) {
 		ref_count_ptr<StgShotObject>::unsync obj = (*itr);
-		if(obj->IsDeleted())
-		{
+		if (obj->IsDeleted()) {
 			obj->ClearShotObject();
 			itr = listObj_.erase(itr);
-		}
-		else if(!obj->IsActive())
-		{
+		} else if (!obj->IsActive()) {
 			itr = listObj_.erase(itr);
-		}
-		else itr++;
+		} else
+			itr++;
 	}
-
 }
 void StgShotManager::Render(int targetPriority)
 {
@@ -51,32 +44,33 @@ void StgShotManager::Render(int targetPriority)
 	graphics->SetZWriteEnalbe(false);
 	graphics->SetCullingMode(D3DCULL_NONE);
 	graphics->SetLightingEnable(false);
-	//graphics->SetTextureFilter(DirectGraphics::MODE_TEXTURE_FILTER_POINT);
-	//			MODE_TEXTURE_FILTER_POINT,//補間なし
-	//			MODE_TEXTURE_FILTER_LINEAR,//線形補間
+	// graphics->SetTextureFilter(DirectGraphics::MODE_TEXTURE_FILTER_POINT);
+	// 			MODE_TEXTURE_FILTER_POINT,//補間なし
+	// 			MODE_TEXTURE_FILTER_LINEAR,//線形補間
 	//フォグを解除する
 	DWORD bEnableFog = FALSE;
 	graphics->GetDevice()->GetRenderState(D3DRS_FOGENABLE, &bEnableFog);
-	if(bEnableFog)
+	if (bEnableFog)
 		graphics->SetFogEnable(false);
 
 	DxCamera2D* camera = graphics->GetCamera2D().GetPointer();
 	D3DXMATRIX matCamera = camera->GetMatrix();
 
-	std::list<ref_count_ptr<StgShotObject>::unsync >::iterator itr = listObj_.begin();
-	for(; itr != listObj_.end(); itr++)
-	{
+	std::list<ref_count_ptr<StgShotObject>::unsync>::iterator itr = listObj_.begin();
+	for (; itr != listObj_.end(); itr++) {
 		ref_count_ptr<StgShotObject>::unsync obj = (*itr);
-		if(obj->IsDeleted())continue;
-		if(!obj->IsActive())continue;
-		if(obj->GetRenderPriorityI() != targetPriority)continue;
+		if (obj->IsDeleted())
+			continue;
+		if (!obj->IsActive())
+			continue;
+		if (obj->GetRenderPriorityI() != targetPriority)
+			continue;
 		obj->RenderOnShotManager(matCamera);
 	}
 
 	//描画
 	int countBlendType = StgShotDataList::RENDER_TYPE_COUNT;
-	int blendMode[] = 
-	{
+	int blendMode[] = {
 		DirectGraphics::MODE_BLEND_ADD_ARGB,
 		DirectGraphics::MODE_BLEND_ADD_RGB,
 		DirectGraphics::MODE_BLEND_MULTIPLY,
@@ -84,41 +78,35 @@ void StgShotManager::Render(int targetPriority)
 		DirectGraphics::MODE_BLEND_INV_DESTRGB,
 		DirectGraphics::MODE_BLEND_ALPHA
 	};
-	int typeRender[] = 
-	{
-		StgShotDataList::RENDER_ADD_ARGB, 
+	int typeRender[] = {
+		StgShotDataList::RENDER_ADD_ARGB,
 		StgShotDataList::RENDER_ADD_RGB,
 		StgShotDataList::RENDER_MULTIPLY,
 		StgShotDataList::RENDER_SUBTRACT,
 		StgShotDataList::RENDER_INV_DESTRGB,
 		StgShotDataList::RENDER_ALPHA
 	};
-	for(int iBlend = 0 ; iBlend < countBlendType ; iBlend++)
-	{
+	for (int iBlend = 0; iBlend < countBlendType; iBlend++) {
 		graphics->SetBlendMode(blendMode[iBlend]);
-		std::vector<ref_count_ptr<StgShotRenderer>::unsync >* listPlayer = 
-			listPlayerShotData_->GetRendererList(typeRender[iBlend]);
+		std::vector<ref_count_ptr<StgShotRenderer>::unsync>* listPlayer = listPlayerShotData_->GetRendererList(typeRender[iBlend]);
 		int iRender = 0;
-		for(iRender = 0 ; iRender < listPlayer->size() ; iRender++)
+		for (iRender = 0; iRender < listPlayer->size(); iRender++)
 			(listPlayer->at(iRender))->Render();
 
-		std::vector<ref_count_ptr<StgShotRenderer>::unsync >* listEnemy = 
-			listEnemyShotData_->GetRendererList(typeRender[iBlend]);
-		for(iRender = 0 ; iRender < listEnemy->size() ; iRender++)
+		std::vector<ref_count_ptr<StgShotRenderer>::unsync>* listEnemy = listEnemyShotData_->GetRendererList(typeRender[iBlend]);
+		for (iRender = 0; iRender < listEnemy->size(); iRender++)
 			(listEnemy->at(iRender))->Render();
 	}
 
-	if(bEnableFog)
+	if (bEnableFog)
 		graphics->SetFogEnable(true);
 }
 void StgShotManager::RegistIntersectionTarget()
 {
-	std::list<ref_count_ptr<StgShotObject>::unsync >::iterator itr = listObj_.begin();
-	for(; itr != listObj_.end(); itr++)
-	{
+	std::list<ref_count_ptr<StgShotObject>::unsync>::iterator itr = listObj_.begin();
+	for (; itr != listObj_.end(); itr++) {
 		ref_count_ptr<StgShotObject>::unsync obj = (*itr);
-		if(!obj->IsDeleted() && obj->IsActive())
-		{
+		if (!obj->IsDeleted() && obj->IsActive()) {
 			obj->ClearIntersectedIdList();
 			obj->RegistIntersectionTarget();
 		}
@@ -150,37 +138,30 @@ void StgShotManager::DeleteInCircle(int typeDelete, int typeTo, int typeOnwer, i
 {
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 
-	std::list<ref_count_ptr<StgShotObject>::unsync >::iterator itr = listObj_.begin();
-	for(; itr != listObj_.end(); itr++)
-	{
+	std::list<ref_count_ptr<StgShotObject>::unsync>::iterator itr = listObj_.begin();
+	for (; itr != listObj_.end(); itr++) {
 		ref_count_ptr<StgShotObject>::unsync obj = (*itr);
-		if(obj->IsDeleted())continue;
+		if (obj->IsDeleted())
+			continue;
 
-		if(typeOnwer != StgShotObject::OWNER_NULL && 
-			obj->GetOwnerType() != typeOnwer)continue;
+		if (typeOnwer != StgShotObject::OWNER_NULL && obj->GetOwnerType() != typeOnwer)
+			continue;
 
-		if(typeDelete == DEL_TYPE_SHOT && obj->GetLife() == StgShotObject::LIFE_SPELL_REGIST)continue;
+		if (typeDelete == DEL_TYPE_SHOT && obj->GetLife() == StgShotObject::LIFE_SPELL_REGIST)
+			continue;
 
 		double sx = obj->GetPositionX();
 		double sy = obj->GetPositionY();
 
-		double tr = pow(pow(cx-sx, 2) + pow(cy-sy, 2), 0.5);
-		if(tr <= radius)
-		{
-			if(typeTo == TO_TYPE_IMMEDIATE)
-			{
+		double tr = pow(pow(cx - sx, 2) + pow(cy - sy, 2), 0.5);
+		if (tr <= radius) {
+			if (typeTo == TO_TYPE_IMMEDIATE)
 				obj->DeleteImmediate();
-			}
-			else if(typeTo == TO_TYPE_FADE)
-			{
+			else if (typeTo == TO_TYPE_FADE)
 				obj->SetFadeDelete();
-			}
-			else if(typeTo == TO_TYPE_ITEM)
-			{
+			else if (typeTo == TO_TYPE_ITEM)
 				obj->ConvertToItem();
-			}
 		}
-
 	}
 }
 
@@ -189,39 +170,37 @@ std::vector<int> StgShotManager::GetShotIdInCircle(int typeOnwer, int cx, int cy
 	std::vector<int> res;
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 
-	std::list<ref_count_ptr<StgShotObject>::unsync >::iterator itr = listObj_.begin();
-	for(; itr != listObj_.end(); itr++)
-	{
+	std::list<ref_count_ptr<StgShotObject>::unsync>::iterator itr = listObj_.begin();
+	for (; itr != listObj_.end(); itr++) {
 		ref_count_ptr<StgShotObject>::unsync obj = (*itr);
-		if(obj->IsDeleted())continue;
+		if (obj->IsDeleted())
+			continue;
 
-		if(typeOnwer != StgShotObject::OWNER_NULL && 
-			obj->GetOwnerType() != typeOnwer)continue;
+		if (typeOnwer != StgShotObject::OWNER_NULL && obj->GetOwnerType() != typeOnwer)
+			continue;
 
 		double sx = obj->GetPositionX();
 		double sy = obj->GetPositionY();
 
-		double tr = pow(pow(cx-sx, 2) + pow(cy-sy, 2), 0.5);
-		if(tr <= radius)
-		{
+		double tr = pow(pow(cx - sx, 2) + pow(cy - sy, 2), 0.5);
+		if (tr <= radius) {
 			int id = obj->GetObjectID();
 			res.push_back(id);
 		}
-
 	}
 	return res;
 }
 int StgShotManager::GetShotCount(int typeOnwer)
 {
 	int res = 0;
-	std::list<ref_count_ptr<StgShotObject>::unsync >::iterator itr = listObj_.begin();
-	for(; itr != listObj_.end(); itr++)
-	{
+	std::list<ref_count_ptr<StgShotObject>::unsync>::iterator itr = listObj_.begin();
+	for (; itr != listObj_.end(); itr++) {
 		ref_count_ptr<StgShotObject>::unsync obj = (*itr);
-		if(obj->IsDeleted())continue;
+		if (obj->IsDeleted())
+			continue;
 
-		if(typeOnwer != StgShotObject::OWNER_NULL && 
-			obj->GetOwnerType() != typeOnwer)continue;
+		if (typeOnwer != StgShotObject::OWNER_NULL && obj->GetOwnerType() != typeOnwer)
+			continue;
 
 		res++;
 	}
@@ -233,11 +212,11 @@ std::vector<bool> StgShotManager::GetValidRenderPriorityList()
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 	res.resize(objectManager->GetRenderBucketCapacity());
 
-	std::list<ref_count_ptr<StgShotObject>::unsync >::iterator itr = listObj_.begin();
-	for(; itr != listObj_.end(); itr++)
-	{
+	std::list<ref_count_ptr<StgShotObject>::unsync>::iterator itr = listObj_.begin();
+	for (; itr != listObj_.end(); itr++) {
 		ref_count_ptr<StgShotObject>::unsync obj = (*itr);
-		if(obj->IsDeleted())continue;
+		if (obj->IsDeleted())
+			continue;
 
 		int pri = obj->GetRenderPriorityI();
 		res[pri] = true;
@@ -248,8 +227,7 @@ std::vector<bool> StgShotManager::GetValidRenderPriorityList()
 void StgShotManager::SetDeleteEventEnableByType(int type, bool bEnable)
 {
 	int bit = 0;
-	switch(type)
-	{
+	switch (type) {
 	case StgStageShotScript::EV_DELETE_SHOT_IMMEDIATE:
 		bit = StgShotManager::BIT_EV_DELETE_IMMEDIATE;
 		break;
@@ -261,12 +239,9 @@ void StgShotManager::SetDeleteEventEnableByType(int type, bool bEnable)
 		break;
 	}
 
-	if(bEnable)
-	{
+	if (bEnable) {
 		listDeleteEventEnable_.set(bit);
-	}
-	else
-	{
+	} else {
 		listDeleteEventEnable_.reset(bit);
 	}
 }
@@ -289,49 +264,40 @@ StgShotDataList::~StgShotDataList()
 }
 bool StgShotDataList::AddShotDataList(std::wstring path, bool bReload)
 {
-	if(!bReload && listReadPath_.find(path) != listReadPath_.end())return true;
+	if (!bReload && listReadPath_.find(path) != listReadPath_.end())
+		return true;
 
 	ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-	if(reader == NULL) throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path).c_str());
-	if(!reader->Open())throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path).c_str());
+	if (reader == NULL)
+		throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path).c_str());
+	if (!reader->Open())
+		throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path).c_str());
 	std::string source = reader->ReadAllString();
 
 	bool res = false;
 	Scanner scanner(source);
-	try
-	{
-		std::vector<ref_count_ptr<StgShotData>::unsync > listData;
+	try {
+		std::vector<ref_count_ptr<StgShotData>::unsync> listData;
 		std::wstring pathImage = L"";
-		RECT rcDelay = {-1, -1, -1, -1};
-		while(scanner.HasNext())
-		{
+		RECT rcDelay = { -1, -1, -1, -1 };
+		while (scanner.HasNext()) {
 			Token& tok = scanner.Next();
-			if(tok.GetType() == Token::TK_EOF)//Eofの識別子が来たらファイルの調査終了
-			{
+			if (tok.GetType() == Token::TK_EOF) //Eofの識別子が来たらファイルの調査終了
 				break;
-			}
-			else if(tok.GetType() == Token::TK_ID)
-			{
+			else if (tok.GetType() == Token::TK_ID) {
 				std::wstring element = tok.GetElement();
-				if(element == L"ShotData")
-				{
+				if (element == L"ShotData") {
 					_ScanShot(listData, scanner);
-				}
-				else if(element == L"shot_image")
-				{
+				} else if (element == L"shot_image") {
 					scanner.CheckType(scanner.Next(), Token::TK_EQUAL);
 					pathImage = scanner.Next().GetString();
-				}
-				else if(element == L"delay_color")
-				{
+				} else if (element == L"delay_color") {
 					std::vector<std::wstring> list = _GetArgumentList(scanner);
-					defaultDelayColor_ = D3DCOLOR_ARGB(255, 
+					defaultDelayColor_ = D3DCOLOR_ARGB(255,
 						StringUtility::ToInteger(list[0]),
 						StringUtility::ToInteger(list[1]),
 						StringUtility::ToInteger(list[2]));
-				}
-				else if(element == L"delay_rect")
-				{
+				} else if (element == L"delay_rect") {
 					std::vector<std::wstring> list = _GetArgumentList(scanner);
 					RECT rect;
 					rect.left = StringUtility::ToInteger(list[0]);
@@ -340,51 +306,48 @@ bool StgShotDataList::AddShotDataList(std::wstring path, bool bReload)
 					rect.bottom = StringUtility::ToInteger(list[3]);
 					rcDelay = rect;
 				}
-				if(scanner.HasNext())
+				if (scanner.HasNext())
 					tok = scanner.Next();
-
 			}
 		}
 
 		//テクスチャ読み込み
-		if(pathImage.size() == 0)throw gstd::wexception(L"画像ファイルが設定されていません。");
+		if (pathImage.size() == 0)
+			throw gstd::wexception(L"画像ファイルが設定されていません。");
 		std::wstring dir = PathProperty::GetFileDirectory(path);
 		pathImage = StringUtility::Replace(pathImage, L"./", dir);
 
 		ref_count_ptr<Texture> texture = new Texture();
 		bool bTexture = texture->CreateFromFile(pathImage);
-		if(!bTexture)throw gstd::wexception(L"画像ファイルが見つかりませんでした。");
+		if (!bTexture)
+			throw gstd::wexception(L"画像ファイルが見つかりませんでした。");
 
 		int textureIndex = -1;
-		for(int iTexture = 0 ;iTexture < listTexture_.size() ; iTexture++)
-		{
+		for (int iTexture = 0; iTexture < listTexture_.size(); iTexture++) {
 			ref_count_ptr<Texture> tSearch = listTexture_[iTexture];
-			if(tSearch->GetName() == texture->GetName())
-			{
+			if (tSearch->GetName() == texture->GetName()) {
 				textureIndex = iTexture;
 				break;
 			}
 		}
-		if(textureIndex < 0)
-		{
+		if (textureIndex < 0) {
 			textureIndex = listTexture_.size();
 			listTexture_.push_back(texture);
-			for(int iRender = 0 ; iRender < listRenderer_.size(); iRender++)
-			{
+			for (int iRender = 0; iRender < listRenderer_.size(); iRender++) {
 				ref_count_ptr<StgShotRenderer>::unsync render = new StgShotRenderer();
 				render->SetTexture(texture);
 				listRenderer_[iRender].push_back(render);
 			}
 		}
 
-		if(listData_.size() < listData.size())
+		if (listData_.size() < listData.size())
 			listData_.resize(listData.size());
-		for(int iData = 0 ; iData < listData.size() ; iData++)
-		{
+		for (int iData = 0; iData < listData.size(); iData++) {
 			ref_count_ptr<StgShotData>::unsync data = listData[iData];
-			if(data == NULL)continue;
+			if (data == NULL)
+				continue;
 			data->indexTexture_ = textureIndex;
-			if(data->rcDelay_.left < 0)
+			if (data->rcDelay_.left < 0)
 				data->rcDelay_ = rcDelay;
 			listData_[iData] = data;
 		}
@@ -392,15 +355,11 @@ bool StgShotDataList::AddShotDataList(std::wstring path, bool bReload)
 		listReadPath_.insert(path);
 		Logger::WriteTop(StringUtility::Format(L"弾データを読み込みました:%s", path.c_str()));
 		res = true;
-	}
-	catch(gstd::wexception& e)
-	{
+	} catch (gstd::wexception& e) {
 		std::wstring log = StringUtility::Format(L"弾データ読み込み失敗:%d行目(%s)", scanner.GetCurrentLine(), e.what());
 		Logger::WriteTop(log);
 		res = NULL;
-	}
-	catch(...)
-	{
+	} catch (...) {
 		std::wstring log = StringUtility::Format(L"弾データ読み込み失敗:%d行目", scanner.GetCurrentLine());
 		Logger::WriteTop(log);
 		res = NULL;
@@ -408,34 +367,28 @@ bool StgShotDataList::AddShotDataList(std::wstring path, bool bReload)
 
 	return res;
 }
-void StgShotDataList::_ScanShot(std::vector<ref_count_ptr<StgShotData>::unsync >& listData, Scanner& scanner)
+void StgShotDataList::_ScanShot(std::vector<ref_count_ptr<StgShotData>::unsync>& listData, Scanner& scanner)
 {
 	Token& tok = scanner.Next();
-	if(tok.GetType() == Token::TK_NEWLINE)tok = scanner.Next();
+	if (tok.GetType() == Token::TK_NEWLINE)
+		tok = scanner.Next();
 	scanner.CheckType(tok, Token::TK_OPENC);
 
 	ref_count_ptr<StgShotData>::unsync data = new StgShotData(this);
 	data->colorDelay_ = defaultDelayColor_;
 	int id = -1;
 
-	while(true)
-	{
+	while (true) {
 		tok = scanner.Next();
-		if(tok.GetType() == Token::TK_CLOSEC)
-		{
+		if (tok.GetType() == Token::TK_CLOSEC) {
 			break;
-		}
-		else if(tok.GetType() == Token::TK_ID)
-		{
+		} else if (tok.GetType() == Token::TK_ID) {
 			std::wstring element = tok.GetElement();
 
-			if(element == L"id")
-			{
+			if (element == L"id") {
 				scanner.CheckType(scanner.Next(), Token::TK_EQUAL);
 				id = scanner.Next().GetInteger();
-			}
-			else if(element == L"rect")
-			{
+			} else if (element == L"rect") {
 				std::vector<std::wstring> list = _GetArgumentList(scanner);
 				RECT rect;
 				rect.left = StringUtility::ToInteger(list[0]);
@@ -443,17 +396,13 @@ void StgShotDataList::_ScanShot(std::vector<ref_count_ptr<StgShotData>::unsync >
 				rect.right = StringUtility::ToInteger(list[2]);
 				rect.bottom = StringUtility::ToInteger(list[3]);
 				data->rcSrc_ = rect;
-			}
-			else if(element == L"delay_color")
-			{
+			} else if (element == L"delay_color") {
 				std::vector<std::wstring> list = _GetArgumentList(scanner);
-				data->colorDelay_ = D3DCOLOR_ARGB(255, 
+				data->colorDelay_ = D3DCOLOR_ARGB(255,
 					StringUtility::ToInteger(list[0]),
 					StringUtility::ToInteger(list[1]),
 					StringUtility::ToInteger(list[2]));
-			}
-			else if(element == L"delay_rect")
-			{
+			} else if (element == L"delay_rect") {
 				std::vector<std::wstring> list = _GetArgumentList(scanner);
 				RECT rect;
 				rect.left = StringUtility::ToInteger(list[0]);
@@ -461,94 +410,77 @@ void StgShotDataList::_ScanShot(std::vector<ref_count_ptr<StgShotData>::unsync >
 				rect.right = StringUtility::ToInteger(list[2]);
 				rect.bottom = StringUtility::ToInteger(list[3]);
 				data->rcDelay_ = rect;
-			}
-			else if(element == L"collision")
-			{
+			} else if (element == L"collision") {
 				DxCircle circle;
 				std::vector<std::wstring> list = _GetArgumentList(scanner);
-				if(list.size() == 1)
-				{
+				if (list.size() == 1) {
 					circle.SetR(StringUtility::ToInteger(list[0]));
-				}
-				else if(list.size() == 3)
-				{
+				} else if (list.size() == 3) {
 					circle.SetR(StringUtility::ToInteger(list[0]));
 					circle.SetX(StringUtility::ToInteger(list[1]));
 					circle.SetY(StringUtility::ToInteger(list[2]));
 				}
 
 				data->listCol_.push_back(circle);
-			}
-			else if(element == L"render" || element == L"delay_render")
-			{
+			} else if (element == L"render" || element == L"delay_render") {
 				scanner.CheckType(scanner.Next(), Token::TK_EQUAL);
 				std::wstring strRender = scanner.Next().GetElement();
 				int typeRender = DirectGraphics::MODE_BLEND_ALPHA;
 
-				if(strRender == L"ADD" || strRender == L"ADD_RGB")
+				if (strRender == L"ADD" || strRender == L"ADD_RGB")
 					typeRender = DirectGraphics::MODE_BLEND_ADD_RGB;
-				else if(strRender == L"ADD_ARGB")
+				else if (strRender == L"ADD_ARGB")
 					typeRender = DirectGraphics::MODE_BLEND_ADD_ARGB;
-				else if(strRender == L"MULTIPLY")
+				else if (strRender == L"MULTIPLY")
 					typeRender = DirectGraphics::MODE_BLEND_MULTIPLY;
-				else if(strRender == L"SUBTRACT")
+				else if (strRender == L"SUBTRACT")
 					typeRender = DirectGraphics::MODE_BLEND_SUBTRACT;
-				else if(strRender == L"INV_DESTRGB")
+				else if (strRender == L"INV_DESTRGB")
 					typeRender = DirectGraphics::MODE_BLEND_INV_DESTRGB;
 
-				if(element == L"render")data->typeRender_ = typeRender;
-				else if(element == L"delay_render")data->typeDelayRender_ = typeRender;
-			}
-			else if(element == L"alpha")
-			{
+				if (element == L"render")
+					data->typeRender_ = typeRender;
+				else if (element == L"delay_render")
+					data->typeDelayRender_ = typeRender;
+			} else if (element == L"alpha") {
 				scanner.CheckType(scanner.Next(), Token::TK_EQUAL);
 				data->alpha_ = scanner.Next().GetInteger();
-			}
-			else if(element == L"angular_velocity")
-			{
+			} else if (element == L"angular_velocity") {
 				scanner.CheckType(scanner.Next(), Token::TK_EQUAL);
 				tok = scanner.Next();
-				if(tok.GetElement() == L"rand")
-				{
+				if (tok.GetElement() == L"rand") {
 					scanner.CheckType(scanner.Next(), Token::TK_OPENP);
 					data->angularVelocityMin_ = scanner.Next().GetReal();
 					scanner.CheckType(scanner.Next(), Token::TK_COMMA);
 					data->angularVelocityMax_ = scanner.Next().GetReal();
 					scanner.CheckType(scanner.Next(), Token::TK_CLOSEP);
-				}
-				else
-				{
+				} else {
 					data->angularVelocityMin_ = tok.GetReal();
 					data->angularVelocityMax_ = data->angularVelocityMin_;
 				}
-			}
-			else if(element == L"fixed_angle")
-			{
+			} else if (element == L"fixed_angle") {
 				scanner.CheckType(scanner.Next(), Token::TK_EQUAL);
 				tok = scanner.Next();
 				data->bFixedAngle_ = tok.GetElement() == L"true";
-			}
-			else if(element == L"AnimationData")
-			{
+			} else if (element == L"AnimationData") {
 				_ScanAnimation(data, scanner);
 			}
 		}
 	}
 
-	if(id >= 0) 
-	{
-		if(data->listCol_.size() == 0)
-		{
+	if (id >= 0) {
+		if (data->listCol_.size() == 0) {
 			RECT rect = data->rcSrc_;
-			int rx = abs(rect.right-rect.left);
-			int ry = abs(rect.bottom-rect.top);
+			int rx = abs(rect.right - rect.left);
+			int ry = abs(rect.bottom - rect.top);
 			int r = min(rx, ry);
 			r = r / 3 - 3;
-			if(r <= 3)r = 3;
+			if (r <= 3)
+				r = 3;
 			DxCircle circle(0, 0, r);
 			data->listCol_.push_back(circle);
 		}
-		if(listData.size() <= id) 
+		if (listData.size() <= id)
 			listData.resize(id + 1);
 
 		listData[id] = data;
@@ -557,25 +489,20 @@ void StgShotDataList::_ScanShot(std::vector<ref_count_ptr<StgShotData>::unsync >
 void StgShotDataList::_ScanAnimation(ref_count_ptr<StgShotData>::unsync shotData, Scanner& scanner)
 {
 	Token& tok = scanner.Next();
-	if(tok.GetType() == Token::TK_NEWLINE)tok = scanner.Next();
+	if (tok.GetType() == Token::TK_NEWLINE)
+		tok = scanner.Next();
 	scanner.CheckType(tok, Token::TK_OPENC);
 
-	while(true)
-	{
+	while (true) {
 		tok = scanner.Next();
-		if(tok.GetType() == Token::TK_CLOSEC)
-		{
+		if (tok.GetType() == Token::TK_CLOSEC)
 			break;
-		}
-		else if(tok.GetType() == Token::TK_ID)
-		{
+		else if (tok.GetType() == Token::TK_ID) {
 			std::wstring element = tok.GetElement();
 
-			if(element == L"animation_data")
-			{
+			if (element == L"animation_data") {
 				std::vector<std::wstring> list = _GetArgumentList(scanner);
-				if(list.size() == 5) 
-				{
+				if (list.size() == 5) {
 					StgShotData::AnimationData anime;
 					int frame = StringUtility::ToInteger(list[0]);
 					RECT rcSrc = {
@@ -602,22 +529,18 @@ std::vector<std::wstring> StgShotDataList::_GetArgumentList(Scanner& scanner)
 
 	Token& tok = scanner.Next();
 
-	if(tok.GetType() == Token::TK_OPENP)
-	{
-		while(true) 
-		{
+	if (tok.GetType() == Token::TK_OPENP) {
+		while (true) {
 			tok = scanner.Next();
 			int type = tok.GetType();
-			if(type == Token::TK_CLOSEP)break;
-			else if(type != Token::TK_COMMA)
-			{
+			if (type == Token::TK_CLOSEP)
+				break;
+			else if (type != Token::TK_COMMA) {
 				std::wstring str = tok.GetElement();
 				res.push_back(str);
 			}
 		}
-	}
-	else
-	{
+	} else {
 		res.push_back(tok.GetElement());
 	}
 	return res;
@@ -630,7 +553,7 @@ StgShotData::StgShotData(StgShotDataList* listShotData)
 	typeRender_ = DirectGraphics::MODE_BLEND_ALPHA;
 	typeDelayRender_ = DirectGraphics::MODE_BLEND_ADD_ARGB;
 	colorDelay_ = D3DCOLOR_ARGB(255, 255, 255, 255);
-	SetRect(&rcSrc_ , 0, 0, 0, 0);
+	SetRect(&rcSrc_, 0, 0, 0, 0);
 	SetRect(&rcDelay_, -1, -1, -1, -1);
 	alpha_ = 255;
 	totalAnimeFrame_ = 0;
@@ -643,19 +566,17 @@ StgShotData::~StgShotData()
 }
 RECT StgShotData::GetRect(int frame)
 {
-	if(totalAnimeFrame_ == 0) 
+	if (totalAnimeFrame_ == 0)
 		return rcSrc_;
 
 	RECT res;
 	frame = frame % totalAnimeFrame_;
 	int total = 0;
 	std::vector<AnimationData>::iterator itr = listAnime_.begin();
-	for(;itr != listAnime_.end();itr++) 
-	{
-		//AnimationData* anime = itr;
+	for (; itr != listAnime_.end(); itr++) {
+		// AnimationData* anime = itr;
 		total += itr->frame_;
-		if(total >= frame)
-		{
+		if (total >= frame) {
 			res = itr->rcSrc_;
 			break;
 		}
@@ -680,27 +601,24 @@ StgShotRenderer* StgShotData::GetRenderer(int type)
 StgShotRenderer* StgShotData::GetRendererFromGraphicsBlendType(int blendType)
 {
 	StgShotRenderer* res = NULL;
-	if(blendType == DirectGraphics::MODE_BLEND_ALPHA)
+	if (blendType == DirectGraphics::MODE_BLEND_ALPHA)
 		res = listShotData_->GetRenderer(indexTexture_, StgShotDataList::RENDER_ALPHA).GetPointer();
-	else if(blendType == DirectGraphics::MODE_BLEND_ADD_RGB)
+	else if (blendType == DirectGraphics::MODE_BLEND_ADD_RGB)
 		res = listShotData_->GetRenderer(indexTexture_, StgShotDataList::RENDER_ADD_RGB).GetPointer();
-	else if(blendType == DirectGraphics::MODE_BLEND_ADD_ARGB)
+	else if (blendType == DirectGraphics::MODE_BLEND_ADD_ARGB)
 		res = listShotData_->GetRenderer(indexTexture_, StgShotDataList::RENDER_ADD_ARGB).GetPointer();
-	else if(blendType == DirectGraphics::MODE_BLEND_MULTIPLY)
+	else if (blendType == DirectGraphics::MODE_BLEND_MULTIPLY)
 		res = listShotData_->GetRenderer(indexTexture_, StgShotDataList::RENDER_MULTIPLY).GetPointer();
-	else if(blendType == DirectGraphics::MODE_BLEND_SUBTRACT)
+	else if (blendType == DirectGraphics::MODE_BLEND_SUBTRACT)
 		res = listShotData_->GetRenderer(indexTexture_, StgShotDataList::RENDER_SUBTRACT).GetPointer();
-	else if(blendType == DirectGraphics::MODE_BLEND_INV_DESTRGB)
+	else if (blendType == DirectGraphics::MODE_BLEND_INV_DESTRGB)
 		res = listShotData_->GetRenderer(indexTexture_, StgShotDataList::RENDER_INV_DESTRGB).GetPointer();
 	return res;
 }
 bool StgShotData::IsAlphaBlendValidType(int blendType)
 {
 	bool bValidAlpha = false;
-	if(blendType == DirectGraphics::MODE_BLEND_ALPHA ||
-		blendType == DirectGraphics::MODE_BLEND_ADD_ARGB ||
-		blendType == DirectGraphics::MODE_BLEND_SUBTRACT)
-	{
+	if (blendType == DirectGraphics::MODE_BLEND_ALPHA || blendType == DirectGraphics::MODE_BLEND_ADD_ARGB || blendType == DirectGraphics::MODE_BLEND_SUBTRACT) {
 		bValidAlpha = true;
 	}
 	return bValidAlpha;
@@ -713,7 +631,6 @@ StgShotRenderer::StgShotRenderer()
 {
 	countRenderVertex_ = 0;
 	SetVertexCount(256 * 256);
-
 }
 int StgShotRenderer::GetVertexCount()
 {
@@ -726,7 +643,7 @@ void StgShotRenderer::Render()
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	IDirect3DDevice9* device = graphics->GetDevice();
 	ref_count_ptr<Texture>& texture = texture_[0];
-	if(texture != NULL)
+	if (texture != NULL)
 		device->SetTexture(0, texture->GetD3DTexture());
 	else
 		device->SetTexture(0, NULL);
@@ -755,7 +672,8 @@ void StgShotRenderer::AddSquareVertex(VERTEX_TLX* listVertex)
 /**********************************************************
 //StgShotObject
 **********************************************************/
-StgShotObject::StgShotObject(StgStageController* stageController) : StgMoveObject(stageController)
+StgShotObject::StgShotObject(StgStageController* stageController)
+	: StgMoveObject(stageController)
 {
 	stageController_ = stageController;
 
@@ -789,36 +707,32 @@ StgShotObject::StgShotObject(StgStageController* stageController) : StgMoveObjec
 }
 StgShotObject::~StgShotObject()
 {
-	if(listReserveShot_ != NULL)
-	{
+	if (listReserveShot_ != NULL)
 		listReserveShot_->Clear(stageController_);
-	}
 }
 void StgShotObject::Work()
 {
 }
 void StgShotObject::_Move()
 {
-	if(delay_ == 0)
+	if (delay_ == 0)
 		StgMoveObject::_Move();
 	SetX(posX_);
 	SetY(posY_);
 
 	//弾画像置き換え処理
-	if(pattern_ != NULL)
-	{
+	if (pattern_ != NULL) {
 		int idShot = pattern_->GetShotDataID();
-		if(idShot != StgMovePattern::NO_CHANGE)
-		{
+		if (idShot != StgMovePattern::NO_CHANGE) {
 			SetShotDataID(idShot);
 		}
 	}
 }
 void StgShotObject::_DeleteInLife()
 {
-	if(IsDeleted())return;
-	if(life_ <= 0)
-	{
+	if (IsDeleted())
+		return;
+	if (life_ <= 0) {
 		_SendDeleteEvent(StgShotManager::BIT_EV_DELETE_IMMEDIATE);
 		ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 		objectManager->DeleteObject(idObject_);
@@ -826,21 +740,22 @@ void StgShotObject::_DeleteInLife()
 }
 void StgShotObject::_DeleteInAutoClip()
 {
-	if(IsDeleted())return;
-	if(!IsAutoDelete())return;
+	if (IsDeleted())
+		return;
+	if (!IsAutoDelete())
+		return;
 	StgShotManager* shotManager = stageController_->GetShotManager();
 	RECT rect = shotManager->GetShotAutoDeleteClipRect();
-	if(posX_ < rect.left  || posX_ > rect.right || posY_ < rect.top || posY_ > rect.bottom)
-	{
+	if (posX_ < rect.left || posX_ > rect.right || posY_ < rect.top || posY_ > rect.bottom) {
 		ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 		objectManager->DeleteObject(idObject_);
 	}
 }
 void StgShotObject::_DeleteInFadeDelete()
 {
-	if(IsDeleted())return;
-	if(frameFadeDelete_ == 0)
-	{
+	if (IsDeleted())
+		return;
+	if (frameFadeDelete_ == 0) {
 		_SendDeleteEvent(StgShotManager::BIT_EV_DELETE_FADE);
 		ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 		objectManager->DeleteObject(idObject_);
@@ -848,11 +763,12 @@ void StgShotObject::_DeleteInFadeDelete()
 }
 void StgShotObject::_DeleteInAutoDeleteFrame()
 {
-	if(IsDeleted())return;
-	if(delay_ > 0)return;
+	if (IsDeleted())
+		return;
+	if (delay_ > 0)
+		return;
 
-	if(frameAutoDelete_ <= 0)
-	{
+	if (frameAutoDelete_ <= 0) {
 		_SendDeleteEvent(StgShotManager::BIT_EV_DELETE_IMMEDIATE);
 		ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 		objectManager->DeleteObject(idObject_);
@@ -862,15 +778,18 @@ void StgShotObject::_DeleteInAutoDeleteFrame()
 }
 void StgShotObject::_SendDeleteEvent(int bit)
 {
-	if(typeOwner_ != OWNER_ENEMY)return;
+	if (typeOwner_ != OWNER_ENEMY)
+		return;
 
 	StgStageScriptManager* stageScriptManager = stageController_->GetScriptManagerP();
 	ref_count_ptr<ManagedScript> scriptShot = stageScriptManager->GetShotScript();
-	if(scriptShot == NULL)return;
+	if (scriptShot == NULL)
+		return;
 
 	StgShotManager* shotManager = stageController_->GetShotManager();
 	bool bSendEnable = shotManager->IsDeleteEventEnable(bit);
-	if(!bSendEnable)return;
+	if (!bSendEnable)
+		return;
 
 	int posX = GetPositionX();
 	int posY = GetPositionY();
@@ -880,13 +799,12 @@ void StgShotObject::_SendDeleteEvent(int bit)
 	listPos.push_back(posY);
 
 	int typeEvent = 0;
-	switch(bit)
-	{
+	switch (bit) {
 	case StgShotManager::BIT_EV_DELETE_IMMEDIATE:
 		typeEvent = StgStageShotScript::EV_DELETE_SHOT_IMMEDIATE;
 		break;
 	case StgShotManager::BIT_EV_DELETE_TO_ITEM:
-		typeEvent = StgStageShotScript::EV_DELETE_SHOT_TO_ITEM;	
+		typeEvent = StgStageShotScript::EV_DELETE_SHOT_TO_ITEM;
 		break;
 	case StgShotManager::BIT_EV_DELETE_FADE:
 		typeEvent = StgStageShotScript::EV_DELETE_SHOT_FADE;
@@ -900,25 +818,25 @@ void StgShotObject::_SendDeleteEvent(int bit)
 }
 void StgShotObject::_AddReservedShotWork()
 {
-	if(IsDeleted())return;
-	if(listReserveShot_ == NULL)return;
+	if (IsDeleted())
+		return;
+	if (listReserveShot_ == NULL)
+		return;
 	ref_count_ptr<ReserveShotList::ListElement>::unsync listData = listReserveShot_->GetNextFrameData();
-	if(listData == NULL)return;
+	if (listData == NULL)
+		return;
 
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 	std::list<ReserveShotListData>* list = listData->GetDataList();
 	std::list<ReserveShotListData>::iterator itr = list->begin();
-	for(; itr != list->end() ; itr++)
-	{
+	for (; itr != list->end(); itr++) {
 		StgShotObject::ReserveShotListData& data = (*itr);
 		int idShot = data.GetShotID();
-		ref_count_ptr<StgShotObject>::unsync obj = 
-			ref_count_ptr<StgShotObject>::unsync::DownCast(objectManager->GetObject(idShot));
-		if(obj == NULL || obj->IsDeleted())continue;
-
+		ref_count_ptr<StgShotObject>::unsync obj = ref_count_ptr<StgShotObject>::unsync::DownCast(objectManager->GetObject(idShot));
+		if (obj == NULL || obj->IsDeleted())
+			continue;
 		_AddReservedShot(obj, &data);
 	}
-
 }
 
 void StgShotObject::_AddReservedShot(ref_count_ptr<StgShotObject>::unsync obj, StgShotObject::ReserveShotListData* data)
@@ -928,7 +846,7 @@ void StgShotObject::_AddReservedShot(ref_count_ptr<StgShotObject>::unsync obj, S
 	double ownAngle = GetDirectionAngle();
 	double ox = GetPositionX();
 	double oy = GetPositionY();
-	
+
 	double dRadius = data->GetRadius();
 	double dAngle = data->GetAngle();
 	double sx = obj->GetPositionX();
@@ -949,17 +867,14 @@ void StgShotObject::_AddReservedShot(ref_count_ptr<StgShotObject>::unsync obj, S
 
 void StgShotObject::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget)
 {
-
 }
 StgShotData* StgShotObject::_GetShotData()
 {
 	StgShotData* res = NULL;
 	StgShotManager* shotManager = stageController_->GetShotManager();
-	StgShotDataList* dataList = (typeOwner_ == OWNER_PLAYER) ?
-		shotManager->GetPlayerShotDataList() : shotManager->GetEnemyShotDataList();
+	StgShotDataList* dataList = (typeOwner_ == OWNER_PLAYER) ? shotManager->GetPlayerShotDataList() : shotManager->GetEnemyShotDataList();
 
-	if(dataList != NULL)
-	{
+	if (dataList != NULL) {
 		res = dataList->GetData(idShotData_).GetPointer();
 	}
 
@@ -980,8 +895,9 @@ void StgShotObject::_SetVertexPosition(VERTEX_TLX& vertex, float x, float y, flo
 void StgShotObject::_SetVertexUV(VERTEX_TLX& vertex, float u, float v)
 {
 	StgShotData* shotData = _GetShotData();
-	if(shotData == NULL)return;
-	
+	if (shotData == NULL)
+		return;
+
 	ref_count_ptr<Texture> texture = shotData->GetTexture();
 	int width = texture->GetWidth();
 	int height = texture->GetHeight();
@@ -1008,16 +924,16 @@ void StgShotObject::AddShot(int frame, int idShot, int radius, int angle)
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 	objectManager->ActivateObject(idShot, false);
 
-	if(listReserveShot_ == NULL)
+	if (listReserveShot_ == NULL)
 		listReserveShot_ = new ReserveShotList();
 	listReserveShot_->AddData(frame, idShot, radius, angle);
 }
 void StgShotObject::ConvertToItem()
 {
-	if(IsDeleted())return;
+	if (IsDeleted())
+		return;
 
-	if(bChangeItemEnable_)
-	{
+	if (bChangeItemEnable_) {
 		_ConvertToItemAndSendEvent();
 		_SendDeleteEvent(StgShotManager::BIT_EV_DELETE_TO_ITEM);
 	}
@@ -1027,7 +943,8 @@ void StgShotObject::ConvertToItem()
 }
 void StgShotObject::DeleteImmediate()
 {
-	if(IsDeleted())return;
+	if (IsDeleted())
+		return;
 
 	_SendDeleteEvent(StgShotManager::BIT_EV_DELETE_IMMEDIATE);
 
@@ -1039,8 +956,7 @@ void StgShotObject::DeleteImmediate()
 ref_count_ptr<StgShotObject::ReserveShotList::ListElement>::unsync StgShotObject::ReserveShotList::GetNextFrameData()
 {
 	ref_count_ptr<ListElement>::unsync res = NULL;
-	if(mapData_.find(frame_) != mapData_.end())
-	{
+	if (mapData_.find(frame_) != mapData_.end()) {
 		res = mapData_[frame_];
 		mapData_.erase(frame_);
 	}
@@ -1051,13 +967,10 @@ ref_count_ptr<StgShotObject::ReserveShotList::ListElement>::unsync StgShotObject
 void StgShotObject::ReserveShotList::AddData(int frame, int idShot, int radius, int angle)
 {
 	ref_count_ptr<ListElement>::unsync list;
-	if(mapData_.find(frame) == mapData_.end())
-	{
+	if (mapData_.find(frame) == mapData_.end()) {
 		list = new ListElement();
 		mapData_[frame] = list;
-	}
-	else
-	{
+	} else {
 		list = mapData_[frame];
 	}
 
@@ -1070,21 +983,20 @@ void StgShotObject::ReserveShotList::AddData(int frame, int idShot, int radius, 
 void StgShotObject::ReserveShotList::Clear(StgStageController* stageController)
 {
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController->GetMainObjectManager();
-	if(objectManager == NULL)return;
+	if (objectManager == NULL)
+		return;
 
-	std::map<int, ref_count_ptr<ListElement>::unsync >::iterator itrMap = mapData_.begin();
-	for(;itrMap != mapData_.end() ; itrMap++)
-	{
+	std::map<int, ref_count_ptr<ListElement>::unsync>::iterator itrMap = mapData_.begin();
+	for (; itrMap != mapData_.end(); itrMap++) {
 		ref_count_ptr<ListElement>::unsync listElement = itrMap->second;
 		std::list<ReserveShotListData>* list = listElement->GetDataList();
 		std::list<ReserveShotListData>::iterator itr = list->begin();
-		for(; itr != list->end() ; itr++)
-		{
+		for (; itr != list->end(); itr++) {
 			StgShotObject::ReserveShotListData& data = (*itr);
 			int idShot = data.GetShotID();
-			ref_count_ptr<StgShotObject>::unsync objShot = 
-				ref_count_ptr<StgShotObject>::unsync::DownCast(objectManager->GetObject(idShot));
-			if(objShot != NULL)objShot->ClearShotObject();
+			ref_count_ptr<StgShotObject>::unsync objShot = ref_count_ptr<StgShotObject>::unsync::DownCast(objectManager->GetObject(idShot));
+			if (objShot != NULL)
+				objShot->ClearShotObject();
 			objectManager->DeleteObject(idShot);
 		}
 	}
@@ -1093,30 +1005,28 @@ void StgShotObject::ReserveShotList::Clear(StgStageController* stageController)
 /**********************************************************
 //StgNormalShotObject
 **********************************************************/
-StgNormalShotObject::StgNormalShotObject(StgStageController* stageController) : StgShotObject(stageController)
+StgNormalShotObject::StgNormalShotObject(StgStageController* stageController)
+	: StgShotObject(stageController)
 {
 	typeObject_ = StgStageScript::OBJ_SHOT;
 	angularVelocity_ = 0;
 }
 StgNormalShotObject::~StgNormalShotObject()
 {
-
 }
 void StgNormalShotObject::Work()
 {
 	_Move();
-	if(delay_ == 0)
-	{
+	if (delay_ == 0) {
 		_AddReservedShotWork();
 	}
-	
+
 	delay_ = max(delay_ - 1, 0);
 	frameWork_++;
 
 	angle_.z += angularVelocity_;
 
-	if(frameFadeDelete_ >= 0)
-	{
+	if (frameFadeDelete_ >= 0) {
 		frameFadeDelete_--;
 	}
 
@@ -1128,33 +1038,37 @@ void StgNormalShotObject::Work()
 
 void StgNormalShotObject::_AddIntersectionRelativeTarget()
 {
-	if(delay_ > 0)return;
-	if(frameFadeDelete_ >= 0)return;
+	if (delay_ > 0)
+		return;
+	if (frameFadeDelete_ >= 0)
+		return;
 	ClearIntersected();
-	if(IsDeleted())return;
-	if(bUserIntersectionMode_)return;//ユーザ定義あたり判定モード
-	if(!bIntersectionEnable_)return;
+	if (IsDeleted())
+		return;
+	if (bUserIntersectionMode_)
+		return; //ユーザ定義あたり判定モード
+	if (!bIntersectionEnable_)
+		return;
 
 	StgShotData* shotData = _GetShotData();
-	if(shotData == NULL)return;
+	if (shotData == NULL)
+		return;
 
 	StgIntersectionManager* intersectionManager = stageController_->GetIntersectionManager();
 	std::vector<DxCircle>* listCircle = shotData->GetIntersectionCircleList();
-	if(GetIntersectionRelativeTargetCount() != listCircle->size())
-	{
+	if (GetIntersectionRelativeTargetCount() != listCircle->size()) {
 		ClearIntersectionRelativeTarget();
 
 		ref_count_ptr<StgShotObject>::unsync obj = GetOwnObject();
-		if(obj == NULL)return;
+		if (obj == NULL)
+			return;
 		ref_count_weak_ptr<StgShotObject>::unsync wObj = obj;
 
-		for(int iTarget = 0 ; iTarget < listCircle->size() ; iTarget++)
-		{
-			ref_count_ptr<StgIntersectionTarget_Circle>::unsync target =
-				ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
-			if(typeOwner_ == OWNER_PLAYER)
+		for (int iTarget = 0; iTarget < listCircle->size(); iTarget++) {
+			ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
+			if (typeOwner_ == OWNER_PLAYER)
 				target->SetTargetType(StgIntersectionTarget::TYPE_PLAYER_SHOT);
-			else 
+			else
 				target->SetTargetType(StgIntersectionTarget::TYPE_ENEMY_SHOT);
 			target->SetObject(wObj);
 			AddIntersectionRelativeTarget(target);
@@ -1162,92 +1076,88 @@ void StgNormalShotObject::_AddIntersectionRelativeTarget()
 	}
 
 	bool bInvalid = true;
-	for(int iCircle = 0 ; iCircle < listCircle->size() ; iCircle++)
-	{
+	for (int iCircle = 0; iCircle < listCircle->size(); iCircle++) {
 		ref_count_ptr<StgIntersectionTarget>::unsync target = GetIntersectionRelativeTarget(iCircle);
 		StgIntersectionTarget_Circle* cTarget = (StgIntersectionTarget_Circle*)target.GetPointer();
 
 		DxCircle circle = listCircle->at(iCircle);
-		if(circle.GetX() != 0 || circle.GetY() != 0) 
-		{
+		if (circle.GetX() != 0 || circle.GetY() != 0) {
 			double angleZ = 0;
-			if(!shotData->IsFixedAngle())angleZ = GetDirectionAngle() + 90 + angle_.z;
-			else angleZ = angle_.z;
+			if (!shotData->IsFixedAngle())
+				angleZ = GetDirectionAngle() + 90 + angle_.z;
+			else
+				angleZ = angle_.z;
 
 			double px = circle.GetX() * cos(D3DXToRadian(angleZ)) - (-circle.GetY()) * sin(D3DXToRadian(angleZ));
 			double py = circle.GetX() * sin(D3DXToRadian(angleZ)) + (-circle.GetY()) * cos(D3DXToRadian(angleZ));
 			circle.SetX(px + posX_);
 			circle.SetY(py + posY_);
-		}
-		else
-		{
+		} else {
 			circle.SetX(circle.GetX() + posX_);
 			circle.SetY(circle.GetY() + posY_);
 		}
 		cTarget->SetCircle(circle);
 
 		RECT rect = cTarget->GetIntersectionSapceRect();
-		if(rect.left != rect.right && rect.top != rect.bottom)
+		if (rect.left != rect.right && rect.top != rect.bottom)
 			bInvalid = false;
 	}
 
-	if(typeOwner_ == OWNER_PLAYER)
-	{
+	if (typeOwner_ == OWNER_PLAYER) {
 		//自弾の場合は登録
 		bInvalid = false;
-	}
-	else
-	{
+	} else {
 		//自機の移動範囲が負の値が可能であれば敵弾でも登録
 		ref_count_ptr<StgPlayerObject>::unsync player = stageController_->GetPlayerObject();
-		if(player != NULL)
-		{
+		if (player != NULL) {
 			RECT rcClip = player->GetClip();
-			if(rcClip.left < 0 || rcClip.top < 0)
+			if (rcClip.left < 0 || rcClip.top < 0)
 				bInvalid = false;
 		}
 	}
 
-	if(!bInvalid)
+	if (!bInvalid)
 		RegistIntersectionRelativeTarget(intersectionManager);
 }
-std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > StgNormalShotObject::GetIntersectionTargetList()
+std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> StgNormalShotObject::GetIntersectionTargetList()
 {
-	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > res;
+	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> res;
 
-	if(delay_ > 0)return res;
-	if(frameFadeDelete_ >= 0)return res;
-	if(IsDeleted())return res;
-	if(bUserIntersectionMode_)return res;//ユーザ定義あたり判定モード
-	if(!bIntersectionEnable_)return res;
+	if (delay_ > 0)
+		return res;
+	if (frameFadeDelete_ >= 0)
+		return res;
+	if (IsDeleted())
+		return res;
+	if (bUserIntersectionMode_)
+		return res; //ユーザ定義あたり判定モード
+	if (!bIntersectionEnable_)
+		return res;
 
 	StgShotData* shotData = _GetShotData();
-	if(shotData == NULL)return res;
+	if (shotData == NULL)
+		return res;
 
 	std::vector<DxCircle>* listCircle = shotData->GetIntersectionCircleList();
 	StgIntersectionManager* intersectionManager = stageController_->GetIntersectionManager();
 
-
-	for(int iCircle = 0 ; iCircle < listCircle->size() ; iCircle++)
-	{
-		ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = 
-			ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
+	for (int iCircle = 0; iCircle < listCircle->size(); iCircle++) {
+		ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
 		StgIntersectionTarget_Circle* cTarget = (StgIntersectionTarget_Circle*)target.GetPointer();
 
 		DxCircle circle = listCircle->at(iCircle);
-		if(circle.GetX() != 0 || circle.GetY() != 0) 
-		{
+		if (circle.GetX() != 0 || circle.GetY() != 0) {
 			double angleZ = 0;
-			if(!shotData->IsFixedAngle())angleZ = GetDirectionAngle() + 90 + angle_.z;
-			else angleZ = angle_.z;
+			if (!shotData->IsFixedAngle())
+				angleZ = GetDirectionAngle() + 90 + angle_.z;
+			else
+				angleZ = angle_.z;
 
 			double px = circle.GetX() * cos(D3DXToRadian(angleZ)) - (-circle.GetY()) * sin(D3DXToRadian(angleZ));
 			double py = circle.GetX() * sin(D3DXToRadian(angleZ)) + (-circle.GetY()) * cos(D3DXToRadian(angleZ));
 			circle.SetX(px + posX_);
 			circle.SetY(py + posY_);
-		}
-		else
-		{
+		} else {
 			circle.SetX(circle.GetX() + posX_);
 			circle.SetY(circle.GetY() + posY_);
 		}
@@ -1261,59 +1171,55 @@ std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > StgNormalShotObject::
 
 void StgNormalShotObject::RenderOnShotManager(D3DXMATRIX& matO)
 {
-	if(!IsVisible())return;
+	if (!IsVisible())
+		return;
 	D3DXMATRIX mat = matO;
 
 	StgShotData* shotData = _GetShotData();
-	if(shotData == NULL)return;
+	if (shotData == NULL)
+		return;
 
 	StgShotRenderer* renderer = NULL;
 
 	int shotBlendType = DirectGraphics::MODE_BLEND_ALPHA;
-	if(delay_ > 0)
-	{
+	if (delay_ > 0) {
 		//遅延時間
 		int objDelayBlendType = GetSourceBlendType();
-		if(objDelayBlendType == DirectGraphics::MODE_BLEND_NONE)
-		{
+		if (objDelayBlendType == DirectGraphics::MODE_BLEND_NONE) {
 			shotBlendType = shotData->GetDelayRenderType();
 			renderer = shotData->GetRendererFromGraphicsBlendType(shotBlendType);
-		}
-		else
-		{
+		} else {
 			renderer = shotData->GetRendererFromGraphicsBlendType(objDelayBlendType);
 		}
-	}
-	else
-	{
+	} else {
 		int objBlendType = GetBlendType();
-		if(objBlendType == DirectGraphics::MODE_BLEND_NONE)
-		{
+		if (objBlendType == DirectGraphics::MODE_BLEND_NONE) {
 			renderer = shotData->GetRenderer();
 			shotBlendType = shotData->GetRenderType();
-		}
-		else
-		{
+		} else {
 			renderer = shotData->GetRendererFromGraphicsBlendType(objBlendType);
 		}
 	}
 
-	if(renderer == NULL)return;
+	if (renderer == NULL)
+		return;
 
 	D3DXMATRIX matScale;
 	D3DXMATRIX matRot;
 	D3DXMATRIX matTrans;
 	RECT rcSrc;
 	D3DCOLOR color;
-	if(delay_ > 0)
-	{
+	if (delay_ > 0) {
 		//遅延時間
 		double expa = 0.5f + (double)delay_ / 30.0f * 2;
-		if(expa > 2)expa = 2;
+		if (expa > 2)
+			expa = 2;
 
 		double angleZ = 0;
-		if(!shotData->IsFixedAngle())angleZ = GetDirectionAngle() + 90 + angle_.z;
-		else angleZ = angle_.z;
+		if (!shotData->IsFixedAngle())
+			angleZ = GetDirectionAngle() + 90 + angle_.z;
+		else
+			angleZ = angle_.z;
 
 		D3DXMatrixScaling(&matScale, expa, expa, 1.0f);
 		D3DXMatrixRotationYawPitchRoll(&matRot, D3DXToRadian(angle_.y), D3DXToRadian(angle_.x), D3DXToRadian(angleZ));
@@ -1322,12 +1228,12 @@ void StgNormalShotObject::RenderOnShotManager(D3DXMATRIX& matO)
 
 		rcSrc = shotData->GetDelayRect();
 		color = shotData->GetDelayColor();
-	}
-	else
-	{
+	} else {
 		double angleZ = 0;
-		if(!shotData->IsFixedAngle())angleZ = GetDirectionAngle() + 90 + angle_.z;
-		else angleZ = angle_.z;
+		if (!shotData->IsFixedAngle())
+			angleZ = GetDirectionAngle() + 90 + angle_.z;
+		else
+			angleZ = angle_.z;
 
 		D3DXMatrixScaling(&matScale, scale_.x, scale_.y, scale_.z);
 		D3DXMatrixRotationYawPitchRoll(&matRot, D3DXToRadian(angle_.y), D3DXToRadian(angle_.x), D3DXToRadian(angleZ));
@@ -1337,18 +1243,15 @@ void StgNormalShotObject::RenderOnShotManager(D3DXMATRIX& matO)
 		rcSrc = shotData->GetRect(frameWork_);
 		color = color_;
 		double alpha = shotData->GetAlpha() / 255.0;
-		if(frameFadeDelete_ >= 0) 
+		if (frameFadeDelete_ >= 0)
 			alpha = (double)frameFadeDelete_ / (double)FRAME_FADEDELETE;
 
 		bool bValidAlpha = StgShotData::IsAlphaBlendValidType(shotBlendType);
-		if(bValidAlpha)
-		{
+		if (bValidAlpha) {
 			//α有効
 			int colorA = ColorAccess::GetColorA(color);
 			color = ColorAccess::SetColorA(color, alpha * colorA);
-		}
-		else
-		{
+		} else {
 			//α無効
 			color = ColorAccess::ApplyAlpha(color, alpha);
 		}
@@ -1356,19 +1259,20 @@ void StgNormalShotObject::RenderOnShotManager(D3DXMATRIX& matO)
 
 	int width = rcSrc.right - rcSrc.left;
 	int height = rcSrc.bottom - rcSrc.top;
-	RECT rcDest = {-width / 2, -height / 2, width / 2, height / 2};
-	if(width % 2 == 1)rcDest.right += 1;
-	if(height % 2 == 1)rcDest.bottom += 1;
+	RECT rcDest = { -width / 2, -height / 2, width / 2, height / 2 };
+	if (width % 2 == 1)
+		rcDest.right += 1;
+	if (height % 2 == 1)
+		rcDest.bottom += 1;
 
 	//if(bIntersected_)color = D3DCOLOR_ARGB(255, 255, 0, 0);//接触テスト
 
 	VERTEX_TLX verts[4];
-	int srcX[] = {rcSrc.left, rcSrc.right, rcSrc.left, rcSrc.right};
-	int srcY[] = {rcSrc.top, rcSrc.top, rcSrc.bottom, rcSrc.bottom};
-	int destX[] = {rcDest.left, rcDest.right, rcDest.left, rcDest.right};
-	int destY[] = {rcDest.top, rcDest.top, rcDest.bottom, rcDest.bottom};
-	for(int iVert = 0 ;iVert < 4 ; iVert++)
-	{
+	int srcX[] = { rcSrc.left, rcSrc.right, rcSrc.left, rcSrc.right };
+	int srcY[] = { rcSrc.top, rcSrc.top, rcSrc.bottom, rcSrc.bottom };
+	int destX[] = { rcDest.left, rcDest.right, rcDest.left, rcDest.right };
+	int destY[] = { rcDest.top, rcDest.top, rcDest.bottom, rcDest.bottom };
+	for (int iVert = 0; iVert < 4; iVert++) {
 		_SetVertexUV(verts[iVert], srcX[iVert], srcY[iVert]);
 		_SetVertexPosition(verts[iVert], destX[iVert], destY[iVert]);
 		_SetVertexColorARGB(verts[iVert], color);
@@ -1391,47 +1295,40 @@ void StgNormalShotObject::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync
 {
 	double damage = 0;
 	int otherType = otherTarget->GetTargetType();
-	switch(otherType)
-	{
-		case StgIntersectionTarget::TYPE_PLAYER:
-		{
-			//自機
-			frameGrazeInvalid_ = INT_MAX;
-			break;
+	switch (otherType) {
+	case StgIntersectionTarget::TYPE_PLAYER: {
+		//自機
+		frameGrazeInvalid_ = INT_MAX;
+		break;
+	}
+	case StgIntersectionTarget::TYPE_PLAYER_SHOT: {
+		//自機弾
+		StgShotObject* shot = (StgShotObject*)otherTarget->GetObject().GetPointer();
+		if (shot != NULL) {
+			bool bEraseShot = shot->IsEraseShot();
+			if (bEraseShot && life_ != LIFE_SPELL_REGIST)
+				ConvertToItem();
 		}
-		case StgIntersectionTarget::TYPE_PLAYER_SHOT:
-		{
-			//自機弾
-			StgShotObject* shot = (StgShotObject*)otherTarget->GetObject().GetPointer();
-			if(shot != NULL)
-			{
-				bool bEraseShot = shot->IsEraseShot();
-				if(bEraseShot && life_ != LIFE_SPELL_REGIST)
-					ConvertToItem();
-			}
-			break;
+		break;
+	}
+	case StgIntersectionTarget::TYPE_PLAYER_SPELL: {
+		//自機スペル
+		StgPlayerSpellObject* spell = (StgPlayerSpellObject*)otherTarget->GetObject().GetPointer();
+		if (spell != NULL) {
+			bool bEraseShot = spell->IsEraseShot();
+			if (bEraseShot && life_ != LIFE_SPELL_REGIST)
+				ConvertToItem();
 		}
-		case StgIntersectionTarget::TYPE_PLAYER_SPELL:
-		{
-			//自機スペル
-			StgPlayerSpellObject* spell = (StgPlayerSpellObject*)otherTarget->GetObject().GetPointer();
-			if(spell != NULL)
-			{
-				bool bEraseShot = spell->IsEraseShot();
-				if(bEraseShot && life_ != LIFE_SPELL_REGIST)
-					ConvertToItem();
-			}
-			break;
-		}
-		case StgIntersectionTarget::TYPE_ENEMY:
-		case StgIntersectionTarget::TYPE_ENEMY_SHOT:
-		{
-			damage = 1;
-			break;
-		}
+		break;
+	}
+	case StgIntersectionTarget::TYPE_ENEMY:
+	case StgIntersectionTarget::TYPE_ENEMY_SHOT: {
+		damage = 1;
+		break;
+	}
 	}
 
-	if(life_ != LIFE_SPELL_REGIST)
+	if (life_ != LIFE_SPELL_REGIST)
 		life_ = max(life_ - damage, 0);
 }
 void StgNormalShotObject::_ConvertToItemAndSendEvent()
@@ -1442,8 +1339,7 @@ void StgNormalShotObject::_ConvertToItemAndSendEvent()
 
 	int posX = GetPositionX();
 	int posY = GetPositionY();
-	if(scriptItem != NULL)
-	{
+	if (scriptItem != NULL) {
 		std::vector<long double> listPos;
 		listPos.push_back(posX);
 		listPos.push_back(posY);
@@ -1454,13 +1350,11 @@ void StgNormalShotObject::_ConvertToItemAndSendEvent()
 		scriptItem->RequestEvent(StgStageScript::EV_DELETE_SHOT_TO_ITEM, listScriptValue);
 	}
 
-	if(itemManager->IsDefaultBonusItemEnable())
-	{
+	if (itemManager->IsDefaultBonusItemEnable()) {
 		ref_count_ptr<StgItemObject>::unsync obj = new StgItemObject_Bonus(stageController_);
 		ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 		int id = objectManager->AddObject(obj);
-		if(id != DxScript::ID_INVALID)
-		{
+		if (id != DxScript::ID_INVALID) {
 			//弾の座標にアイテムを作成する
 			StgItemManager* itemManager = stageController_->GetItemManager();
 			itemManager->AddItem(obj);
@@ -1471,11 +1365,8 @@ void StgNormalShotObject::_ConvertToItemAndSendEvent()
 }
 void StgNormalShotObject::RegistIntersectionTarget()
 {
-	if(!bUserIntersectionMode_)
-	{
+	if (!bUserIntersectionMode_)
 		_AddIntersectionRelativeTarget();
-	}
-
 }
 void StgNormalShotObject::SetShotDataID(int id)
 {
@@ -1484,31 +1375,27 @@ void StgNormalShotObject::SetShotDataID(int id)
 
 	//角速度更新
 	StgShotData* shotData = _GetShotData();
-	if(shotData != NULL && oldData != shotData)
-	{
-		if(angularVelocity_ != 0)
-		{
+	if (shotData != NULL && oldData != shotData) {
+		if (angularVelocity_ != 0) {
 			angularVelocity_ = 0;
 			angle_.z = 0;
 		}
 
 		double avMin = shotData->GetAngularVelocityMin();
 		double avMax = shotData->GetAngularVelocityMax();
-		if(avMin != 0 || avMax != 0)
-		{
+		if (avMin != 0 || avMax != 0) {
 			ref_count_ptr<StgStageInformation> stageInfo = stageController_->GetStageInformation();
 			ref_count_ptr<MersenneTwister> rand = stageInfo->GetMersenneTwister();
 			angularVelocity_ = rand->GetReal(avMin, avMax);
 		}
-
 	}
-
 }
 
 /**********************************************************
 //StgLaserObject(レーザー基本部)
 **********************************************************/
-StgLaserObject::StgLaserObject(StgStageController* stageController) : StgShotObject(stageController)
+StgLaserObject::StgLaserObject(StgStageController* stageController)
+	: StgShotObject(stageController)
 {
 	life_ = LIFE_SPELL_REGIST;
 	length_ = 0;
@@ -1522,13 +1409,16 @@ StgLaserObject::StgLaserObject(StgStageController* stageController) : StgShotObj
 void StgLaserObject::SetLength(int length)
 {
 	length_ = length;
-	if(invalidLengthStart_<0)invalidLengthStart_=length_*0.1;
-	if(invalidLengthEnd_<0)invalidLengthEnd_=length_*0.1;
+	if (invalidLengthStart_ < 0)
+		invalidLengthStart_ = length_ * 0.1;
+	if (invalidLengthEnd_ < 0)
+		invalidLengthEnd_ = length_ * 0.1;
 }
 void StgLaserObject::SetRenderWidth(int width)
 {
 	widthRender_ = width;
-	if(widthIntersection_ < 0)widthIntersection_=width/4;
+	if (widthIntersection_ < 0)
+		widthIntersection_ = width / 4;
 }
 void StgLaserObject::ClearShotObject()
 {
@@ -1536,114 +1426,102 @@ void StgLaserObject::ClearShotObject()
 }
 void StgLaserObject::_AddIntersectionRelativeTarget()
 {
-	if(delay_ > 0)return;
-	if(frameFadeDelete_ >= 0)return;
+	if (delay_ > 0)
+		return;
+	if (frameFadeDelete_ >= 0)
+		return;
 	ClearIntersected();
 
 	StgIntersectionManager* intersectionManager = stageController_->GetIntersectionManager();
-	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > listTarget = GetIntersectionTargetList();
-	for(int iTarget = 0 ; iTarget < listTarget.size() ; iTarget++)
+	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> listTarget = GetIntersectionTargetList();
+	for (int iTarget = 0; iTarget < listTarget.size(); iTarget++)
 		intersectionManager->AddTarget(listTarget[iTarget]);
 }
 void StgLaserObject::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget)
 {
 	double damage = 0;
 	int otherType = otherTarget->GetTargetType();
-	switch(otherType)
-	{
-		case StgIntersectionTarget::TYPE_PLAYER:
-		{
-			//自機
-			if(frameGrazeInvalid_ <= 0)
-			{
-				frameGrazeInvalid_ = frameGrazeInvalidStart_ > 0 ? frameGrazeInvalidStart_ : INT_MAX;
-			}
-			break;
+	switch (otherType) {
+	case StgIntersectionTarget::TYPE_PLAYER: {
+		//自機
+		if (frameGrazeInvalid_ <= 0) {
+			frameGrazeInvalid_ = frameGrazeInvalidStart_ > 0 ? frameGrazeInvalidStart_ : INT_MAX;
 		}
-		case StgIntersectionTarget::TYPE_PLAYER_SHOT:
-		{
-			//自機弾弾
-			StgShotObject* shot = (StgShotObject*)otherTarget->GetObject().GetPointer();
-			if(shot != NULL)
-			{
-				bool bEraseShot = shot->IsEraseShot();
-				if(bEraseShot && life_ != LIFE_SPELL_REGIST)
-				{
-					damage = shot->GetDamage();
-					ConvertToItem();
-				}
-			}
-			break;
-		}
-		case StgIntersectionTarget::TYPE_PLAYER_SPELL:
-		{
-			//自機スペル
-			StgPlayerSpellObject* spell = (StgPlayerSpellObject*)otherTarget->GetObject().GetPointer();
-			if(spell != NULL)
-			{
-				bool bEraseShot = spell->IsEraseShot();
-				if(bEraseShot && life_ != LIFE_SPELL_REGIST)
-				{
-					damage = spell->GetDamage();
-					ConvertToItem();
-				}
-			}
-			break;
-		}
+		break;
 	}
-	if(life_ != LIFE_SPELL_REGIST)
+	case StgIntersectionTarget::TYPE_PLAYER_SHOT: {
+		//自機弾弾
+		StgShotObject* shot = (StgShotObject*)otherTarget->GetObject().GetPointer();
+		if (shot != NULL) {
+			bool bEraseShot = shot->IsEraseShot();
+			if (bEraseShot && life_ != LIFE_SPELL_REGIST) {
+				damage = shot->GetDamage();
+				ConvertToItem();
+			}
+		}
+		break;
+	}
+	case StgIntersectionTarget::TYPE_PLAYER_SPELL: {
+		//自機スペル
+		StgPlayerSpellObject* spell = (StgPlayerSpellObject*)otherTarget->GetObject().GetPointer();
+		if (spell != NULL) {
+			bool bEraseShot = spell->IsEraseShot();
+			if (bEraseShot && life_ != LIFE_SPELL_REGIST) {
+				damage = spell->GetDamage();
+				ConvertToItem();
+			}
+		}
+		break;
+	}
+	}
+	if (life_ != LIFE_SPELL_REGIST)
 		life_ = max(life_ - damage, 0);
 }
-
 
 /**********************************************************
 //StgLooseLaserObject(射出型レーザー)
 **********************************************************/
-StgLooseLaserObject::StgLooseLaserObject(StgStageController* stageController) : StgLaserObject(stageController)
+StgLooseLaserObject::StgLooseLaserObject(StgStageController* stageController)
+	: StgLaserObject(stageController)
 {
 	typeObject_ = StgStageScript::OBJ_LOOSE_LASER;
 }
 void StgLooseLaserObject::Work()
 {
 	//1フレーム目は移動しない
-	if(frameWork_ == 0)
-	{
+	if (frameWork_ == 0) {
 		posXE_ = posX_;
 		posYE_ = posY_;
 	}
 
 	_Move();
-	if(delay_ == 0)
-	{
+	if (delay_ == 0)
 		_AddReservedShotWork();
-	}
-	
+
 	delay_ = max(delay_ - 1, 0);
 	frameWork_++;
 
-	if(frameFadeDelete_ >= 0)
-	{
+	if (frameFadeDelete_ >= 0)
 		frameFadeDelete_--;
-	}
 
 	_DeleteInAutoClip();
 	_DeleteInLife();
 	_DeleteInFadeDelete();
 	_DeleteInAutoDeleteFrame();
-//	_AddIntersectionRelativeTarget();
+	// _AddIntersectionRelativeTarget();
 	frameGrazeInvalid_--;
 }
 void StgLooseLaserObject::_Move()
 {
-	if(delay_ == 0)
+	if (delay_ == 0)
 		StgMoveObject::_Move();
 	DxScriptRenderObject::SetX(posX_);
 	DxScriptRenderObject::SetY(posY_);
 
-	if(delay_ > 0)return;
-	double radius = pow(pow(posXE_ - posX_,2)+pow(posYE_ - posY_,2), 0.5);
-	if(radius > length_)
-	{
+	if (delay_ > 0)
+		return;
+	double radius = pow(pow(posXE_ - posX_, 2) + pow(posYE_ - posY_, 2), 0.5);
+	if (radius > length_) {
 		double speed = GetSpeed();
 		double ang = GetDirectionAngle();
 		posXE_ += speed * cos(Math::DegreeToRadian(ang));
@@ -1652,41 +1530,48 @@ void StgLooseLaserObject::_Move()
 }
 void StgLooseLaserObject::_DeleteInAutoClip()
 {
-	if(IsDeleted())return;
-	if(!IsAutoDelete())return;
+	if (IsDeleted())
+		return;
+	if (!IsAutoDelete())
+		return;
 	StgShotManager* shotManager = stageController_->GetShotManager();
 	RECT rect = shotManager->GetShotAutoDeleteClipRect();
-	if((posX_ < rect.left && posXE_ < rect.left) || (posX_ > rect.right && posXE_ > rect.right) || 
-		(posY_ < rect.top && posYE_ < rect.top) || (posY_ > rect.bottom && posYE_ > rect.bottom))
-	{
+	if ((posX_ < rect.left && posXE_ < rect.left) || (posX_ > rect.right && posXE_ > rect.right) || (posY_ < rect.top && posYE_ < rect.top) || (posY_ > rect.bottom && posYE_ > rect.bottom)) {
 		ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 		objectManager->DeleteObject(idObject_);
 	}
 }
 
-std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > StgLooseLaserObject::GetIntersectionTargetList()
+std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> StgLooseLaserObject::GetIntersectionTargetList()
 {
-	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > res;
+	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> res;
 
-	if(delay_ > 0)return res;
-	if(frameFadeDelete_ >= 0)return res;
-	if(IsDeleted())return res;
-	if(bUserIntersectionMode_)return res;//ユーザ定義あたり判定モード
-	if(!bIntersectionEnable_)return res;
+	if (delay_ > 0)
+		return res;
+	if (frameFadeDelete_ >= 0)
+		return res;
+	if (IsDeleted())
+		return res;
+	if (bUserIntersectionMode_)
+		return res; //ユーザ定義あたり判定モード
+	if (!bIntersectionEnable_)
+		return res;
 
 	StgShotData* shotData = _GetShotData();
-	if(shotData == NULL)return res;
+	if (shotData == NULL)
+		return res;
 
 	ref_count_ptr<StgShotObject>::unsync obj = GetOwnObject();
-	if(obj == NULL)return res;
+	if (obj == NULL)
+		return res;
 
 	//当たり判定
 	double ang = GetDirectionAngle();
-	int length = pow(pow(posXE_ - posX_, 2) + pow(posYE_ - posY_, 2) , 0.5);
-	int invalidLengthS = min(length , invalidLengthStart_);
+	int length = pow(pow(posXE_ - posX_, 2) + pow(posYE_ - posY_, 2), 0.5);
+	int invalidLengthS = min(length, invalidLengthStart_);
 	int posXS = posX_ - invalidLengthS * cos(Math::DegreeToRadian(ang));
 	int posYS = posY_ - invalidLengthS * sin(Math::DegreeToRadian(ang));
-	int invalidLengthE = min(length , invalidLengthEnd_);
+	int invalidLengthE = min(length, invalidLengthEnd_);
 	int posXE = posXE_ + invalidLengthE * cos(Math::DegreeToRadian(ang));
 	int posYE = posYE_ + invalidLengthE * sin(Math::DegreeToRadian(ang));
 
@@ -1694,11 +1579,10 @@ std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > StgLooseLaserObject::
 	DxWidthLine line(posXS, posYS, posXE, posYE, widthIntersection_);
 
 	ref_count_weak_ptr<StgShotObject>::unsync wObj = obj;
-	ref_count_ptr<StgIntersectionTarget_Line>::unsync target = 
-		ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_LINE));
-	if(typeOwner_ == OWNER_PLAYER)
+	ref_count_ptr<StgIntersectionTarget_Line>::unsync target = ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_LINE));
+	if (typeOwner_ == OWNER_PLAYER)
 		target->SetTargetType(StgIntersectionTarget::TYPE_PLAYER_SHOT);
-	else 
+	else
 		target->SetTargetType(StgIntersectionTarget::TYPE_ENEMY_SHOT);
 	target->SetObject(wObj);
 	target->SetLine(line);
@@ -1709,44 +1593,38 @@ std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > StgLooseLaserObject::
 
 void StgLooseLaserObject::RenderOnShotManager(D3DXMATRIX& matO)
 {
-	if(!IsVisible())return;
+	if (!IsVisible())
+		return;
 	D3DXMATRIX mat = matO;
 
 	StgShotData* shotData = _GetShotData();
-	if(shotData == NULL)return;
+	if (shotData == NULL)
+		return;
 
 	int shotBlendType = StgShotDataList::RENDER_ADD_ARGB;
 	StgShotRenderer* renderer = NULL;
-	if(delay_ > 0)
-	{
+	if (delay_ > 0) {
 		//遅延時間
 		int objDelayBlendType = GetSourceBlendType();
-		if(objDelayBlendType == DirectGraphics::MODE_BLEND_NONE)
-		{
+		if (objDelayBlendType == DirectGraphics::MODE_BLEND_NONE) {
 			renderer = shotData->GetRenderer(StgShotDataList::RENDER_ADD_ARGB);
 			shotBlendType = DirectGraphics::MODE_BLEND_ADD_ARGB;
-		}
-		else
-		{
+		} else {
 			renderer = shotData->GetRendererFromGraphicsBlendType(objDelayBlendType);
 		}
-	}
-	else
-	{
+	} else {
 		int objBlendType = GetBlendType();
 		int shotBlendType = objBlendType;
-		if(objBlendType == DirectGraphics::MODE_BLEND_NONE)
-		{
+		if (objBlendType == DirectGraphics::MODE_BLEND_NONE) {
 			renderer = shotData->GetRenderer(StgShotDataList::RENDER_ADD_ARGB);
 			shotBlendType = DirectGraphics::MODE_BLEND_ADD_ARGB;
-		}
-		else
-		{
+		} else {
 			renderer = shotData->GetRendererFromGraphicsBlendType(objBlendType);
 		}
 	}
 
-	if(renderer == NULL)return;
+	if (renderer == NULL)
+		return;
 
 	D3DXMATRIX matScale;
 	D3DXMATRIX matRot;
@@ -1754,11 +1632,11 @@ void StgLooseLaserObject::RenderOnShotManager(D3DXMATRIX& matO)
 	RECT rcSrc;
 	RECT rcDest;
 	D3DCOLOR color;
-	if(delay_ > 0)
-	{
+	if (delay_ > 0) {
 		//遅延時間
 		double expa = 0.5f + (double)delay_ / 30.0f * 2;
-		if(expa > 3.5)expa = 3.5;
+		if (expa > 3.5)
+			expa = 3.5;
 
 		D3DXMatrixScaling(&matScale, expa, expa, 1.0f);
 		D3DXMatrixRotationYawPitchRoll(&matRot, 0, 0, D3DXToRadian(GetDirectionAngle() + 90));
@@ -1771,48 +1649,43 @@ void StgLooseLaserObject::RenderOnShotManager(D3DXMATRIX& matO)
 		int width = rcSrc.right - rcSrc.left;
 		int height = rcSrc.bottom - rcSrc.top;
 		SetRect(&rcDest, -width / 2, -height / 2, width / 2, height / 2);
-		if(width % 2 == 1)rcDest.right += 1;
-		if(height % 2 == 1)rcDest.bottom += 1;
-	}
-	else
-	{
+		if (width % 2 == 1)
+			rcDest.right += 1;
+		if (height % 2 == 1)
+			rcDest.bottom += 1;
+	} else {
 		D3DXMatrixScaling(&matScale, 1.0f, 1.0f, 1.0f);
 		D3DXMatrixRotationYawPitchRoll(&matRot, 0, 0, D3DXToRadian(GetDirectionAngle() + 90));
 		D3DXMatrixTranslation(&matTrans, position_.x, position_.y, position_.z);
 		mat = matScale * matRot * matTrans * mat;
 
-		double radius = pow(pow(posXE_ - posX_,2)+pow(posYE_-posY_,2), 0.5);
+		double radius = pow(pow(posXE_ - posX_, 2) + pow(posYE_ - posY_, 2), 0.5);
 		rcSrc = shotData->GetRect(frameWork_);
 		color = color_;
 		double alpha = shotData->GetAlpha() / 255.0;
-		if(frameFadeDelete_ >= 0) 
+		if (frameFadeDelete_ >= 0)
 			alpha = (double)frameFadeDelete_ / (double)FRAME_FADEDELETE;
 
 		bool bValidAlpha = StgShotData::IsAlphaBlendValidType(shotBlendType);
-		if(bValidAlpha)
-		{
+		if (bValidAlpha) {
 			//α有効
 			int colorA = ColorAccess::GetColorA(color);
 			color = ColorAccess::SetColorA(color, alpha * colorA);
-		}
-		else
-		{
+		} else {
 			//α無効
 			color = ColorAccess::ApplyAlpha(color, alpha);
 		}
 
 		color = ColorAccess::ApplyAlpha(color, alpha);
-		SetRect(&rcDest, -widthRender_/2, 0, widthRender_/2, radius);
+		SetRect(&rcDest, -widthRender_ / 2, 0, widthRender_ / 2, radius);
 	}
 
-
 	VERTEX_TLX verts[4];
-	int srcX[] = {rcSrc.left, rcSrc.right, rcSrc.left, rcSrc.right};
-	int srcY[] = {rcSrc.top, rcSrc.top, rcSrc.bottom, rcSrc.bottom};
-	int destX[] = {rcDest.left, rcDest.right, rcDest.left, rcDest.right};
-	int destY[] = {rcDest.top, rcDest.top, rcDest.bottom, rcDest.bottom};
-	for(int iVert = 0 ;iVert < 4 ; iVert++)
-	{
+	int srcX[] = { rcSrc.left, rcSrc.right, rcSrc.left, rcSrc.right };
+	int srcY[] = { rcSrc.top, rcSrc.top, rcSrc.bottom, rcSrc.bottom };
+	int destX[] = { rcDest.left, rcDest.right, rcDest.left, rcDest.right };
+	int destY[] = { rcDest.top, rcDest.top, rcDest.bottom, rcDest.bottom };
+	for (int iVert = 0; iVert < 4; iVert++) {
 		_SetVertexUV(verts[iVert], srcX[iVert], srcY[iVert]);
 		_SetVertexPosition(verts[iVert], destX[iVert], destY[iVert]);
 		_SetVertexColorARGB(verts[iVert], color);
@@ -1836,13 +1709,11 @@ void StgLooseLaserObject::_ConvertToItemAndSendEvent()
 	int ey = GetPositionY();
 	double angle = GetDirectionAngle();
 
-	int length = pow(pow(posXE_ - posX_, 2) + pow(posYE_ - posY_, 2) , 0.5);
-	for(double itemPos = 0 ; itemPos < length ; itemPos += itemDistance_)
-	{
+	int length = pow(pow(posXE_ - posX_, 2) + pow(posYE_ - posY_, 2), 0.5);
+	for (double itemPos = 0; itemPos < length; itemPos += itemDistance_) {
 		double posX = ex - itemPos * cos(Math::DegreeToRadian(angle));
 		double posY = ey - itemPos * sin(Math::DegreeToRadian(angle));
-		if(scriptItem != NULL)
-		{
+		if (scriptItem != NULL) {
 			std::vector<long double> listPos;
 			listPos.push_back(posX);
 			listPos.push_back(posY);
@@ -1853,33 +1724,29 @@ void StgLooseLaserObject::_ConvertToItemAndSendEvent()
 			scriptItem->RequestEvent(StgStageScript::EV_DELETE_SHOT_TO_ITEM, listScriptValue);
 		}
 
-		if(itemManager->IsDefaultBonusItemEnable() && delay_ == 0)
-		{
+		if (itemManager->IsDefaultBonusItemEnable() && delay_ == 0) {
 			ref_count_ptr<StgItemObject>::unsync obj = new StgItemObject_Bonus(stageController_);
 			int id = stageController_->GetMainObjectManager()->AddObject(obj);
-			if(id != DxScript::ID_INVALID)
-			{
+			if (id != DxScript::ID_INVALID) {
 				//弾の座標にアイテムを作成する
 				itemManager->AddItem(obj);
 				obj->SetPositionX(posX);
 				obj->SetPositionY(posY);
 			}
-		
 		}
 	}
 }
 void StgLooseLaserObject::RegistIntersectionTarget()
 {
-	if(!bUserIntersectionMode_)
-	{
+	if (!bUserIntersectionMode_)
 		_AddIntersectionRelativeTarget();
-	}
 }
 
 /**********************************************************
 //StgStraightLaserObject(設置型レーザー)
 **********************************************************/
-StgStraightLaserObject::StgStraightLaserObject(StgStageController* stageController) : StgLaserObject(stageController)
+StgStraightLaserObject::StgStraightLaserObject(StgStageController* stageController)
+	: StgLaserObject(stageController)
 {
 	typeObject_ = StgStageScript::OBJ_STRAIGHT_LASER;
 	angLaser_ = 270;
@@ -1890,68 +1757,72 @@ StgStraightLaserObject::StgStraightLaserObject(StgStageController* stageControll
 void StgStraightLaserObject::Work()
 {
 	_Move();
-	if(delay_ == 0)
-	{
+	if (delay_ == 0)
 		_AddReservedShotWork();
-	}
-	
+
 	delay_ = max(delay_ - 1, 0);
-	if(delay_ <= 0)scaleX_ = min(1.0, scaleX_ + 0.1);
+	if (delay_ <= 0)
+		scaleX_ = min(1.0, scaleX_ + 0.1);
 
 	frameWork_++;
 
-	if(frameFadeDelete_ >= 0)
-	{
+	if (frameFadeDelete_ >= 0)
 		frameFadeDelete_--;
-	}
 
 	_DeleteInAutoClip();
 	_DeleteInLife();
 	_DeleteInFadeDelete();
 	_DeleteInAutoDeleteFrame();
-//	_AddIntersectionRelativeTarget();
+	// _AddIntersectionRelativeTarget();
 	frameGrazeInvalid_--;
 }
 
 void StgStraightLaserObject::_DeleteInAutoClip()
 {
-	if(IsDeleted())return;
-	if(!IsAutoDelete())return;
+	if (IsDeleted())
+		return;
+	if (!IsAutoDelete())
+		return;
 	StgShotManager* shotManager = stageController_->GetShotManager();
 	RECT rect = shotManager->GetShotAutoDeleteClipRect();
 	int posXE = posX_ + (int)(length_ * cos(Math::DegreeToRadian(angLaser_)));
 	int posYE = posY_ + (int)(length_ * sin(Math::DegreeToRadian(angLaser_)));
 
-	if((posX_ < rect.left && posXE < rect.left) || (posX_ > rect.right && posXE > rect.right) || 
-		(posY_ < rect.top && posYE < rect.top) || (posY_ > rect.bottom && posYE > rect.bottom))
-	{
+	if ((posX_ < rect.left && posXE < rect.left) || (posX_ > rect.right && posXE > rect.right) || (posY_ < rect.top && posYE < rect.top) || (posY_ > rect.bottom && posYE > rect.bottom)) {
 		ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 		objectManager->DeleteObject(idObject_);
 	}
 }
 void StgStraightLaserObject::_DeleteInAutoDeleteFrame()
 {
-	if(IsDeleted())return;
-	if(delay_ > 0)return;
+	if (IsDeleted())
+		return;
+	if (delay_ > 0)
+		return;
 
-	if(frameAutoDelete_ <= 0)
-	{
+	if (frameAutoDelete_ <= 0)
 		SetFadeDelete();
-	}
 	frameAutoDelete_ = max(0, frameAutoDelete_ - 1);
 }
-std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > StgStraightLaserObject::GetIntersectionTargetList()
+std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> StgStraightLaserObject::GetIntersectionTargetList()
 {
-	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > res;
-	if(delay_ > 0)return res;
-	if(frameFadeDelete_ >= 0)return res;
-	if(IsDeleted())return res;
-	if(bUserIntersectionMode_)return res;//ユーザ定義あたり判定モード
-	if(!bIntersectionEnable_)return res;
+	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> res;
+	if (delay_ > 0)
+		return res;
+	if (frameFadeDelete_ >= 0)
+		return res;
+	if (IsDeleted())
+		return res;
+	if (bUserIntersectionMode_)
+		return res; //ユーザ定義あたり判定モード
+	if (!bIntersectionEnable_)
+		return res;
 
 	StgShotData* shotData = _GetShotData();
-	if(shotData == NULL)return res;
-	if(scaleX_ < 1.0 && typeOwner_ != OWNER_PLAYER)return res;
+	if (shotData == NULL)
+		return res;
+	if (scaleX_ < 1.0 && typeOwner_ != OWNER_PLAYER)
+		return res;
 
 	//当たり判定
 	int posXS = posX_ + invalidLengthStart_ * cos(Math::DegreeToRadian(angLaser_));
@@ -1963,14 +1834,14 @@ std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > StgStraightLaserObjec
 	StgIntersectionManager* intersectionManager = stageController_->GetIntersectionManager();
 	DxWidthLine line(posXS, posYS, posXE, posYE, widthIntersection_);
 	ref_count_ptr<StgShotObject>::unsync obj = GetOwnObject();
-	if(obj == NULL)return res;
+	if (obj == NULL)
+		return res;
 
 	ref_count_weak_ptr<StgShotObject>::unsync wObj = obj;
-	ref_count_ptr<StgIntersectionTarget_Line>::unsync target = 
-		ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_LINE));
-	if(typeOwner_ == OWNER_PLAYER)
+	ref_count_ptr<StgIntersectionTarget_Line>::unsync target = ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_LINE));
+	if (typeOwner_ == OWNER_PLAYER)
 		target->SetTargetType(StgIntersectionTarget::TYPE_PLAYER_SHOT);
-	else 
+	else
 		target->SetTargetType(StgIntersectionTarget::TYPE_ENEMY_SHOT);
 	target->SetObject(wObj);
 	target->SetLine(line);
@@ -1985,7 +1856,7 @@ void StgStraightLaserObject::_AddReservedShot(ref_count_ptr<StgShotObject>::unsy
 	double ownAngle = GetDirectionAngle();
 	double ox = GetPositionX();
 	double oy = GetPositionY();
-	
+
 	double dRadius = data->GetRadius();
 	double dAngle = data->GetAngle();
 	double sx = obj->GetPositionX();
@@ -2007,25 +1878,25 @@ void StgStraightLaserObject::_AddReservedShot(ref_count_ptr<StgShotObject>::unsy
 }
 void StgStraightLaserObject::RenderOnShotManager(D3DXMATRIX& matO)
 {
-	if(!IsVisible())return;
+	if (!IsVisible())
+		return;
 	D3DXMATRIX mat = matO;
 	StgShotData* shotData = _GetShotData();
-	if(shotData == NULL)return;
+	if (shotData == NULL)
+		return;
 
 	int objBlendType = GetBlendType();
 	int shotBlendType = objBlendType;
 	{
 		StgShotRenderer* renderer = NULL;
-		if(objBlendType == DirectGraphics::MODE_BLEND_NONE)
-		{
+		if (objBlendType == DirectGraphics::MODE_BLEND_NONE) {
 			renderer = shotData->GetRenderer(StgShotDataList::RENDER_ADD_ARGB);
 			shotBlendType = DirectGraphics::MODE_BLEND_ADD_ARGB;
-		}
-		else
-		{
+		} else {
 			renderer = shotData->GetRendererFromGraphicsBlendType(objBlendType);
 		}
-		if(renderer == NULL)return;
+		if (renderer == NULL)
+			return;
 
 		//レーザー
 		D3DXMATRIX matScale;
@@ -2042,34 +1913,30 @@ void StgStraightLaserObject::RenderOnShotManager(D3DXMATRIX& matO)
 		rcSrc = shotData->GetRect(frameWork_);
 		color = color_;
 		double alpha = shotData->GetAlpha() / 255.0;
-		if(frameFadeDelete_ >= 0) 
+		if (frameFadeDelete_ >= 0)
 			alpha = (double)frameFadeDelete_ / (double)FRAME_FADEDELETE_LASER;
 
 		bool bValidAlpha = StgShotData::IsAlphaBlendValidType(shotBlendType);
-		if(bValidAlpha)
-		{
+		if (bValidAlpha) {
 			//α有効
 			int colorA = ColorAccess::GetColorA(color);
 			color = ColorAccess::SetColorA(color, alpha * colorA);
-		}
-		else
-		{
+		} else {
 			//α無効
 			color = ColorAccess::ApplyAlpha(color, alpha);
-		}		
+		}
 
-//		if(delay_ > 0)
-//			SetRect(&rcDest, -16, length_, 16, 0);
-//		else
-			SetRect(&rcDest, -widthRender_/2, length_, widthRender_/2, 0);
+		// if(delay_ > 0)
+		// 	SetRect(&rcDest, -16, length_, 16, 0);
+		// else
+		SetRect(&rcDest, -widthRender_ / 2, length_, widthRender_ / 2, 0);
 
 		VERTEX_TLX verts[4];
-		int srcX[] = {rcSrc.left, rcSrc.right, rcSrc.left, rcSrc.right};
-		int srcY[] = {rcSrc.top, rcSrc.top, rcSrc.bottom, rcSrc.bottom};
-		int destX[] = {rcDest.left, rcDest.right, rcDest.left, rcDest.right};
-		int destY[] = {rcDest.top, rcDest.top, rcDest.bottom, rcDest.bottom};
-		for(int iVert = 0 ;iVert < 4 ; iVert++)
-		{
+		int srcX[] = { rcSrc.left, rcSrc.right, rcSrc.left, rcSrc.right };
+		int srcY[] = { rcSrc.top, rcSrc.top, rcSrc.bottom, rcSrc.bottom };
+		int destX[] = { rcDest.left, rcDest.right, rcDest.left, rcDest.right };
+		int destY[] = { rcDest.top, rcDest.top, rcDest.bottom, rcDest.bottom };
+		for (int iVert = 0; iVert < 4; iVert++) {
 			_SetVertexUV(verts[iVert], srcX[iVert], srcY[iVert]);
 			_SetVertexPosition(verts[iVert], destX[iVert], destY[iVert]);
 			_SetVertexColorARGB(verts[iVert], color);
@@ -2084,22 +1951,19 @@ void StgStraightLaserObject::RenderOnShotManager(D3DXMATRIX& matO)
 		renderer->AddVertex(verts[3]);
 	}
 
-	if(bUseSouce_ && frameFadeDelete_ < 0)
-	{
+	if (bUseSouce_ && frameFadeDelete_ < 0) {
 		StgShotRenderer* renderer = NULL;
 		int objSourceBlendType = GetSourceBlendType();
 		int sourceBlendType = shotBlendType;
-		if(objSourceBlendType == DirectGraphics::MODE_BLEND_NONE)
-		{
+		if (objSourceBlendType == DirectGraphics::MODE_BLEND_NONE) {
 			//未設定の場合は、レーザー描画種別を引き継ぐ
 			renderer = shotData->GetRendererFromGraphicsBlendType(sourceBlendType);
-		}
-		else
-		{
+		} else {
 			renderer = shotData->GetRendererFromGraphicsBlendType(objSourceBlendType);
 			sourceBlendType = objSourceBlendType;
 		}
-		if(renderer == NULL)return;
+		if (renderer == NULL)
+			return;
 
 		//光源
 		D3DXMATRIX matScale;
@@ -2120,12 +1984,11 @@ void StgStraightLaserObject::RenderOnShotManager(D3DXMATRIX& matO)
 		SetRect(&rcDest, -sourceWidth, -sourceWidth, sourceWidth, sourceWidth);
 
 		VERTEX_TLX verts[4];
-		int srcX[] = {rcSrc.left, rcSrc.right, rcSrc.left, rcSrc.right};
-		int srcY[] = {rcSrc.top, rcSrc.top, rcSrc.bottom, rcSrc.bottom};
-		int destX[] = {rcDest.left, rcDest.right, rcDest.left, rcDest.right};
-		int destY[] = {rcDest.top, rcDest.top, rcDest.bottom, rcDest.bottom};
-		for(int iVert = 0 ;iVert < 4 ; iVert++)
-		{
+		int srcX[] = { rcSrc.left, rcSrc.right, rcSrc.left, rcSrc.right };
+		int srcY[] = { rcSrc.top, rcSrc.top, rcSrc.bottom, rcSrc.bottom };
+		int destX[] = { rcDest.left, rcDest.right, rcDest.left, rcDest.right };
+		int destY[] = { rcDest.top, rcDest.top, rcDest.bottom, rcDest.bottom };
+		for (int iVert = 0; iVert < 4; iVert++) {
 			_SetVertexUV(verts[iVert], srcX[iVert], srcY[iVert]);
 			_SetVertexPosition(verts[iVert], destX[iVert], destY[iVert]);
 			_SetVertexColorARGB(verts[iVert], color);
@@ -2139,7 +2002,6 @@ void StgStraightLaserObject::RenderOnShotManager(D3DXMATRIX& matO)
 		renderer->AddVertex(verts[2]);
 		renderer->AddVertex(verts[3]);
 	}
-
 }
 void StgStraightLaserObject::_ConvertToItemAndSendEvent()
 {
@@ -2151,13 +2013,11 @@ void StgStraightLaserObject::_ConvertToItemAndSendEvent()
 	int ey = GetPositionY();
 	double angle = angLaser_;
 
-	for(double itemPos = 0 ; itemPos < length_ ; itemPos += itemDistance_)
-	{
+	for (double itemPos = 0; itemPos < length_; itemPos += itemDistance_) {
 		double posX = ex + itemPos * cos(Math::DegreeToRadian(angle));
 		double posY = ey + itemPos * sin(Math::DegreeToRadian(angle));
 
-		if(scriptItem != NULL)
-		{
+		if (scriptItem != NULL) {
 			std::vector<long double> listPos;
 			listPos.push_back(posX);
 			listPos.push_back(posY);
@@ -2168,12 +2028,10 @@ void StgStraightLaserObject::_ConvertToItemAndSendEvent()
 			scriptItem->RequestEvent(StgStageScript::EV_DELETE_SHOT_TO_ITEM, listScriptValue);
 		}
 
-		if(itemManager->IsDefaultBonusItemEnable() && delay_ == 0)
-		{
+		if (itemManager->IsDefaultBonusItemEnable() && delay_ == 0) {
 			ref_count_ptr<StgItemObject>::unsync obj = new StgItemObject_Bonus(stageController_);
 			int id = stageController_->GetMainObjectManager()->AddObject(obj);
-			if(id != DxScript::ID_INVALID)
-			{
+			if (id != DxScript::ID_INVALID) {
 				//弾の座標にアイテムを作成する
 				itemManager->AddItem(obj);
 				obj->SetPositionX(posX);
@@ -2184,15 +2042,15 @@ void StgStraightLaserObject::_ConvertToItemAndSendEvent()
 }
 void StgStraightLaserObject::RegistIntersectionTarget()
 {
-	if(!bUserIntersectionMode_)
-	{
+	if (!bUserIntersectionMode_) {
 		_AddIntersectionRelativeTarget();
 	}
 }
 /**********************************************************
 //StgCurveLaserObject(曲がる型レーザー)
 **********************************************************/
-StgCurveLaserObject::StgCurveLaserObject(StgStageController* stageController) : StgLaserObject(stageController)
+StgCurveLaserObject::StgCurveLaserObject(StgStageController* stageController)
+	: StgLaserObject(stageController)
 {
 	typeObject_ = StgStageScript::OBJ_CURVE_LASER;
 	tipDecrement_ = 1.0;
@@ -2200,24 +2058,20 @@ StgCurveLaserObject::StgCurveLaserObject(StgStageController* stageController) : 
 void StgCurveLaserObject::Work()
 {
 	_Move();
-	if(delay_ == 0)
-	{
+	if (delay_ == 0)
 		_AddReservedShotWork();
-	}
-	
+
 	delay_ = max(delay_ - 1, 0);
 	frameWork_++;
 
-	if(frameFadeDelete_ >= 0)
-	{
+	if (frameFadeDelete_ >= 0)
 		frameFadeDelete_--;
-	}
 
 	_DeleteInAutoClip();
 	_DeleteInLife();
 	_DeleteInFadeDelete();
 	_DeleteInAutoDeleteFrame();
-//	_AddIntersectionRelativeTarget();
+	// _AddIntersectionRelativeTarget();
 	frameGrazeInvalid_--;
 }
 void StgCurveLaserObject::_Move()
@@ -2231,81 +2085,81 @@ void StgCurveLaserObject::_Move()
 	pos.y = posY_;
 
 	listPosition_.push_front(pos);
-	if(listPosition_.size() > length_)
-	{
+	if (listPosition_.size() > length_) {
 		listPosition_.pop_back();
 	}
 }
 void StgCurveLaserObject::_DeleteInAutoClip()
 {
-	if(IsDeleted())return;
-	if(!IsAutoDelete())return;
+	if (IsDeleted())
+		return;
+	if (!IsAutoDelete())
+		return;
 	StgShotManager* shotManager = stageController_->GetShotManager();
 	RECT rect = shotManager->GetShotAutoDeleteClipRect();
 
 	bool bDelete = listPosition_.size() > 0;
 	std::list<Position>::iterator itr = listPosition_.begin();
-	for(; itr != listPosition_.end() ; itr++)
-	{
+	for (; itr != listPosition_.end(); itr++) {
 		Position& pos = (*itr);
 		bool bXOut = pos.x < rect.left || pos.x > rect.right;
 		bool bYOut = pos.y < rect.top || pos.y > rect.bottom;
-		if(!bXOut && !bYOut)
-		{
+		if (!bXOut && !bYOut) {
 			bDelete = false;
 			break;
 		}
 	}
 
-	if(bDelete)
-	{
+	if (bDelete) {
 		ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 		objectManager->DeleteObject(idObject_);
 	}
-
 }
-std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > StgCurveLaserObject::GetIntersectionTargetList()
+std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> StgCurveLaserObject::GetIntersectionTargetList()
 {
-	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > res;
-	if(delay_ > 0)return res;
-	if(frameFadeDelete_ >= 0)return res;
-	if(IsDeleted())return res;
-	if(bUserIntersectionMode_)return res;//ユーザ定義あたり判定モード
-	if(!bIntersectionEnable_)return res;
+	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> res;
+	if (delay_ > 0)
+		return res;
+	if (frameFadeDelete_ >= 0)
+		return res;
+	if (IsDeleted())
+		return res;
+	if (bUserIntersectionMode_)
+		return res; //ユーザ定義あたり判定モード
+	if (!bIntersectionEnable_)
+		return res;
 
 	StgShotData* shotData = _GetShotData();
-	if(shotData == NULL)return res;
+	if (shotData == NULL)
+		return res;
 
 	ref_count_ptr<StgShotObject>::unsync obj = GetOwnObject();
-	if(obj == NULL)return res;
+	if (obj == NULL)
+		return res;
 	ref_count_weak_ptr<StgShotObject>::unsync wObj = obj;
 
 	//当たり判定
 	std::vector<Position> listPos;
 	std::list<Position>::iterator itr = listPosition_.begin();
-	for(; itr != listPosition_.end() ; itr++)
-	{
+	for (; itr != listPosition_.end(); itr++) {
 		listPos.push_back(*itr);
 	}
 
 	StgIntersectionManager* intersectionManager = stageController_->GetIntersectionManager();
 	int countPos = listPos.size();
-	for(int iPos = 0 ; iPos < countPos - 1; iPos++)
-	{
+	for (int iPos = 0; iPos < countPos - 1; iPos++) {
 		double posXS = listPos[iPos].x;
 		double posYS = listPos[iPos].y;
 		double posXE = listPos[iPos + 1].x;
 		double posYE = listPos[iPos + 1].y;
 /*
-		if(iPos == 0)
-		{
+		if (iPos == 0) {
 			double ang = atan2(posYE - posYS, posXE - posXS);
-			int length = min(0 , invalidLengthStart_);
+			int length = min(0, invalidLengthStart_);
 			posXS = posXS + length * cos(ang);
 			posYS = posYS + length * sin(ang);
 		}
-		if(iPos == countPos - 2)
-		{
+		if (iPos == countPos - 2) {
 			double ang = atan2(posYE - posYS, posXE - posXS);
 			int length = max(invalidLengthEnd_, 0);
 			posXE = posXE - length * cos(ang);
@@ -2313,11 +2167,10 @@ std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > StgCurveLaserObject::
 		}
 */
 		DxWidthLine line(posXS, posYS, posXE, posYE, widthIntersection_);
-		ref_count_ptr<StgIntersectionTarget_Line>::unsync target = 
-			ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_LINE));
-		if(typeOwner_ == OWNER_PLAYER)
+		ref_count_ptr<StgIntersectionTarget_Line>::unsync target = ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_LINE));
+		if (typeOwner_ == OWNER_PLAYER)
 			target->SetTargetType(StgIntersectionTarget::TYPE_PLAYER_SHOT);
-		else 
+		else
 			target->SetTargetType(StgIntersectionTarget::TYPE_ENEMY_SHOT);
 		target->SetObject(wObj);
 		target->SetLine(line);
@@ -2327,7 +2180,8 @@ std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > StgCurveLaserObject::
 	return res;
 }
 
-double StgShotObject::cssn(double s, double ang) {
+double StgShotObject::cssn(double s, double ang)
+{
 	const double PAI = 3.14159265358979323846;
 	const double TWOPAI = PAI * 2;
 	double c = sqrt(1 - s * s);
@@ -2341,36 +2195,37 @@ double StgShotObject::cssn(double s, double ang) {
 }
 
 //Extremely special thanks to Natashi for making this not awful
-void StgCurveLaserObject::RenderOnShotManager(D3DXMATRIX& mat) {    //original: (D3DXMATRIX mat)
-	if (!IsVisible())return;
+void StgCurveLaserObject::RenderOnShotManager(D3DXMATRIX& mat)
+{ //original: (D3DXMATRIX mat)
+	if (!IsVisible())
+		return;
 
 	StgShotData* shotData = _GetShotData();
-	if (shotData == nullptr)return;
+	if (shotData == nullptr)
+		return;
 
 	int shotBlendType = StgShotDataList::RENDER_ADD_ARGB;
-	StgShotRenderer * renderer = nullptr;
+	StgShotRenderer* renderer = nullptr;
 	if (delay_ > 0) {
 		int objDelayBlendType = GetSourceBlendType();
 		if (objDelayBlendType == DirectGraphics::MODE_BLEND_NONE) {
 			renderer = shotData->GetRenderer(StgShotDataList::RENDER_ADD_ARGB);
 			shotBlendType = DirectGraphics::MODE_BLEND_ADD_ARGB;
-		}
-		else {
+		} else {
 			renderer = shotData->GetRendererFromGraphicsBlendType(objDelayBlendType);
 		}
-	}
-	else {
+	} else {
 		int objBlendType = GetBlendType();
 		int shotBlendType = objBlendType;
 		if (objBlendType == DirectGraphics::MODE_BLEND_NONE) {
 			renderer = shotData->GetRenderer(StgShotDataList::RENDER_ADD_ARGB);
 			shotBlendType = DirectGraphics::MODE_BLEND_ADD_ARGB;
-		}
-		else {
+		} else {
 			renderer = shotData->GetRendererFromGraphicsBlendType(objBlendType);
 		}
 	}
-	if (renderer == nullptr)return;
+	if (renderer == nullptr)
+		return;
 
 	D3DCOLOR color;
 
@@ -2379,9 +2234,10 @@ void StgCurveLaserObject::RenderOnShotManager(D3DXMATRIX& mat) {    //original: 
 		RECT rcDest;
 
 		double expa = 0.5f + (double)delay_ / 30.0f * 2;
-		if (expa > 3.5)expa = 3.5;
+		if (expa > 3.5)
+			expa = 3.5;
 
-		double ang = GetDirectionAngle() + D3DXToRadian(270);   //D3DXToRadian(GetDirectionAngle() + 270)
+		double ang = GetDirectionAngle() + D3DXToRadian(270); //D3DXToRadian(GetDirectionAngle() + 270)
 		double c = cos(ang);
 		double s = sin(ang);
 
@@ -2390,8 +2246,10 @@ void StgCurveLaserObject::RenderOnShotManager(D3DXMATRIX& mat) {    //original: 
 		int width = rcSrc.right - rcSrc.left;
 		int height = rcSrc.bottom - rcSrc.top;
 		SetRect(&rcDest, -width / 2, -height / 2, width / 2, height / 2);
-		if (width % 2 == 1)rcDest.right += 1;
-		if (height % 2 == 1)rcDest.bottom += 1;
+		if (width % 2 == 1)
+			rcDest.right += 1;
+		if (height % 2 == 1)
+			rcDest.bottom += 1;
 
 		VERTEX_TLX verts[4];
 		int srcX[] = { rcSrc.left, rcSrc.right, rcSrc.left, rcSrc.right };
@@ -2416,8 +2274,7 @@ void StgCurveLaserObject::RenderOnShotManager(D3DXMATRIX& mat) {    //original: 
 		}
 
 		renderer->AddSquareVertex(verts);
-	}
-	else {
+	} else {
 		int countPos = listPosition_.size();
 		RECT rcSrcOrg = shotData->GetRect(frameWork_);
 		double rate = (double)(rcSrcOrg.bottom - rcSrcOrg.top) / (double)max(countPos, 1);
@@ -2432,8 +2289,7 @@ void StgCurveLaserObject::RenderOnShotManager(D3DXMATRIX& mat) {    //original: 
 			//α有効
 			int colorA = ColorAccess::GetColorA(color);
 			color = ColorAccess::SetColorA(color, alpha * colorA);
-		}
-		else {
+		} else {
 			//α無効
 			color = ColorAccess::ApplyAlpha(color, alpha);
 		}
@@ -2454,8 +2310,9 @@ void StgCurveLaserObject::RenderOnShotManager(D3DXMATRIX& mat) {    //original: 
 		size_t incr = 1;
 
 		for (; iPos < listPosition_.size(); itr++, iPos++) {
-			std::list<Position>::iterator nxt = next(itr,1);
-			if ((iPos + 1) >= listPosition_.size()) break;
+			std::list<Position>::iterator nxt = next(itr, 1);
+			if ((iPos + 1) >= listPosition_.size())
+				break;
 
 			double posXS = (*itr).x;
 			double posYS = (*itr).y;
@@ -2472,7 +2329,8 @@ void StgCurveLaserObject::RenderOnShotManager(D3DXMATRIX& mat) {    //original: 
 			RECT_D rcDestD;
 			rcSrcD.top = rcSrcOrg.top + posSrc;
 			double bottom = rcSrcD.top + rate;
-			if (rcSrcD.top == bottom) bottom++;
+			if (rcSrcD.top == bottom)
+				bottom++;
 			rcSrcD.bottom = bottom;
 			posSrc += rate;
 
@@ -2489,8 +2347,7 @@ void StgCurveLaserObject::RenderOnShotManager(D3DXMATRIX& mat) {    //original: 
 			if (bValidAlpha) {
 				int colorA = ColorAccess::GetColorA(tColor);
 				tColor = ColorAccess::SetColorA(tColor, tAlpha * colorA);
-			}
-			else {
+			} else {
 				tColor = ColorAccess::ApplyAlpha(tColor, tAlpha / 255.0);
 			}
 
@@ -2532,14 +2389,12 @@ void StgCurveLaserObject::_ConvertToItemAndSendEvent()
 	ref_count_ptr<ManagedScript> scriptItem = stageScriptManager->GetItemScript();
 
 	std::list<Position>::iterator itr = listPosition_.begin();
-	for(; itr != listPosition_.end() ; itr++)
-	{
+	for (; itr != listPosition_.end(); itr++) {
 		Position pos = (*itr);
 		double posX = pos.x;
 		double posY = pos.y;
 
-		if(scriptItem != NULL)
-		{
+		if (scriptItem != NULL) {
 			std::vector<long double> listPos;
 			listPos.push_back(posX);
 			listPos.push_back(posY);
@@ -2550,25 +2405,20 @@ void StgCurveLaserObject::_ConvertToItemAndSendEvent()
 			scriptItem->RequestEvent(StgStageScript::EV_DELETE_SHOT_TO_ITEM, listScriptValue);
 		}
 
-		if(itemManager->IsDefaultBonusItemEnable() && delay_ == 0)
-		{
+		if (itemManager->IsDefaultBonusItemEnable() && delay_ == 0) {
 			ref_count_ptr<StgItemObject>::unsync obj = new StgItemObject_Bonus(stageController_);
 			int id = stageController_->GetMainObjectManager()->AddObject(obj);
-			if(id != DxScript::ID_INVALID)
-			{
+			if (id != DxScript::ID_INVALID) {
 				//弾の座標にアイテムを作成する
 				itemManager->AddItem(obj);
 				obj->SetPositionX(posX);
 				obj->SetPositionY(posY);
 			}
-		
 		}
 	}
 }
 void StgCurveLaserObject::RegistIntersectionTarget()
 {
-	if(!bUserIntersectionMode_)
-	{
+	if (!bUserIntersectionMode_)
 		_AddIntersectionRelativeTarget();
-	}
 }

--- a/source/TouhouDanmakufu/Common/StgShot.hpp
+++ b/source/TouhouDanmakufu/Common/StgShot.hpp
@@ -1,8 +1,8 @@
 #ifndef __TOUHOUDANMAKUFU_DNHSTG_SHOT__
 #define __TOUHOUDANMAKUFU_DNHSTG_SHOT__
 
-#include"StgCommon.hpp"
-#include"StgIntersection.hpp"
+#include "StgCommon.hpp"
+#include "StgIntersection.hpp"
 
 class StgShotDataList;
 class StgShotData;
@@ -11,444 +11,471 @@ class StgShotObject;
 /**********************************************************
 //StgShotManager
 **********************************************************/
-class StgShotManager
-{
-	public:
-		enum
-		{
-			DEL_TYPE_ALL,
-			DEL_TYPE_SHOT,
-			DEL_TYPE_CHILD,
-			TO_TYPE_IMMEDIATE,
-			TO_TYPE_FADE,
-			TO_TYPE_ITEM,
-		};
+class StgShotManager {
+public:
+	enum {
+		DEL_TYPE_ALL,
+		DEL_TYPE_SHOT,
+		DEL_TYPE_CHILD,
+		TO_TYPE_IMMEDIATE,
+		TO_TYPE_FADE,
+		TO_TYPE_ITEM,
+	};
 
-		enum
-		{
-			BIT_EV_DELETE_IMMEDIATE = 1,
-			BIT_EV_DELETE_TO_ITEM,
-			BIT_EV_DELETE_FADE,
-			BIT_EV_DELETE_COUNT,
-		};
+	enum {
+		BIT_EV_DELETE_IMMEDIATE = 1,
+		BIT_EV_DELETE_TO_ITEM,
+		BIT_EV_DELETE_FADE,
+		BIT_EV_DELETE_COUNT,
+	};
 
-	protected:
-		StgStageController* stageController_;
-		ref_count_ptr<StgShotDataList>::unsync listPlayerShotData_;
-		ref_count_ptr<StgShotDataList>::unsync listEnemyShotData_;
-		std::list<ref_count_ptr<StgShotObject>::unsync > listObj_;
+public:
+	StgShotManager(StgStageController* stageController);
+	virtual ~StgShotManager();
+	void Work();
+	void Render(int targetPriority);
+	void RegistIntersectionTarget();
 
-		std::bitset<BIT_EV_DELETE_COUNT> listDeleteEventEnable_;
+	void AddShot(ref_count_ptr<StgShotObject>::unsync obj) { listObj_.push_back(obj); }
 
-	public:
-		StgShotManager(StgStageController* stageController);
-		virtual ~StgShotManager();
-		void Work();
-		void Render(int targetPriority);
-		void RegistIntersectionTarget();
+	StgShotDataList* GetPlayerShotDataList() { return listPlayerShotData_.GetPointer(); }
+	StgShotDataList* GetEnemyShotDataList() { return listEnemyShotData_.GetPointer(); }
 
-		void AddShot(ref_count_ptr<StgShotObject>::unsync obj){listObj_.push_back(obj);}
+	bool LoadPlayerShotData(std::wstring path, bool bReload = false);
+	bool LoadEnemyShotData(std::wstring path, bool bReload = false);
 
-		StgShotDataList* GetPlayerShotDataList(){return listPlayerShotData_.GetPointer();}
-		StgShotDataList* GetEnemyShotDataList(){return listEnemyShotData_.GetPointer();}
+	RECT GetShotAutoDeleteClipRect();
 
-		bool LoadPlayerShotData(std::wstring path, bool bReload = false);
-		bool LoadEnemyShotData(std::wstring path, bool bReload = false);
+	void DeleteInCircle(int typeDelete, int typeTo, int typeOnwer, int cx, int cy, double radius);
+	std::vector<int> GetShotIdInCircle(int typeOnwer, int cx, int cy, int radius);
+	int GetShotCount(int typeOnwer);
+	int GetShotCountAll() { return listObj_.size(); }
+	std::vector<bool> GetValidRenderPriorityList();
 
-		RECT GetShotAutoDeleteClipRect();
+	void SetDeleteEventEnableByType(int type, bool bEnable);
+	bool IsDeleteEventEnable(int bit);
 
-		void DeleteInCircle(int typeDelete, int typeTo, int typeOnwer, int cx, int cy, double radius);
-		std::vector<int> GetShotIdInCircle(int typeOnwer, int cx, int cy, int radius);
-		int GetShotCount(int typeOnwer);
-		int GetShotCountAll(){return listObj_.size();}
-		std::vector<bool> GetValidRenderPriorityList();
+protected:
+	StgStageController* stageController_;
+	ref_count_ptr<StgShotDataList>::unsync listPlayerShotData_;
+	ref_count_ptr<StgShotDataList>::unsync listEnemyShotData_;
+	std::list<ref_count_ptr<StgShotObject>::unsync> listObj_;
 
-		void SetDeleteEventEnableByType(int type, bool bEnable);
-		bool IsDeleteEventEnable(int bit);
+	std::bitset<BIT_EV_DELETE_COUNT> listDeleteEventEnable_;
 };
 
 /**********************************************************
 //StgShotDataList
 **********************************************************/
-class StgShotDataList
-{
-	public:
-		enum
-		{
-			RENDER_TYPE_COUNT = 6,
-			RENDER_ALPHA = 0,
-			RENDER_ADD_RGB,
-			RENDER_ADD_ARGB,
-			RENDER_MULTIPLY,
-			RENDER_SUBTRACT,
-			RENDER_INV_DESTRGB,
-		};
-	private:
-		std::set<std::wstring> listReadPath_;
-		std::vector<ref_count_ptr<Texture> > listTexture_;
-		std::vector<std::vector<ref_count_ptr<StgShotRenderer>::unsync > >listRenderer_;
-		std::vector<ref_count_ptr<StgShotData>::unsync > listData_;
+class StgShotDataList {
+public:
+	enum {
+		RENDER_TYPE_COUNT = 6,
+		RENDER_ALPHA = 0,
+		RENDER_ADD_RGB,
+		RENDER_ADD_ARGB,
+		RENDER_MULTIPLY,
+		RENDER_SUBTRACT,
+		RENDER_INV_DESTRGB,
+	};
 
-		D3DCOLOR defaultDelayColor_;
+public:
+	StgShotDataList();
+	virtual ~StgShotDataList();
 
-		void _ScanShot(std::vector<ref_count_ptr<StgShotData>::unsync >& listData, Scanner& scanner);
-		void _ScanAnimation(ref_count_ptr<StgShotData>::unsync shotData, Scanner& scanner);
-		std::vector<std::wstring> _GetArgumentList(Scanner& scanner);
-	public:
-		StgShotDataList();
-		virtual ~StgShotDataList();
+	int GetTextureCount() { return listTexture_.size(); }
+	ref_count_ptr<Texture> GetTexture(int index) { return listTexture_[index]; }
+	ref_count_ptr<StgShotRenderer>::unsync GetRenderer(int index, int typeRender) { return listRenderer_[typeRender][index]; }
+	std::vector<ref_count_ptr<StgShotRenderer>::unsync>* GetRendererList(int typeRender) { return &listRenderer_[typeRender]; }
 
-		int GetTextureCount(){return listTexture_.size();}
-		ref_count_ptr<Texture> GetTexture(int index){return listTexture_[index];}
-		ref_count_ptr<StgShotRenderer>::unsync GetRenderer(int index, int typeRender){return listRenderer_[typeRender][index];}
-		std::vector<ref_count_ptr<StgShotRenderer>::unsync >* GetRendererList(int typeRender){return &listRenderer_[typeRender];}
+	ref_count_ptr<StgShotData>::unsync GetData(int id) { return (id >= 0 && id < listData_.size()) ? listData_[id] : NULL; }
 
-		ref_count_ptr<StgShotData>::unsync GetData(int id){return (id >= 0 && id < listData_.size()) ? listData_[id] : NULL;}
+	bool AddShotDataList(std::wstring path, bool bReload);
 
-		bool AddShotDataList(std::wstring path, bool bReload);
+private:
+	void _ScanShot(std::vector<ref_count_ptr<StgShotData>::unsync>& listData, Scanner& scanner);
+	void _ScanAnimation(ref_count_ptr<StgShotData>::unsync shotData, Scanner& scanner);
+	std::vector<std::wstring> _GetArgumentList(Scanner& scanner);
+
+	std::set<std::wstring> listReadPath_;
+	std::vector<ref_count_ptr<Texture>> listTexture_;
+	std::vector<std::vector<ref_count_ptr<StgShotRenderer>::unsync>> listRenderer_;
+	std::vector<ref_count_ptr<StgShotData>::unsync> listData_;
+
+	D3DCOLOR defaultDelayColor_;
 };
 
-class StgShotData
-{
+class StgShotData {
 	friend StgShotDataList;
-	private:
-		struct AnimationData
-		{
-			RECT rcSrc_;
-			int frame_;
-		};
-
-		StgShotDataList* listShotData_;
-		int indexTexture_;
-		int typeRender_;
-		int typeDelayRender_;
+	struct AnimationData {
 		RECT rcSrc_;
-		RECT rcDelay_;
-		int alpha_;
-		D3DCOLOR colorDelay_;
-		std::vector<DxCircle> listCol_;
+		int frame_;
+	};
 
-		std::vector<AnimationData> listAnime_;
-		int totalAnimeFrame_;
+public:
+	StgShotData(StgShotDataList* listShotData);
+	virtual ~StgShotData();
 
-		double angularVelocityMin_;
-		double angularVelocityMax_;
-		bool bFixedAngle_;
+	int GetTextureIndex() { return indexTexture_; }
+	int GetRenderType() { return typeRender_; }
+	int GetDelayRenderType() { return typeDelayRender_; }
+	RECT GetRect(int frame);
+	RECT GetDelayRect() { return rcDelay_; }
+	int GetAlpha() { return alpha_; }
+	D3DCOLOR GetDelayColor() { return colorDelay_; }
+	std::vector<DxCircle>* GetIntersectionCircleList() { return &listCol_; }
+	double GetAngularVelocityMin() { return angularVelocityMin_; }
+	double GetAngularVelocityMax() { return angularVelocityMax_; }
+	bool IsFixedAngle() { return bFixedAngle_; }
 
-	public:
-		StgShotData(StgShotDataList* listShotData);
-		virtual ~StgShotData();
+	ref_count_ptr<Texture> GetTexture();
+	StgShotRenderer* GetRenderer();
+	StgShotRenderer* GetRenderer(int type);
+	StgShotRenderer* GetRendererFromGraphicsBlendType(int blendType);
+	static bool IsAlphaBlendValidType(int blendType);
 
-		int GetTextureIndex(){return indexTexture_;}
-		int GetRenderType(){return typeRender_;}
-		int GetDelayRenderType(){return typeDelayRender_;}
-		RECT GetRect(int frame);
-		RECT GetDelayRect(){return rcDelay_;}
-		int GetAlpha(){return alpha_;}
-		D3DCOLOR GetDelayColor(){return colorDelay_;}
-		std::vector<DxCircle>* GetIntersectionCircleList(){return &listCol_;}
-		double GetAngularVelocityMin(){return angularVelocityMin_;}
-		double GetAngularVelocityMax(){return angularVelocityMax_;}
-		bool IsFixedAngle(){return bFixedAngle_;}
+private:
+	StgShotDataList* listShotData_;
+	int indexTexture_;
+	int typeRender_;
+	int typeDelayRender_;
+	RECT rcSrc_;
+	RECT rcDelay_;
+	int alpha_;
+	D3DCOLOR colorDelay_;
+	std::vector<DxCircle> listCol_;
 
-		ref_count_ptr<Texture> GetTexture();
-		StgShotRenderer* GetRenderer();
-		StgShotRenderer* GetRenderer(int type);
-		StgShotRenderer* GetRendererFromGraphicsBlendType(int blendType);
-		static bool IsAlphaBlendValidType(int blendType);
+	std::vector<AnimationData> listAnime_;
+	int totalAnimeFrame_;
+
+	double angularVelocityMin_;
+	double angularVelocityMax_;
+	bool bFixedAngle_;
 };
 
 /**********************************************************
 //StgShotRenderer
 **********************************************************/
-class StgShotRenderer : public RenderObjectTLX
-{
-		int countRenderVertex_;
-	public:
-		StgShotRenderer();
-		virtual int GetVertexCount();
-		virtual void Render();
-		void AddVertex(VERTEX_TLX& vertex);
-		void AddSquareVertex(VERTEX_TLX* listVertex);
+class StgShotRenderer : public RenderObjectTLX {
+public:
+	StgShotRenderer();
+	virtual int GetVertexCount();
+	virtual void Render();
+	void AddVertex(VERTEX_TLX& vertex);
+	void AddSquareVertex(VERTEX_TLX* listVertex);
+
+private:
+	int countRenderVertex_;
 };
 
 /**********************************************************
 //StgShotObject
 **********************************************************/
-class StgShotObject : public DxScriptRenderObject , public StgMoveObject, public StgIntersectionObject
-{
-	public:
-		enum
-		{
-			OWNER_PLAYER = 0,
-			OWNER_ENEMY,
-			OWNER_NULL,
+class StgShotObject : public DxScriptRenderObject, public StgMoveObject, public StgIntersectionObject {
+public:
+	enum {
+		OWNER_PLAYER = 0,
+		OWNER_ENEMY,
+		OWNER_NULL,
 
-			FRAME_FADEDELETE = 30,
-			FRAME_FADEDELETE_LASER = 30,
+		FRAME_FADEDELETE = 30,
+		FRAME_FADEDELETE_LASER = 30,
 
-			LIFE_SPELL_UNREGIST = 5,
-			LIFE_SPELL_REGIST = 256 * 256 * 256,
-		};
-		class ReserveShotList;
-		class ReserveShotListData;
+		LIFE_SPELL_UNREGIST = 5,
+		LIFE_SPELL_REGIST = 256 * 256 * 256,
+	};
+	class ReserveShotList;
+	class ReserveShotListData;
 
-	protected:
-		StgStageController* stageController_;
+public:
+	StgShotObject(StgStageController* stageController);
+	virtual ~StgShotObject();
 
-		int frameWork_;
-		int idShotData_;
-		int typeOwner_;
+	virtual void Work();
+	virtual void Render() {} //一括で描画するためオブジェクト管理での描画はしない
+	virtual void Activate() {}
+	virtual void RenderOnShotManager(D3DXMATRIX& mat) {}
+	double cssn(double s, double ang);
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	virtual void ClearShotObject() { ClearIntersectionRelativeTarget(); }
+	virtual void RegistIntersectionTarget() = 0;
 
-		D3DCOLOR color_;
-		int delay_;//遅延時間
-		int typeSourceBrend_; //遅延時間ブレンド種別
-		int frameGrazeInvalid_;//かすり無効フレーム
-		int frameFadeDelete_;
-		double damage_;
-		double life_;//貫通力
-		bool bAutoDelete_;
-		bool bEraseShot_;//弾削除機能
-		bool bSpellFactor_;//スペル付加
-		int frameAutoDelete_;//自動削除フレーム
-		ref_count_ptr<ReserveShotList>::unsync listReserveShot_;
+	virtual void SetX(double x)
+	{
+		posX_ = x;
+		DxScriptRenderObject::SetX(x);
+	}
+	virtual void SetY(double y)
+	{
+		posY_ = y;
+		DxScriptRenderObject::SetY(y);
+	}
+	virtual void SetColor(int r, int g, int b);
+	virtual void SetAlpha(int alpha);
+	virtual void SetRenderState() {}
 
-		bool bUserIntersectionMode_;//ユーザ定義あたり判定モード
-		bool bIntersectionEnable_;
-		bool bChangeItemEnable_;
+	ref_count_ptr<StgShotObject>::unsync GetOwnObject();
+	int GetShotDataID() { return idShotData_; }
+	virtual void SetShotDataID(int id) { idShotData_ = id; }
+	int GetOwnerType() { return typeOwner_; }
+	void SetOwnerType(int type) { typeOwner_ = type; }
 
-		StgShotData* _GetShotData();
-		void _SetVertexPosition(VERTEX_TLX& vertex, float x, float y, float z = 1.0f, float w = 1.0f);
-		void _SetVertexUV(VERTEX_TLX& vertex, float u, float v);
-		void _SetVertexColorARGB(VERTEX_TLX& vertex, D3DCOLOR color);
-		virtual void _DeleteInLife();
-		virtual void _DeleteInAutoClip();
-		virtual void _DeleteInFadeDelete();
-		virtual void _DeleteInAutoDeleteFrame();
-		virtual void _Move();
-		void _AddReservedShotWork();
-		virtual void _AddReservedShot(ref_count_ptr<StgShotObject>::unsync obj, ReserveShotListData* data);
-		virtual void _ConvertToItemAndSendEvent(){}
-		virtual void _SendDeleteEvent(int bit);
-	public:
-		StgShotObject(StgStageController* stageController);
-		virtual ~StgShotObject();
+	bool IsValidGraze() { return frameGrazeInvalid_ <= 0; }
+	int GetDelay() { return delay_; }
+	void SetDelay(int delay) { delay_ = delay; }
+	int GetSourceBlendType() { return typeSourceBrend_; }
+	void SetSourceBlendType(int type) { typeSourceBrend_ = type; }
+	double GetLife() { return life_; }
+	void SetLife(double life) { life_ = life; }
+	double GetDamage() { return damage_; }
+	void SetDamage(double damage) { damage_ = damage; }
+	virtual void SetFadeDelete()
+	{
+		if (frameFadeDelete_ < 0)
+			frameFadeDelete_ = FRAME_FADEDELETE;
+	}
+	bool IsAutoDelete() { return bAutoDelete_; }
+	void SetAutoDelete(bool b) { bAutoDelete_ = b; }
+	void SetAutoDeleteFrame(int frame) { frameAutoDelete_ = frame; }
+	bool IsEraseShot() { return bEraseShot_; }
+	void SetEraseShot(bool bErase) { bEraseShot_ = bErase; }
+	bool IsSpellFactor() { return bSpellFactor_; }
+	void SetSpellFactor(bool bSpell) { bSpellFactor_ = bSpell; }
+	void SetUserIntersectionMode(bool b) { bUserIntersectionMode_ = b; }
+	void SetIntersectionEnable(bool b) { bIntersectionEnable_ = b; }
+	void SetItemChangeEnable(bool b) { bChangeItemEnable_ = b; }
 
-		virtual void Work();
-		virtual void Render(){}//一括で描画するためオブジェクト管理での描画はしない
-		virtual void Activate(){}
-		virtual void RenderOnShotManager(D3DXMATRIX& mat){}
-		double cssn(double s, double ang);
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
-		virtual void ClearShotObject(){ClearIntersectionRelativeTarget();}
-		virtual void RegistIntersectionTarget() = 0;
+	virtual void DeleteImmediate();
+	virtual void ConvertToItem();
+	void AddShot(int frame, int idShot, int radius, int angle);
 
-		virtual void SetX(double x){posX_ = x; DxScriptRenderObject::SetX(x);}
-		virtual void SetY(double y){posY_ = y; DxScriptRenderObject::SetY(y);}
-		virtual void SetColor(int r, int g, int b);
-		virtual void SetAlpha(int alpha);
-		virtual void SetRenderState(){}
+protected:
+	StgStageController* stageController_;
 
-		ref_count_ptr<StgShotObject>::unsync GetOwnObject();
-		int GetShotDataID(){return idShotData_;}
-		virtual void SetShotDataID(int id){idShotData_ = id;}
-		int GetOwnerType(){return typeOwner_;}
-		void SetOwnerType(int type){typeOwner_ = type;}
+	int frameWork_;
+	int idShotData_;
+	int typeOwner_;
 
-		bool IsValidGraze(){return frameGrazeInvalid_ <= 0;}
-		int GetDelay(){return delay_;}
-		void SetDelay(int delay){delay_ = delay;}
-		int GetSourceBlendType(){return typeSourceBrend_;}
-		void SetSourceBlendType(int type){typeSourceBrend_ = type;}
-		double GetLife(){return life_;}
-		void SetLife(double life){life_ = life;}
-		double GetDamage(){return damage_;}
-		void SetDamage(double damage){damage_ = damage;}
-		virtual void SetFadeDelete(){if(frameFadeDelete_ < 0)frameFadeDelete_ = FRAME_FADEDELETE;}
-		bool IsAutoDelete(){return bAutoDelete_;}
-		void SetAutoDelete(bool b){bAutoDelete_ = b;}
-		void SetAutoDeleteFrame(int frame){frameAutoDelete_ = frame;}
-		bool IsEraseShot(){return bEraseShot_;}
-		void SetEraseShot(bool bErase){bEraseShot_ = bErase;}
-		bool IsSpellFactor(){return bSpellFactor_;}
-		void SetSpellFactor(bool bSpell){bSpellFactor_ = bSpell;}
-		void SetUserIntersectionMode(bool b){bUserIntersectionMode_ = b;}
-		void SetIntersectionEnable(bool b){bIntersectionEnable_ = b;}
-		void SetItemChangeEnable(bool b){bChangeItemEnable_ = b;}
+	D3DCOLOR color_;
+	int delay_; //遅延時間
+	int typeSourceBrend_; //遅延時間ブレンド種別
+	int frameGrazeInvalid_; //かすり無効フレーム
+	int frameFadeDelete_;
+	double damage_;
+	double life_; //貫通力
+	bool bAutoDelete_;
+	bool bEraseShot_; //弾削除機能
+	bool bSpellFactor_; //スペル付加
+	int frameAutoDelete_; //自動削除フレーム
+	ref_count_ptr<ReserveShotList>::unsync listReserveShot_;
 
-		virtual void DeleteImmediate();
-		virtual void ConvertToItem();
-		void AddShot(int frame, int idShot, int radius, int angle);
+	bool bUserIntersectionMode_; //ユーザ定義あたり判定モード
+	bool bIntersectionEnable_;
+	bool bChangeItemEnable_;
+
+	StgShotData* _GetShotData();
+	void _SetVertexPosition(VERTEX_TLX& vertex, float x, float y, float z = 1.0f, float w = 1.0f);
+	void _SetVertexUV(VERTEX_TLX& vertex, float u, float v);
+	void _SetVertexColorARGB(VERTEX_TLX& vertex, D3DCOLOR color);
+	virtual void _DeleteInLife();
+	virtual void _DeleteInAutoClip();
+	virtual void _DeleteInFadeDelete();
+	virtual void _DeleteInAutoDeleteFrame();
+	virtual void _Move();
+	void _AddReservedShotWork();
+	virtual void _AddReservedShot(ref_count_ptr<StgShotObject>::unsync obj, ReserveShotListData* data);
+	virtual void _ConvertToItemAndSendEvent() {}
+	virtual void _SendDeleteEvent(int bit);
 };
 
-class StgShotObject::ReserveShotListData
-{
+class StgShotObject::ReserveShotListData {
 	friend ReserveShotList;
-		int idShot_;//対象ID
-		double radius_;//出現位置距離
-		double angle_;//出現位置角度
-	public:
-		ReserveShotListData(){idShot_ = DxScript::ID_INVALID; radius_ = 0 ; angle_ = 0;}
-		virtual ~ReserveShotListData(){}
-		int GetShotID(){return idShot_;}
-		double GetRadius(){return radius_;}
-		double GetAngle(){return angle_;}
+
+public:
+	ReserveShotListData()
+	{
+		idShot_ = DxScript::ID_INVALID;
+		radius_ = 0;
+		angle_ = 0;
+	}
+	virtual ~ReserveShotListData() {}
+	int GetShotID() { return idShot_; }
+	double GetRadius() { return radius_; }
+	double GetAngle() { return angle_; }
+
+private:
+	int idShot_; //対象ID
+	double radius_; //出現位置距離
+	double angle_; //出現位置角度
 };
 
-class StgShotObject::ReserveShotList
-{
+class StgShotObject::ReserveShotList {
+public:
+	class ListElement {
+		std::list<ReserveShotListData> list_;
+
 	public:
-		class ListElement
-		{
-				std::list<ReserveShotListData> list_;
-			public:
-				ListElement(){}
-				virtual ~ListElement(){}
-				void Add(ReserveShotListData& data){list_.push_back(data);}
-				std::list<ReserveShotListData>* GetDataList(){return &list_;}
-		};
-	private:
-		int frame_;
-		std::map<int, ref_count_ptr<ListElement>::unsync > mapData_;
-	public:
-		ReserveShotList(){frame_ = 0;}
-		virtual ~ReserveShotList(){}
-		ref_count_ptr<ListElement>::unsync GetNextFrameData();
-		void AddData(int frame, int idShot, int radius, int angle);
-		void Clear(StgStageController* stageController);
+		ListElement() {}
+		virtual ~ListElement() {}
+		void Add(ReserveShotListData& data) { list_.push_back(data); }
+		std::list<ReserveShotListData>* GetDataList() { return &list_; }
+	};
+
+public:
+	ReserveShotList() { frame_ = 0; }
+	virtual ~ReserveShotList() {}
+	ref_count_ptr<ListElement>::unsync GetNextFrameData();
+	void AddData(int frame, int idShot, int radius, int angle);
+	void Clear(StgStageController* stageController);
+
+private:
+	int frame_;
+	std::map<int, ref_count_ptr<ListElement>::unsync> mapData_;
 };
 
 /**********************************************************
 //StgNormalShotObject
 **********************************************************/
-class StgNormalShotObject : public StgShotObject
-{
-	protected:
-		double angularVelocity_;
-		void _AddIntersectionRelativeTarget();
-		virtual void _ConvertToItemAndSendEvent();
-	public:
-		StgNormalShotObject(StgStageController* stageController);
-		virtual ~StgNormalShotObject();
-		virtual void Work();
-		virtual void RenderOnShotManager(D3DXMATRIX& mat);
-		virtual void ClearShotObject();
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+class StgNormalShotObject : public StgShotObject {
+public:
+	StgNormalShotObject(StgStageController* stageController);
+	virtual ~StgNormalShotObject();
+	virtual void Work();
+	virtual void RenderOnShotManager(D3DXMATRIX& mat);
+	virtual void ClearShotObject();
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
 
-		virtual void RegistIntersectionTarget();
-		virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > GetIntersectionTargetList();
-		virtual void SetShotDataID(int id);
+	virtual void RegistIntersectionTarget();
+	virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList();
+	virtual void SetShotDataID(int id);
+
+protected:
+	void _AddIntersectionRelativeTarget();
+	virtual void _ConvertToItemAndSendEvent();
+	double angularVelocity_;
 };
 
 /**********************************************************
 //StgLaserObject(レーザー基本部)
 **********************************************************/
-class StgLaserObject : public StgShotObject
-{
-	protected:
-		int length_;
-		int widthRender_;
-		int widthIntersection_;
-		int invalidLengthStart_;
-		int invalidLengthEnd_;
-		int frameGrazeInvalidStart_;
-		double itemDistance_;
-		void _AddIntersectionRelativeTarget();
+class StgLaserObject : public StgShotObject {
+public:
+	StgLaserObject(StgStageController* stageController);
+	virtual void ClearShotObject();
+	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
 
-	public:
-		StgLaserObject(StgStageController* stageController);
-		virtual void ClearShotObject();
-		virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	int GetLength() { return length_; }
+	void SetLength(int length);
+	int GetRenderWidth() { return widthRender_; }
+	void SetRenderWidth(int width);
+	int GetIntersectionWidth() { return widthIntersection_; }
+	void SetIntersectionWidth(int width) { widthIntersection_ = width; }
+	void SetInvalidLength(int start, int end)
+	{
+		invalidLengthStart_ = start;
+		invalidLengthEnd_ = end;
+	}
+	void SetGrazeInvalidFrame(int frame) { frameGrazeInvalidStart_ = frame; }
+	void SetItemDistance(double dist) { itemDistance_ = dist; }
 
-		int GetLength(){return length_;}
-		void SetLength(int length);
-		int GetRenderWidth(){return widthRender_;}
-		void SetRenderWidth(int width);
-		int GetIntersectionWidth(){return widthIntersection_;}
-		void SetIntersectionWidth(int width){widthIntersection_ = width;}
-		void SetInvalidLength(int start, int end){invalidLengthStart_ = start; invalidLengthEnd_ = end;}
-		void SetGrazeInvalidFrame(int frame){frameGrazeInvalidStart_ = frame;}
-		void SetItemDistance(double dist){itemDistance_ = dist;}
+protected:
+	void _AddIntersectionRelativeTarget();
+	int length_;
+	int widthRender_;
+	int widthIntersection_;
+	int invalidLengthStart_;
+	int invalidLengthEnd_;
+	int frameGrazeInvalidStart_;
+	double itemDistance_;
 };
 
 /**********************************************************
 //StgLooseLaserObject(射出型レーザー)
 **********************************************************/
-class StgLooseLaserObject : public StgLaserObject
-{
-	protected:
-		double posXE_;//後方x
-		double posYE_;//後方y
+class StgLooseLaserObject : public StgLaserObject {
+public:
+	StgLooseLaserObject(StgStageController* stageController);
+	virtual void Work();
+	virtual void RenderOnShotManager(D3DXMATRIX& mat);
 
-		virtual void _DeleteInAutoClip();
-		virtual void _Move();
-		virtual void _ConvertToItemAndSendEvent();
-	public:
-		StgLooseLaserObject(StgStageController* stageController);
-		virtual void Work();
-		virtual void RenderOnShotManager(D3DXMATRIX& mat);
+	virtual void RegistIntersectionTarget();
+	virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList();
+	virtual void SetX(double x)
+	{
+		StgShotObject::SetX(x);
+		posXE_ = x;
+	}
+	virtual void SetY(double y)
+	{
+		StgShotObject::SetY(y);
+		posYE_ = y;
+	}
 
-		virtual void RegistIntersectionTarget();
-		virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > GetIntersectionTargetList();
-		virtual void SetX(double x){StgShotObject::SetX(x);posXE_ = x;}
-		virtual void SetY(double y){StgShotObject::SetY(y);posYE_ = y;}
+protected:
+	virtual void _DeleteInAutoClip();
+	virtual void _Move();
+	virtual void _ConvertToItemAndSendEvent();
+
+	double posXE_; //後方x
+	double posYE_; //後方y
 };
 
 /**********************************************************
 //StgStraightLaserObject(設置型レーザー)
 **********************************************************/
-class StgStraightLaserObject : public StgLaserObject
-{
-	protected:
-		double angLaser_;
-		bool bUseSouce_;
-		double scaleX_;
+class StgStraightLaserObject : public StgLaserObject {
+public:
+	StgStraightLaserObject(StgStageController* stageController);
+	virtual void Work();
+	virtual void RenderOnShotManager(D3DXMATRIX& mat);
+	virtual void RegistIntersectionTarget();
+	virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList();
 
-		virtual void _DeleteInAutoClip();
-		virtual void _DeleteInAutoDeleteFrame();
-		virtual void _AddReservedShot(ref_count_ptr<StgShotObject>::unsync obj, ReserveShotListData* data);
-		virtual void _ConvertToItemAndSendEvent();
-	public:
-		StgStraightLaserObject(StgStageController* stageController);
-		virtual void Work();
-		virtual void RenderOnShotManager(D3DXMATRIX& mat);
-		virtual void RegistIntersectionTarget();
-		virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > GetIntersectionTargetList();
+	double GetLaserAngle() { return angLaser_; }
+	void SetLaserAngle(double angle) { angLaser_ = angle; }
+	void SetFadeDelete()
+	{
+		if (frameFadeDelete_ < 0)
+			frameFadeDelete_ = FRAME_FADEDELETE_LASER;
+	}
+	void SetSourceEnable(bool bEnable) { bUseSouce_ = bEnable; }
 
-		double GetLaserAngle(){return angLaser_;}
-		void SetLaserAngle(double angle){angLaser_ = angle;}
-		void SetFadeDelete(){if(frameFadeDelete_ < 0)frameFadeDelete_ = FRAME_FADEDELETE_LASER;}
-		void SetSourceEnable(bool bEnable){bUseSouce_ = bEnable;}
+protected:
+	virtual void _DeleteInAutoClip();
+	virtual void _DeleteInAutoDeleteFrame();
+	virtual void _AddReservedShot(ref_count_ptr<StgShotObject>::unsync obj, ReserveShotListData* data);
+	virtual void _ConvertToItemAndSendEvent();
 
+	double angLaser_;
+	bool bUseSouce_;
+	double scaleX_;
 };
 
 /**********************************************************
 //StgCurveLaserObject(曲がる型レーザー)
 **********************************************************/
-class StgCurveLaserObject : public StgLaserObject
-{
-	protected:
-		struct Position
-		{
-			double x;
-			double y;
-		};
+class StgCurveLaserObject : public StgLaserObject {
+protected:
+	struct Position {
+		double x;
+		double y;
+	};
 
-		std::list<Position> listPosition_;
-		double tipDecrement_;
+public:
+	StgCurveLaserObject(StgStageController* stageController);
+	virtual void Work();
+	virtual void RenderOnShotManager(D3DXMATRIX& mat);
+	virtual void RegistIntersectionTarget();
+	virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList();
+	void SetTipDecrement(double dec) { tipDecrement_ = dec; }
 
-		virtual void _DeleteInAutoClip();
-		virtual void _Move();
-		virtual void _ConvertToItemAndSendEvent();
-	public:
-		StgCurveLaserObject(StgStageController* stageController);
-		virtual void Work();
-		virtual void RenderOnShotManager(D3DXMATRIX& mat);
-		virtual void RegistIntersectionTarget();
-		virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > GetIntersectionTargetList();
-		void SetTipDecrement(double dec){tipDecrement_ = dec;}
+protected:
+	std::list<Position> listPosition_;
+	double tipDecrement_;
+
+	virtual void _DeleteInAutoClip();
+	virtual void _Move();
+	virtual void _ConvertToItemAndSendEvent();
 };
-
-
 
 #endif

--- a/source/TouhouDanmakufu/Common/StgStageController.cpp
+++ b/source/TouhouDanmakufu/Common/StgStageController.cpp
@@ -1,5 +1,5 @@
-#include"StgStageController.hpp"
-#include"StgSystem.hpp"
+#include "StgStageController.hpp"
+#include "StgSystem.hpp"
 
 /**********************************************************
 //StgStageController
@@ -62,13 +62,12 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 	keyReplayManager_->AddTarget(EDirectInput::KEY_CANCEL);
 	std::set<int> listReplayTargetKey = infoSystem_->GetReplayTargetKeyList();
 	std::set<int>::iterator itrKey = listReplayTargetKey.begin();
-	for(; itrKey != listReplayTargetKey.end() ; itrKey++)
-	{
+	for (; itrKey != listReplayTargetKey.end(); itrKey++) {
 		int id = *itrKey;
 		keyReplayManager_->AddTarget(id);
 	}
 
-	if(replayStageData == NULL)
+	if (replayStageData == NULL)
 		replayStageData = new ReplayInformation::StageData();
 	infoStage_->SetReplayData(replayStageData);
 
@@ -78,17 +77,14 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 	EFpsController::GetInstance()->AddFpsControlObject(wPtr);
 
 	//前ステージ情報反映
-	if(prevStageData != NULL)
-	{
+	if (prevStageData != NULL) {
 		infoStage_->SetScore(prevStageData->GetScore());
 		infoStage_->SetGraze(prevStageData->GetGraze());
 		infoStage_->SetPoint(prevStageData->GetPoint());
 	}
 
-
 	//リプレイ関連(スクリプト初期化前)
-	if(!infoStage_->IsReplay())
-	{
+	if (!infoStage_->IsReplay()) {
 		//乱数
 		int randSeed = infoStage_->GetMersenneTwister()->SeedRNG();
 		replayStageData->SetRandSeed(randSeed);
@@ -107,9 +103,7 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 		replayStageData->SetStartScore(infoStage_->GetScore());
 		replayStageData->SetGraze(infoStage_->GetGraze());
 		replayStageData->SetPoint(infoStage_->GetPoint());
-	}
-	else
-	{
+	} else {
 		//乱数
 		int randSeed = replayStageData->GetRandSeed();
 		infoStage_->GetMersenneTwister()->Initialize(randSeed);
@@ -140,8 +134,7 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 
 	//パッケージスクリプトの場合は、ステージスクリプトと関連付ける
 	StgPackageController* packageController = systemController_->GetPackageController();
-	if(packageController != NULL)
-	{
+	if (packageController != NULL) {
 		ref_count_ptr<ScriptManager> packageScriptManager = packageController->GetScriptManager();
 		ref_count_ptr<ScriptManager> stageScriptManager = scriptManager_;
 		ScriptManager::AddRelativeScriptManagerMutual(packageScriptManager, stageScriptManager);
@@ -157,10 +150,9 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 
 	//システムスクリプト
 	std::wstring pathSystemScript = infoMain->GetSystemPath();
-	if(pathSystemScript == ScriptInformation::DEFAULT)
+	if (pathSystemScript == ScriptInformation::DEFAULT)
 		pathSystemScript = EPathProperty::GetStgDefaultScriptDirectory() + L"Default_System.txt";
-	if(pathSystemScript.size() > 0)
-	{
+	if (pathSystemScript.size() > 0) {
 		pathSystemScript = EPathProperty::ExtendRelativeToFull(dirInfo, pathSystemScript);
 		ELogger::WriteTop(StringUtility::Format(L"システムスクリプト[%s]", pathSystemScript.c_str()));
 		_int64 idScript = scriptManager_->LoadScript(pathSystemScript, StgStageScript::TYPE_SYSTEM);
@@ -172,8 +164,7 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 	ref_count_ptr<ScriptInformation> infoPlayer = infoStage_->GetPlayerScriptInformation();
 	std::wstring pathPlayerScript = infoPlayer->GetScriptPath();
 
-	if(pathPlayerScript.size() > 0)
-	{
+	if (pathPlayerScript.size() > 0) {
 		ELogger::WriteTop(StringUtility::Format(L"自機スクリプト[%s]", pathPlayerScript.c_str()));
 		int idPlayer = objectManager->CreatePlayerObject();
 		objPlayer = ref_count_ptr<StgPlayerObject>::unsync::DownCast(GetMainRenderObject(idPlayer));
@@ -181,37 +172,30 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 		_int64 idScript = scriptManager_->LoadScript(pathPlayerScript, StgStageScript::TYPE_PLAYER);
 		_SetupReplayTargetCommonDataArea(idScript);
 
-		ref_count_ptr<StgStagePlayerScript> script = 
-			ref_count_ptr<StgStagePlayerScript>::DownCast(scriptManager_->GetScript(idScript));
+		ref_count_ptr<StgStagePlayerScript> script = ref_count_ptr<StgStagePlayerScript>::DownCast(scriptManager_->GetScript(idScript));
 		objPlayer->SetScript(script.GetPointer());
 		scriptManager_->SetPlayerScriptID(idScript);
 		scriptManager_->StartScript(idScript);
 
 		//前ステージ情報反映
-		if(prevPlayerInfo != NULL)
+		if (prevPlayerInfo != NULL)
 			objPlayer->SetPlayerInforamtion(prevPlayerInfo);
 	}
-	if(objPlayer != NULL)
+	if (objPlayer != NULL)
 		infoStage_->SetPlayerObjectInformation(objPlayer->GetPlayerInformation());
 
 	//メインスクリプト
-	if(infoMain->GetType() == ScriptInformation::TYPE_SINGLE)
-	{
+	if (infoMain->GetType() == ScriptInformation::TYPE_SINGLE) {
 		std::wstring pathMainScript = EPathProperty::GetSystemResourceDirectory() + L"script/System_SingleStage.txt";
 		_int64 idScript = scriptManager_->LoadScript(pathMainScript, StgStageScript::TYPE_STAGE);
 		scriptManager_->StartScript(idScript);
-	}
-	else if(infoMain->GetType() == ScriptInformation::TYPE_PLURAL)
-	{
+	} else if (infoMain->GetType() == ScriptInformation::TYPE_PLURAL) {
 		std::wstring pathMainScript = EPathProperty::GetSystemResourceDirectory() + L"script/System_PluralStage.txt";
 		_int64 idScript = scriptManager_->LoadScript(pathMainScript, StgStageScript::TYPE_STAGE);
 		scriptManager_->StartScript(idScript);
-	}
-	else
-	{
+	} else {
 		std::wstring pathMainScript = infoMain->GetScriptPath();
-		if(pathMainScript.size() > 0)
-		{
+		if (pathMainScript.size() > 0) {
 			_int64 idScript = scriptManager_->LoadScript(pathMainScript, StgStageScript::TYPE_STAGE);
 			_SetupReplayTargetCommonDataArea(idScript);
 			scriptManager_->StartScript(idScript);
@@ -220,10 +204,9 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 
 	//背景スクリプト
 	std::wstring pathBack = infoMain->GetBackgroundPath();
-	if(pathBack == ScriptInformation::DEFAULT)
+	if (pathBack == ScriptInformation::DEFAULT)
 		pathBack = L"";
-	if(pathBack.size() > 0)
-	{
+	if (pathBack.size() > 0) {
 		pathBack = EPathProperty::ExtendRelativeToFull(dirInfo, pathBack);
 		ELogger::WriteTop(StringUtility::Format(L"背景スクリプト[%s]", pathBack.c_str()));
 		_int64 idScript = scriptManager_->LoadScript(pathBack, StgStageScript::TYPE_STAGE);
@@ -232,15 +215,13 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 
 	//音声再生
 	std::wstring pathBGM = infoMain->GetBgmPath();
-	if(pathBGM == ScriptInformation::DEFAULT)
+	if (pathBGM == ScriptInformation::DEFAULT)
 		pathBGM = L"";
-	if(pathBGM.size() > 0)
-	{
+	if (pathBGM.size() > 0) {
 		pathBGM = EPathProperty::ExtendRelativeToFull(dirInfo, pathBGM);
 		ELogger::WriteTop(StringUtility::Format(L"BGM[%s]", pathBGM.c_str()));
 		ref_count_ptr<SoundPlayer> player = DirectSoundManager::GetBase()->GetPlayer(pathBGM);
-		if(player != NULL)
-		{
+		if (player != NULL) {
 			player->SetSoundDivision(SoundDivision::DIVISION_BGM);
 			SoundPlayer::PlayStyle style;
 			style.SetLoopEnable(true);
@@ -249,12 +230,10 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 	}
 
 	//リプレイ関連(スクリプト初期化後)
-	if(!infoStage_->IsReplay())
-	{
+	if (!infoStage_->IsReplay()) {
 		//自機情報
 		ref_count_ptr<StgPlayerObject>::unsync objPlayer = GetPlayerObject();
-		if(objPlayer != NULL)
-		{
+		if (objPlayer != NULL) {
 			replayStageData->SetPlayerLife(objPlayer->GetLife());
 			replayStageData->SetPlayerBombCount(objPlayer->GetSpell());
 			replayStageData->SetPlayerPower(objPlayer->GetPower());
@@ -268,8 +247,6 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 	}
 
 	infoStage_->SetStageStartTime(timeGetTime());
-
-
 }
 void StgStageController::CloseScene()
 {
@@ -277,8 +254,7 @@ void StgStageController::CloseScene()
 	EFpsController::GetInstance()->RemoveFpsControlObject(wPtr);
 
 	//リプレイ
-	if(!infoStage_->IsReplay())
-	{
+	if (!infoStage_->IsReplay()) {
 		//キー
 		ref_count_ptr<RecordBuffer> recKey = new RecordBuffer();
 		keyReplayManager_->WriteRecord(*recKey.GetPointer());
@@ -295,41 +271,37 @@ void StgStageController::CloseScene()
 }
 void StgStageController::_SetupReplayTargetCommonDataArea(_int64 idScript)
 {
-	ref_count_ptr<StgStageScript> script = 
-		ref_count_ptr<StgStageScript>::DownCast(scriptManager_->GetScript(idScript));
-	if(script == NULL)return;
+	ref_count_ptr<StgStageScript> script = ref_count_ptr<StgStageScript>::DownCast(scriptManager_->GetScript(idScript));
+	if (script == NULL)
+		return;
 
 	gstd::value res = script->RequestEvent(StgStageScript::EV_REQUEST_REPLAY_TARGET_COMMON_AREA);
-	if(!res.has_data())return;
+	if (!res.has_data())
+		return;
 	type_data::type_kind kindRes = res.get_type()->get_kind();
-	if(kindRes != type_data::tk_array)return;
+	if (kindRes != type_data::tk_array)
+		return;
 
 	ref_count_ptr<ReplayInformation::StageData> replayStageData = infoStage_->GetReplayData();
 	std::set<std::string> listArea;
 	int arrayLength = res.length_as_array();
-	for(int iArray = 0 ; iArray < arrayLength ; iArray++)
-	{
+	for (int iArray = 0; iArray < arrayLength; iArray++) {
 		value& arrayValue = res.index_as_array(iArray);
 		std::string area = to_mbcs(arrayValue.as_string());
 		listArea.insert(area);
 	}
 
 	gstd::ref_count_ptr<ScriptCommonDataManager> scriptCommonDataManager = systemController_->GetCommonDataManager();
-	if(!infoStage_->IsReplay())
-	{
+	if (!infoStage_->IsReplay()) {
 		std::set<std::string>::iterator itrArea = listArea.begin();
-		for(; itrArea != listArea.end();itrArea++)
-		{
+		for (; itrArea != listArea.end(); itrArea++) {
 			std::string area = (*itrArea);
 			ref_count_ptr<ScriptCommonData> commonData = scriptCommonDataManager->GetData(area);
 			replayStageData->SetCommonData(area, commonData);
 		}
-	}
-	else
-	{
+	} else {
 		std::set<std::string>::iterator itrArea = listArea.begin();
-		for(; itrArea != listArea.end();itrArea++)
-		{
+		for (; itrArea != listArea.end(); itrArea++) {
 			std::string area = (*itrArea);
 			ref_count_ptr<ScriptCommonData> commonData = replayStageData->GetCommonData(area);
 			scriptCommonDataManager->SetData(area, commonData);
@@ -344,11 +316,9 @@ void StgStageController::Work()
 	bool bPackageMode = infoSystem->IsPackageMode();
 
 	bool bPermitRetryKey = !input->IsTargetKeyCode(DIK_BACK);
-	if(!bPackageMode && bPermitRetryKey && input->GetKeyState(DIK_BACK) == KEY_PUSH)
-	{
+	if (!bPackageMode && bPermitRetryKey && input->GetKeyState(DIK_BACK) == KEY_PUSH) {
 		//リトライ
-		if(!infoStage_->IsReplay())
-		{
+		if (!infoStage_->IsReplay()) {
 			ref_count_ptr<StgSystemInformation> infoSystem = systemController_->GetSystemInformation();
 			infoSystem->SetRetry();
 			return;
@@ -356,25 +326,20 @@ void StgStageController::Work()
 	}
 
 	bool bCurrentPause = infoStage_->IsPause();
-	if(bPackageMode && bCurrentPause)
-	{
+	if (bPackageMode && bCurrentPause) {
 		//パッケージモードで停止中の場合は、パッケージスクリプトで処理する
 		return;
 	}
 
 	bool bPauseKey = (input->GetVirtualKeyState(EDirectInput::KEY_PAUSE) == KEY_PUSH);
-	if(bPauseKey && !bPackageMode)
-	{
+	if (bPauseKey && !bPackageMode) {
 		//停止キー押下
-		if(!bCurrentPause)
+		if (!bCurrentPause)
 			pauseManager_->Start();
 		else
 			pauseManager_->Finish();
-	}
-	else
-	{
-		if(!bCurrentPause)
-		{
+	} else {
+		if (!bCurrentPause) {
 			//リプレイキー更新
 			keyReplayManager_->Update();
 
@@ -385,11 +350,13 @@ void StgStageController::Work()
 			scriptManager_->Work(StgStageScript::TYPE_ITEM);
 
 			ref_count_ptr<StgPlayerObject>::unsync objPlayer = GetPlayerObject();
-			if(objPlayer != NULL)objPlayer->Move(); //自機だけ先に移動
+			if (objPlayer != NULL)
+				objPlayer->Move(); //自機だけ先に移動
 			scriptManager_->Work(StgStageScript::TYPE_PLAYER);
 
 			//オブジェクト動作処理
-			if(infoStage_->IsEnd())return;
+			if (infoStage_->IsEnd())
+				return;
 			objectManagerMain_->WorkObject();
 
 			enemyManager_->Work();
@@ -401,12 +368,10 @@ void StgStageController::Work()
 			shotManager_->RegistIntersectionTarget();
 			intersectionManager_->Work();
 
-			if(!infoStage_->IsReplay())
-			{
+			if (!infoStage_->IsReplay()) {
 				//リプレイ用情報更新
 				int stageFrame = infoStage_->GetCurrentFrame();
-				if(stageFrame % 60 == 0)
-				{
+				if (stageFrame % 60 == 0) {
 					ref_count_ptr<ReplayInformation::StageData> replayStageData = infoStage_->GetReplayData();
 					float framePerSecond = EFpsController::GetInstance()->GetCurrentFps();
 					replayStageData->AddFramePerSecond(framePerSecond);
@@ -414,18 +379,15 @@ void StgStageController::Work()
 			}
 
 			infoStage_->AdvanceFrame();
-			
-		}
-		else
-		{
+
+		} else {
 			//停止中
 			pauseManager_->Work();
 		}
 	}
 
 	ELogger* logger = ELogger::GetInstance();
-	if(logger->IsWindowVisible())
-	{
+	if (logger->IsWindowVisible()) {
 		//ログ関連
 		logger->SetInfo(6, L"stg shot_count", StringUtility::Format(L"%d", shotManager_->GetShotCountAll()));
 		logger->SetInfo(7, L"stg enemy_count", StringUtility::Format(L"%d", enemyManager_->GetEnemyCount()));
@@ -435,17 +397,13 @@ void StgStageController::Work()
 void StgStageController::Render()
 {
 	bool bPause = infoStage_->IsPause();
-	if(!bPause)
-	{
+	if (!bPause) {
 		objectManagerMain_->RenderObject();
 
-		if(infoStage_->IsReplay())
-		{
+		if (infoStage_->IsReplay()) {
 			//リプレイ中
 		}
-	}
-	else
-	{
+	} else {
 		//停止
 		pauseManager_->Render();
 	}
@@ -474,7 +432,8 @@ ref_count_ptr<DxScriptObjectBase>::unsync StgStageController::GetMainRenderObjec
 ref_count_ptr<StgPlayerObject>::unsync StgStageController::GetPlayerObject()
 {
 	int idPlayer = objectManagerMain_->GetPlayerObjectID();
-	if(idPlayer == DxScript::ID_INVALID)return NULL;
+	if (idPlayer == DxScript::ID_INVALID)
+		return NULL;
 	return ref_count_ptr<StgPlayerObject>::unsync::DownCast(GetMainRenderObject(idPlayer));
 }
 
@@ -517,8 +476,7 @@ void StgStageInformation::SetStgFrameRect(RECT rect, bool bUpdateFocusResetValue
 	pos->x = (rect.right - rect.left) / 2;
 	pos->y = (rect.bottom - rect.top) / 2;
 
-	if(bUpdateFocusResetValue)
-	{
+	if (bUpdateFocusResetValue) {
 		DirectGraphics* graphics = DirectGraphics::GetBase();
 		gstd::ref_count_ptr<DxCamera2D> camera2D = graphics->GetCamera2D();
 		camera2D->SetResetFocus(pos);
@@ -533,13 +491,11 @@ int PseudoSlowInformation::GetFps()
 {
 	int fps = STANDARD_FPS;
 	int target = TARGET_ALL;
-	if(mapDataPlayer_.find(target) != mapDataPlayer_.end())
-	{
+	if (mapDataPlayer_.find(target) != mapDataPlayer_.end()) {
 		ref_count_ptr<SlowData> data = mapDataPlayer_[target];
 		fps = min(fps, data->GetFps());
 	}
-	if(mapDataEnemy_.find(target) != mapDataEnemy_.end())
-	{
+	if (mapDataEnemy_.find(target) != mapDataEnemy_.end()) {
 		ref_count_ptr<SlowData> data = mapDataEnemy_[target];
 		fps = min(fps, data->GetFps());
 	}
@@ -547,35 +503,28 @@ int PseudoSlowInformation::GetFps()
 }
 bool PseudoSlowInformation::IsValidFrame(int target)
 {
-	bool res = mapValid_.find(target) == mapValid_.end() ||
-				mapValid_[target];
+	bool res = mapValid_.find(target) == mapValid_.end() || mapValid_[target];
 	return res;
 }
 void PseudoSlowInformation::Next()
 {
 	int fps = STANDARD_FPS;
 	int target = TARGET_ALL;
-	if(mapDataPlayer_.find(target) != mapDataPlayer_.end())
-	{
+	if (mapDataPlayer_.find(target) != mapDataPlayer_.end()) {
 		ref_count_ptr<SlowData> data = mapDataPlayer_[target];
 		fps = min(fps, data->GetFps());
 	}
-	if(mapDataEnemy_.find(target) != mapDataEnemy_.end())
-	{
+	if (mapDataEnemy_.find(target) != mapDataEnemy_.end()) {
 		ref_count_ptr<SlowData> data = mapDataEnemy_[target];
 		fps = min(fps, data->GetFps());
 	}
 
 	bool bValid = false;
-	if(fps == STANDARD_FPS)
-	{
+	if (fps == STANDARD_FPS) {
 		bValid = true;
-	}
-	else
-	{
+	} else {
 		current_ += fps;
-		if(current_ >= STANDARD_FPS)
-		{
+		if (current_ >= STANDARD_FPS) {
 			current_ %= STANDARD_FPS;
 			bValid = true;
 		}
@@ -589,25 +538,23 @@ void PseudoSlowInformation::AddSlow(int fps, int owner, int target)
 	fps = min(STANDARD_FPS, fps);
 	ref_count_ptr<SlowData> data = new SlowData();
 	data->SetFps(fps);
-	switch(owner)
-	{
-		case OWNER_PLAYER:
-			mapDataPlayer_[target] = data;
-			break;
-		case OWNER_ENEMY:
-			mapDataEnemy_[target] = data;
-			break;
+	switch (owner) {
+	case OWNER_PLAYER:
+		mapDataPlayer_[target] = data;
+		break;
+	case OWNER_ENEMY:
+		mapDataEnemy_[target] = data;
+		break;
 	}
 }
 void PseudoSlowInformation::RemoveSlow(int owner, int target)
 {
-	switch(owner)
-	{
-		case OWNER_PLAYER:
-			mapDataPlayer_.erase(target);
-			break;
-		case OWNER_ENEMY:
-			mapDataEnemy_.erase(target);
-			break;
+	switch (owner) {
+	case OWNER_PLAYER:
+		mapDataPlayer_.erase(target);
+		break;
+	case OWNER_ENEMY:
+		mapDataEnemy_.erase(target);
+		break;
 	}
 }

--- a/source/TouhouDanmakufu/Common/StgStageController.hpp
+++ b/source/TouhouDanmakufu/Common/StgStageController.hpp
@@ -1,14 +1,14 @@
 #ifndef __TOUHOUDANMAKUFU_DNHSTG_STAGECONTROLLER__
 #define __TOUHOUDANMAKUFU_DNHSTG_STAGECONTROLLER__
 
-#include"StgCommon.hpp"
-#include"StgStageScript.hpp"
-#include"StgPlayer.hpp"
-#include"StgEnemy.hpp"
-#include"StgShot.hpp"
-#include"StgItem.hpp"
-#include"StgIntersection.hpp"
-#include"StgUserExtendScene.hpp"
+#include "StgCommon.hpp"
+#include "StgEnemy.hpp"
+#include "StgIntersection.hpp"
+#include "StgItem.hpp"
+#include "StgPlayer.hpp"
+#include "StgShot.hpp"
+#include "StgStageScript.hpp"
+#include "StgUserExtendScene.hpp"
 
 class StgStageInformation;
 class StgStageStartData;
@@ -16,222 +16,214 @@ class PseudoSlowInformation;
 /**********************************************************
 //StgStageController
 **********************************************************/
-class StgStageController
-{
-	private:
-		StgSystemController* systemController_;
-		ref_count_ptr<StgSystemInformation> infoSystem_;
-		ref_count_ptr<StgStageInformation> infoStage_;
-		ref_count_ptr<PseudoSlowInformation> infoSlow_;
+class StgStageController {
+public:
+	StgStageController(StgSystemController* systemController);
+	virtual ~StgStageController();
+	void Initialize(ref_count_ptr<StgStageStartData> startData);
+	void CloseScene();
+	void Work();
+	void Render();
+	void RenderToTransitionTexture();
 
-		ref_count_ptr<StgPauseScene> pauseManager_;
-		ref_count_ptr<KeyReplayManager> keyReplayManager_;
-		ref_count_ptr<StgStageScriptObjectManager> objectManagerMain_;
-		ref_count_ptr<StgStageScriptManager> scriptManager_;
-		ref_count_ptr<StgEnemyManager> enemyManager_;
-		ref_count_ptr<StgShotManager> shotManager_;
-		ref_count_ptr<StgItemManager> itemManager_;
-		ref_count_ptr<StgIntersectionManager> intersectionManager_;
+	ref_count_ptr<StgStageScriptObjectManager> GetMainObjectManager() { return objectManagerMain_; }
+	StgStageScriptManager* GetScriptManagerP() { return scriptManager_.GetPointer(); }
+	ref_count_ptr<StgStageScriptManager> GetScriptManagerR() { return scriptManager_; }
+	StgEnemyManager* GetEnemyManager() { return enemyManager_.GetPointer(); }
+	StgShotManager* GetShotManager() { return shotManager_.GetPointer(); }
+	StgItemManager* GetItemManager() { return itemManager_.GetPointer(); }
+	StgIntersectionManager* GetIntersectionManager() { return intersectionManager_.GetPointer(); }
+	ref_count_ptr<StgPauseScene> GetPauseManager() { return pauseManager_; }
 
-		void _SetupReplayTargetCommonDataArea(_int64 idScript);
+	ref_count_ptr<DxScriptObjectBase>::unsync GetMainRenderObject(int idObject);
+	ref_count_ptr<StgPlayerObject>::unsync GetPlayerObject();
 
-	public:
-		StgStageController(StgSystemController* systemController);
-		virtual ~StgStageController();
-		void Initialize(ref_count_ptr<StgStageStartData> startData);
-		void CloseScene();
-		void Work();
-		void Render();
-		void RenderToTransitionTexture();
+	StgSystemController* GetSystemController() { return systemController_; }
+	ref_count_ptr<StgSystemInformation> GetSystemInformation() { return infoSystem_; }
+	ref_count_ptr<StgStageInformation> GetStageInformation() { return infoStage_; }
+	ref_count_ptr<KeyReplayManager> GetKeyReplayManager() { return keyReplayManager_; }
 
-		ref_count_ptr<StgStageScriptObjectManager> GetMainObjectManager(){return objectManagerMain_;}
-		StgStageScriptManager* GetScriptManagerP(){return scriptManager_.GetPointer();}
-		ref_count_ptr<StgStageScriptManager> GetScriptManagerR(){return scriptManager_;}
-		StgEnemyManager* GetEnemyManager(){return enemyManager_.GetPointer();}
-		StgShotManager* GetShotManager(){return shotManager_.GetPointer();}
-		StgItemManager* GetItemManager(){return itemManager_.GetPointer();}
-		StgIntersectionManager* GetIntersectionManager(){return intersectionManager_.GetPointer();}
-		ref_count_ptr<StgPauseScene> GetPauseManager(){return pauseManager_;}
+	ref_count_ptr<PseudoSlowInformation> GetSlowInformation() { return infoSlow_; }
 
-		ref_count_ptr<DxScriptObjectBase>::unsync GetMainRenderObject(int idObject);
-		ref_count_ptr<StgPlayerObject>::unsync GetPlayerObject();
+private:
+	void _SetupReplayTargetCommonDataArea(_int64 idScript);
 
-		StgSystemController* GetSystemController(){return systemController_;}
-		ref_count_ptr<StgSystemInformation> GetSystemInformation(){return infoSystem_;}
-		ref_count_ptr<StgStageInformation> GetStageInformation(){return infoStage_;}
-		ref_count_ptr<KeyReplayManager> GetKeyReplayManager(){return keyReplayManager_;}
+	StgSystemController* systemController_;
+	ref_count_ptr<StgSystemInformation> infoSystem_;
+	ref_count_ptr<StgStageInformation> infoStage_;
+	ref_count_ptr<PseudoSlowInformation> infoSlow_;
 
-		ref_count_ptr<PseudoSlowInformation> GetSlowInformation(){return infoSlow_;}
+	ref_count_ptr<StgPauseScene> pauseManager_;
+	ref_count_ptr<KeyReplayManager> keyReplayManager_;
+	ref_count_ptr<StgStageScriptObjectManager> objectManagerMain_;
+	ref_count_ptr<StgStageScriptManager> scriptManager_;
+	ref_count_ptr<StgEnemyManager> enemyManager_;
+	ref_count_ptr<StgShotManager> shotManager_;
+	ref_count_ptr<StgItemManager> itemManager_;
+	ref_count_ptr<StgIntersectionManager> intersectionManager_;
 };
-
 
 /**********************************************************
 //StgStageInformation
 **********************************************************/
-class StgStageInformation
-{
-	public:
-		enum
-		{
-			RESULT_UNKNOWN,
-			RESULT_BREAK_OFF,
-			RESULT_PLAYER_DOWN,
-			RESULT_CLEARED,
-		};
+class StgStageInformation {
+public:
+	enum {
+		RESULT_UNKNOWN,
+		RESULT_BREAK_OFF,
+		RESULT_PLAYER_DOWN,
+		RESULT_CLEARED,
+	};
 
-	private:
-		bool bEndStg_;
-		bool bPause_;
-		bool bReplay_;//リプレイ
-		int frame_;
-		int stageIndex_;
+public:
+	StgStageInformation();
+	virtual ~StgStageInformation();
+	bool IsEnd() { return bEndStg_; }
+	void SetEnd() { bEndStg_ = true; }
+	bool IsPause() { return bPause_; }
+	void SetPause(bool bPause) { bPause_ = bPause; }
+	bool IsReplay() { return bReplay_; }
+	void SetReplay(bool bReplay) { bReplay_ = bReplay; }
+	int GetCurrentFrame() { return frame_; }
+	void AdvanceFrame() { frame_++; }
+	int GetStageIndex() { return stageIndex_; }
+	void SetStageIndex(int index) { stageIndex_ = index; }
 
-		ref_count_ptr<ScriptInformation> infoMainScript_;
-		ref_count_ptr<ScriptInformation> infoPlayerScript_;
-		ref_count_ptr<StgPlayerInformation> infoPlayerObject_;
-		ref_count_ptr<ReplayInformation::StageData> replayStageData_;
+	ref_count_ptr<ScriptInformation> GetMainScriptInformation() { return infoMainScript_; }
+	void SetMainScriptInformation(ref_count_ptr<ScriptInformation> info) { infoMainScript_ = info; }
+	ref_count_ptr<ScriptInformation> GetPlayerScriptInformation() { return infoPlayerScript_; }
+	void SetPlayerScriptInformation(ref_count_ptr<ScriptInformation> info) { infoPlayerScript_ = info; }
+	ref_count_ptr<StgPlayerInformation> GetPlayerObjectInformation() { return infoPlayerObject_; }
+	void SetPlayerObjectInformation(ref_count_ptr<StgPlayerInformation> info) { infoPlayerObject_ = info; }
+	ref_count_ptr<ReplayInformation::StageData> GetReplayData() { return replayStageData_; }
+	void SetReplayData(ref_count_ptr<ReplayInformation::StageData> data) { replayStageData_ = data; }
 
-		//STG設定
-		RECT rcStgFrame_;
-		int priMinStgFrame_;
-		int priMaxStgFrame_;
-		int priShotObject_;
-		int priItemObject_;
-		int priCameraFocusPermit_;
-		RECT rcShotAutoDeleteClip_;
+	RECT GetStgFrameRect() { return rcStgFrame_; }
+	void SetStgFrameRect(RECT rect, bool bUpdateFocusResetValue = true);
+	int GetStgFrameMinPriority() { return priMinStgFrame_; }
+	void SetStgFrameMinPriority(int pri) { priMinStgFrame_ = pri; }
+	int GetStgFrameMaxPriority() { return priMaxStgFrame_; }
+	void SetStgFrameMaxPriority(int pri) { priMaxStgFrame_ = pri; }
+	int GetShotObjectPriority() { return priShotObject_; }
+	void SetShotObjectPriority(int pri) { priShotObject_ = pri; }
+	int GetItemObjectPriority() { return priItemObject_; }
+	void SetItemObjectPriority(int pri) { priItemObject_ = pri; }
+	int GetCameraFocusPermitPriority() { return priCameraFocusPermit_; }
+	void SetCameraFocusPermitPriority(int pri) { priCameraFocusPermit_ = pri; }
+	RECT GetShotAutoDeleteClip() { return rcShotAutoDeleteClip_; }
+	void SetShotAutoDeleteClip(RECT rect) { rcShotAutoDeleteClip_ = rect; }
 
-		//STG情報
-		ref_count_ptr<MersenneTwister> rand_;
-		_int64 score_;
-		_int64 graze_;
-		_int64 point_;
-		int result_;
-		int timeStart_;
+	ref_count_ptr<MersenneTwister> GetMersenneTwister() { return rand_; }
+	void SetMersenneTwisterSeed(int seed) { rand_->Initialize(seed); }
+	_int64 GetScore() { return score_; }
+	void SetScore(_int64 score) { score_ = score; }
+	void AddScore(_int64 inc) { score_ += inc; }
+	_int64 GetGraze() { return graze_; }
+	void SetGraze(_int64 graze) { graze_ = graze; }
+	void AddGraze(_int64 inc) { graze_ += inc; }
+	_int64 GetPoint() { return point_; }
+	void SetPoint(_int64 point) { point_ = point; }
+	void AddPoint(_int64 inc) { point_ += inc; }
 
-	public:
-		StgStageInformation();
-		virtual ~StgStageInformation();
-		bool IsEnd(){return bEndStg_;}
-		void SetEnd(){bEndStg_ = true;}
-		bool IsPause(){return bPause_;}
-		void SetPause(bool bPause){bPause_ = bPause;}
-		bool IsReplay(){return bReplay_;}
-		void SetReplay(bool bReplay){bReplay_ = bReplay;}
-		int GetCurrentFrame(){return frame_;}
-		void AdvanceFrame(){frame_++;}
-		int GetStageIndex(){return stageIndex_;}
-		void SetStageIndex(int index){stageIndex_ = index;}
+	int GetResult() { return result_; }
+	void SetResult(int result) { result_ = result; }
 
-		ref_count_ptr<ScriptInformation> GetMainScriptInformation(){return infoMainScript_;}
-		void SetMainScriptInformation(ref_count_ptr<ScriptInformation> info){infoMainScript_ = info;}
-		ref_count_ptr<ScriptInformation> GetPlayerScriptInformation(){return infoPlayerScript_;}
-		void SetPlayerScriptInformation(ref_count_ptr<ScriptInformation> info ){infoPlayerScript_ = info;}
-		ref_count_ptr<StgPlayerInformation> GetPlayerObjectInformation(){return infoPlayerObject_;}
-		void SetPlayerObjectInformation(ref_count_ptr<StgPlayerInformation> info ){infoPlayerObject_ = info;}
-		ref_count_ptr<ReplayInformation::StageData> GetReplayData(){return replayStageData_;}
-		void SetReplayData(ref_count_ptr<ReplayInformation::StageData> data){replayStageData_ = data;}
+	int GetStageStartTime() { return timeStart_; }
+	void SetStageStartTime(int time) { timeStart_ = time; }
 
-		RECT GetStgFrameRect(){return rcStgFrame_;}
-		void SetStgFrameRect(RECT rect, bool bUpdateFocusResetValue = true);
-		int GetStgFrameMinPriority(){return priMinStgFrame_;}
-		void SetStgFrameMinPriority(int pri){priMinStgFrame_ = pri;}
-		int GetStgFrameMaxPriority(){return priMaxStgFrame_;}
-		void SetStgFrameMaxPriority(int pri){priMaxStgFrame_ = pri;}
-		int GetShotObjectPriority(){return priShotObject_;}
-		void SetShotObjectPriority(int pri){priShotObject_ = pri;}
-		int GetItemObjectPriority(){return priItemObject_;}
-		void SetItemObjectPriority(int pri){priItemObject_ = pri;}
-		int GetCameraFocusPermitPriority(){return priCameraFocusPermit_;}
-		void SetCameraFocusPermitPriority(int pri){priCameraFocusPermit_ = pri;}
-		RECT GetShotAutoDeleteClip(){return rcShotAutoDeleteClip_;}
-		void SetShotAutoDeleteClip(RECT rect){rcShotAutoDeleteClip_ = rect;}
+private:
+	bool bEndStg_;
+	bool bPause_;
+	bool bReplay_; //リプレイ
+	int frame_;
+	int stageIndex_;
 
-		ref_count_ptr<MersenneTwister> GetMersenneTwister(){return rand_;}
-		void SetMersenneTwisterSeed(int seed){rand_->Initialize(seed);}
-		_int64 GetScore(){return score_;}
-		void SetScore(_int64 score){score_ = score;}
-		void AddScore(_int64 inc){score_ += inc;}
-		_int64 GetGraze(){return graze_;}
-		void SetGraze(_int64 graze){graze_ = graze;}
-		void AddGraze(_int64 inc){graze_ += inc;}
-		_int64 GetPoint(){return point_;}
-		void SetPoint(_int64 point){point_ = point;}
-		void AddPoint(_int64 inc){point_ += inc;}
+	ref_count_ptr<ScriptInformation> infoMainScript_;
+	ref_count_ptr<ScriptInformation> infoPlayerScript_;
+	ref_count_ptr<StgPlayerInformation> infoPlayerObject_;
+	ref_count_ptr<ReplayInformation::StageData> replayStageData_;
 
-		int GetResult(){return result_;}
-		void SetResult(int result){result_ = result;}
+	//STG設定
+	RECT rcStgFrame_;
+	int priMinStgFrame_;
+	int priMaxStgFrame_;
+	int priShotObject_;
+	int priItemObject_;
+	int priCameraFocusPermit_;
+	RECT rcShotAutoDeleteClip_;
 
-		int GetStageStartTime(){return timeStart_;}
-		void SetStageStartTime(int time){timeStart_ = time;}
+	//STG情報
+	ref_count_ptr<MersenneTwister> rand_;
+	_int64 score_;
+	_int64 graze_;
+	_int64 point_;
+	int result_;
+	int timeStart_;
 };
 
 /**********************************************************
 //StgStageStartData
 **********************************************************/
-class StgStageStartData
-{
-	private:
-		ref_count_ptr<StgStageInformation> infoStage_;
-		ref_count_ptr<ReplayInformation::StageData> replayStageData_;
-		ref_count_ptr<StgStageInformation> prevStageInfo_;
-		ref_count_ptr<StgPlayerInformation> prevPlayerInfo_;
+class StgStageStartData {
+public:
+	StgStageStartData() {}
+	virtual ~StgStageStartData() {}
 
-	public:
-		StgStageStartData(){}
-		virtual ~StgStageStartData(){}
+	ref_count_ptr<StgStageInformation> GetStageInformation() { return infoStage_; }
+	void SetStageInformation(ref_count_ptr<StgStageInformation> info) { infoStage_ = info; }
+	ref_count_ptr<ReplayInformation::StageData> GetStageReplayData() { return replayStageData_; }
+	void SetStageReplayData(ref_count_ptr<ReplayInformation::StageData> data) { replayStageData_ = data; }
+	ref_count_ptr<StgStageInformation> GetPrevStageInformation() { return prevStageInfo_; }
+	void SetPrevStageInformation(ref_count_ptr<StgStageInformation> info) { prevStageInfo_ = info; }
+	ref_count_ptr<StgPlayerInformation> GetPrevPlayerInformation() { return prevPlayerInfo_; }
+	void SetPrevPlayerInformation(ref_count_ptr<StgPlayerInformation> info) { prevPlayerInfo_ = info; }
 
-		ref_count_ptr<StgStageInformation> GetStageInformation(){return infoStage_;}
-		void SetStageInformation(ref_count_ptr<StgStageInformation> info){infoStage_ = info;}
-		ref_count_ptr<ReplayInformation::StageData> GetStageReplayData(){return replayStageData_;}
-		void SetStageReplayData(ref_count_ptr<ReplayInformation::StageData> data){replayStageData_ = data;}
-		ref_count_ptr<StgStageInformation> GetPrevStageInformation(){return prevStageInfo_;}
-		void SetPrevStageInformation(ref_count_ptr<StgStageInformation> info){prevStageInfo_ = info;}
-		ref_count_ptr<StgPlayerInformation> GetPrevPlayerInformation(){return prevPlayerInfo_;}
-		void SetPrevPlayerInformation(ref_count_ptr<StgPlayerInformation> info){prevPlayerInfo_ = info;}
-
+private:
+	ref_count_ptr<StgStageInformation> infoStage_;
+	ref_count_ptr<ReplayInformation::StageData> replayStageData_;
+	ref_count_ptr<StgStageInformation> prevStageInfo_;
+	ref_count_ptr<StgPlayerInformation> prevPlayerInfo_;
 };
 
 /**********************************************************
 //PseudoSlowInformation
 **********************************************************/
-class PseudoSlowInformation : public gstd::FpsControlObject
-{
-	public:
-		class SlowData;
-		enum
-		{
-			OWNER_PLAYER = 0,
-			OWNER_ENEMY,
-			TARGET_ALL,
-		};
+class PseudoSlowInformation : public gstd::FpsControlObject {
+public:
+	class SlowData;
+	enum {
+		OWNER_PLAYER = 0,
+		OWNER_ENEMY,
+		TARGET_ALL,
+	};
 
-	private:
-		int current_;
-		std::map<int, gstd::ref_count_ptr<SlowData> > mapDataPlayer_;
-		std::map<int, gstd::ref_count_ptr<SlowData> > mapDataEnemy_;
-		std::map<int, bool> mapValid_;
-		
-	public:
-		PseudoSlowInformation(){current_ = 0;}
-		virtual ~PseudoSlowInformation(){}
-		virtual int GetFps();
+public:
+	PseudoSlowInformation() { current_ = 0; }
+	virtual ~PseudoSlowInformation() {}
+	virtual int GetFps();
 
-		bool IsValidFrame(int target);
-		void Next();
+	bool IsValidFrame(int target);
+	void Next();
 
-		void AddSlow(int fps, int owner, int target);
-		void RemoveSlow(int owner, int target);
+	void AddSlow(int fps, int owner, int target);
+	void RemoveSlow(int owner, int target);
+
+private:
+	int current_;
+	std::map<int, gstd::ref_count_ptr<SlowData>> mapDataPlayer_;
+	std::map<int, gstd::ref_count_ptr<SlowData>> mapDataEnemy_;
+	std::map<int, bool> mapValid_;
 };
 
-class PseudoSlowInformation::SlowData
-{
-	private:
-		int fps_;
-	public:
-		SlowData(){fps_ = STANDARD_FPS;}
-		virtual ~SlowData(){}
-		int GetFps(){return fps_;}
-		void SetFps(int fps){fps_ = fps;}
+class PseudoSlowInformation::SlowData {
+public:
+	SlowData() { fps_ = STANDARD_FPS; }
+	virtual ~SlowData() {}
+	int GetFps() { return fps_; }
+	void SetFps(int fps) { fps_ = fps; }
+
+private:
+	int fps_;
 };
 
 #endif

--- a/source/TouhouDanmakufu/Common/StgStageScript.cpp
+++ b/source/TouhouDanmakufu/Common/StgStageScript.cpp
@@ -1,9 +1,8 @@
-#include"StgStageScript.hpp"
-#include"StgSystem.hpp"
-#include"StgPlayer.hpp"
-#include"StgShot.hpp"
-#include"StgItem.hpp"
-
+#include "StgStageScript.hpp"
+#include "StgItem.hpp"
+#include "StgPlayer.hpp"
+#include "StgShot.hpp"
+#include "StgSystem.hpp"
 
 /**********************************************************
 //StgStageScriptManager
@@ -18,7 +17,6 @@ StgStageScriptManager::StgStageScriptManager(StgStageController* stageController
 }
 StgStageScriptManager::~StgStageScriptManager()
 {
-
 }
 
 void StgStageScriptManager::SetError(std::wstring error)
@@ -35,28 +33,25 @@ bool StgStageScriptManager::IsError()
 ref_count_ptr<ManagedScript> StgStageScriptManager::Create(int type)
 {
 	ref_count_ptr<ManagedScript> res = NULL;
-	switch(type)
-	{
-		case StgStageScript::TYPE_STAGE:
-			res = new StgStageScript(stageController_);
-			break;
-		case StgStageScript::TYPE_SYSTEM:
-			res = new StgStageSystemScript(stageController_);
-			break;
-		case StgStageScript::TYPE_ITEM:
-			res = new StgStageItemScript(stageController_);
-			break;
-		case StgStageScript::TYPE_SHOT:
-			res = new StgStageShotScript(stageController_);
-			break;
-		case StgStageScript::TYPE_PLAYER:
-			res = new StgStagePlayerScript(stageController_);
-			break;
-
+	switch (type) {
+	case StgStageScript::TYPE_STAGE:
+		res = new StgStageScript(stageController_);
+		break;
+	case StgStageScript::TYPE_SYSTEM:
+		res = new StgStageSystemScript(stageController_);
+		break;
+	case StgStageScript::TYPE_ITEM:
+		res = new StgStageItemScript(stageController_);
+		break;
+	case StgStageScript::TYPE_SHOT:
+		res = new StgStageShotScript(stageController_);
+		break;
+	case StgStageScript::TYPE_PLAYER:
+		res = new StgStagePlayerScript(stageController_);
+		break;
 	}
 
-	if(res != NULL)
-	{
+	if (res != NULL) {
 		res->SetScriptManager(stageController_->GetScriptManagerP());
 	}
 
@@ -65,22 +60,17 @@ ref_count_ptr<ManagedScript> StgStageScriptManager::Create(int type)
 ref_count_ptr<ManagedScript> StgStageScriptManager::GetItemScript()
 {
 	ref_count_ptr<ManagedScript> res = NULL;
-	if(idItemScript_ != StgControlScriptManager::ID_INVALID)
-	{
+	if (idItemScript_ != StgControlScriptManager::ID_INVALID)
 		res = GetScript(idItemScript_);
-	}
 	return res;
 }
 ref_count_ptr<ManagedScript> StgStageScriptManager::GetShotScript()
 {
 	ref_count_ptr<ManagedScript> res = NULL;
-	if(idShotScript_ != StgControlScriptManager::ID_INVALID)
-	{
+	if (idShotScript_ != StgControlScriptManager::ID_INVALID)
 		res = GetScript(idShotScript_);
-	}
 	return res;
 }
-
 
 /**********************************************************
 //StgStageScriptObjectManager
@@ -94,22 +84,18 @@ StgStageScriptObjectManager::StgStageScriptObjectManager(StgStageController* sta
 }
 StgStageScriptObjectManager::~StgStageScriptObjectManager()
 {
-	if(idObjPleyer_ != DxScript::ID_INVALID)
-	{
+	if (idObjPleyer_ != DxScript::ID_INVALID) {
 		ref_count_ptr<StgPlayerObject>::unsync obj = ref_count_ptr<StgPlayerObject>::unsync::DownCast(GetObject(idObjPleyer_));
-		if(obj != NULL)
+		if (obj != NULL)
 			obj->Clear();
 	}
 }
 void StgStageScriptObjectManager::RenderObject()
 {
 /*
-	if(invalidPriMin_ < 0 && invalidPriMax_ < 0) 
-	{
+	if (invalidPriMin_ < 0 && invalidPriMax_ < 0) {
 		RenderObject(0, objRender_.size());
-	}
-	else
-	{
+	} else {
 		RenderObject(0, invalidPriMin_);
 		RenderObject(invalidPriMax_ + 1, objRender_.size());
 	}
@@ -118,13 +104,14 @@ void StgStageScriptObjectManager::RenderObject()
 
 void StgStageScriptObjectManager::RenderObject(int priMin, int priMax)
 {
-/*
+	/*
 	std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync >::iterator itr;
-	for(itr = listActiveObject_.begin() ; itr != listActiveObject_.end() ; itr++)
-	{
+	for (itr = listActiveObject_.begin(); itr != listActiveObject_.end(); itr++) {
 		gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj = (*itr);
-		if(obj == NULL || obj->IsDeleted())continue;
-		if(!obj->IsVisible())continue;
+		if (obj == NULL || obj->IsDeleted())
+			continue;
+		if (!obj->IsVisible())
+			continue;
 		AddRenderObject(obj);
 	}
 
@@ -136,7 +123,7 @@ void StgStageScriptObjectManager::RenderObject(int priMin, int priMax)
 	RECT rcStgFrame = stageInfo->GetStgFrameRect();
 	int stgWidth = rcStgFrame.right - rcStgFrame.left;
 	int stgHeight = rcStgFrame.bottom - rcStgFrame.top;
-	POINT stgCenter = {rcStgFrame.left + stgWidth / 2, rcStgFrame.top + stgHeight / 2};
+	POINT stgCenter = { rcStgFrame.left + stgWidth / 2, rcStgFrame.top + stgHeight / 2 };
 	int priMinStgFrame = stageInfo->GetStgFrameMinPriority();
 	int priMaxStgFrame = stageInfo->GetStgFrameMaxPriority();
 	int priShot = stageInfo->GetShotObjectPriority();
@@ -155,17 +142,16 @@ void StgStageScriptObjectManager::RenderObject(int priMin, int priMax)
 	//描画開始前リセット
 	camera2D->SetEnable(false);
 	camera2D->Reset();
-	graphics->ResetViewPort();	
+	graphics->ResetViewPort();
 
 	bool bClearZBufferFor2DCoordinate = false;
 	bool bRunMinStgFrame = false;
 	bool bRunMaxStgFrame = false;
-	for(int iPri = priMin ; iPri <= priMax ; iPri++)
-	{
-		if(iPri >= objRender_.size())break;
+	for (int iPri = priMin; iPri <= priMax; iPri++) {
+		if (iPri >= objRender_.size())
+			break;
 
-		if(iPri >= priMinStgFrame && !bRunMinStgFrame)
-		{
+		if (iPri >= priMinStgFrame && !bRunMinStgFrame) {
 			//STGフレーム開始
 			graphics->ClearRenderTarget(rcStgFrame);
 			camera2D->SetEnable(true);
@@ -180,28 +166,22 @@ void StgStageScriptObjectManager::RenderObject(int priMin, int priMax)
 			bRunMinStgFrame = true;
 			bClearZBufferFor2DCoordinate = false;
 		}
-		if(iPri == priShot)
-		{
+		if (iPri == priShot) {
 			//弾描画
 			stageController_->GetShotManager()->Render();
 		}
-		if(iPri == priItem)
-		{
+		if (iPri == priItem) {
 			//アイテム描画
 			stageController_->GetItemManager()->Render();
 		}
 
-		std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync >::iterator itr;
-		for(itr = objRender_[iPri].begin() ; itr != objRender_[iPri].end() ; itr++)
-		{
-			if(!bClearZBufferFor2DCoordinate)
-			{
+		std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>::iterator itr;
+		for (itr = objRender_[iPri].begin(); itr != objRender_[iPri].end(); itr++) {
+			if (!bClearZBufferFor2DCoordinate) {
 				DxScriptMeshObject* objMesh = dynamic_cast<DxScriptMeshObject*>((*itr).GetPointer());
-				if(objMesh != NULL)
-				{
+				if (objMesh != NULL) {
 					gstd::ref_count_ptr<DxMesh>& mesh = objMesh->GetMesh();
-					if(mesh != NULL && mesh->IsCoordinate2D())
-					{
+					if (mesh != NULL && mesh->IsCoordinate2D()) {
 						graphics->GetDevice()->Clear(0, NULL, D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0,0,0), 1.0,0);
 						bClearZBufferFor2DCoordinate = true;
 					}
@@ -211,13 +191,11 @@ void StgStageScriptObjectManager::RenderObject(int priMin, int priMax)
 		}
 		objRender_[iPri].clear();
 
-		if(iPri == priCamera)
-		{
+		if (iPri == priCamera) {
 			camera2D->SetFocus(stgCenter.x, stgCenter.y);
 			camera2D->SetRatio(1);
 		}
-		if(iPri >= priMaxStgFrame && !bRunMaxStgFrame)
-		{
+		if (iPri >= priMaxStgFrame && !bRunMaxStgFrame) {
 			//STGフレーム終了
 			camera2D->SetEnable(false);
 			camera2D->Reset();
@@ -239,321 +217,320 @@ int StgStageScriptObjectManager::CreatePlayerObject()
 	return idObjPleyer_;
 }
 
-
 /**********************************************************
 //StgStageScript
 **********************************************************/
-function const stgFunction[] =  
-{
+function const stgFunction[] = {
 	//STG共通関数：共通データ
-	{"SaveCommonDataAreaToReplayFile", StgStageScript::Func_SaveCommonDataAreaToReplayFile, 1},
-	{"LoadCommonDataAreaFromReplayFile", StgStageScript::Func_LoadCommonDataAreaFromReplayFile, 1},
+	{ "SaveCommonDataAreaToReplayFile", StgStageScript::Func_SaveCommonDataAreaToReplayFile, 1 },
+	{ "LoadCommonDataAreaFromReplayFile", StgStageScript::Func_LoadCommonDataAreaFromReplayFile, 1 },
 
 	//STG共通関数：システム関連
-	{"GetMainStgScriptPath", StgStageScript::Func_GetMainStgScriptPath, 0},
-	{"GetMainStgScriptDirectory", StgStageScript::Func_GetMainStgScriptDirectory, 0},
-	{"SetStgFrame", StgStageScript::Func_SetStgFrame, 6},
-	{"SetItemRenderPriorityI", StgStageScript::Func_SetItemRenderPriorityI, 1},
-	{"SetShotRenderPriorityI", StgStageScript::Func_SetShotRenderPriorityI, 1},
-	{"GetStgFrameRenderPriorityMinI", StgStageScript::Func_GetStgFrameRenderPriorityMinI, 0},
-	{"GetStgFrameRenderPriorityMaxI", StgStageScript::Func_GetStgFrameRenderPriorityMaxI, 0},
-	{"GetItemRenderPriorityI", StgStageScript::Func_GetItemRenderPriorityI, 0},
-	{"GetShotRenderPriorityI", StgStageScript::Func_GetShotRenderPriorityI, 0},
-	{"GetPlayerRenderPriorityI", StgStageScript::Func_GetPlayerRenderPriorityI, 0},
-	{"GetCameraFocusPermitPriorityI", StgStageScript::Func_GetCameraFocusPermitPriorityI, 0},
-	{"CloseStgScene", StgStageScript::Func_CloseStgScene, 0},
-	{"GetReplayFps", StgStageScript::Func_GetReplayFps, 0},
+	{ "GetMainStgScriptPath", StgStageScript::Func_GetMainStgScriptPath, 0 },
+	{ "GetMainStgScriptDirectory", StgStageScript::Func_GetMainStgScriptDirectory, 0 },
+	{ "SetStgFrame", StgStageScript::Func_SetStgFrame, 6 },
+	{ "SetItemRenderPriorityI", StgStageScript::Func_SetItemRenderPriorityI, 1 },
+	{ "SetShotRenderPriorityI", StgStageScript::Func_SetShotRenderPriorityI, 1 },
+	{ "GetStgFrameRenderPriorityMinI", StgStageScript::Func_GetStgFrameRenderPriorityMinI, 0 },
+	{ "GetStgFrameRenderPriorityMaxI", StgStageScript::Func_GetStgFrameRenderPriorityMaxI, 0 },
+	{ "GetItemRenderPriorityI", StgStageScript::Func_GetItemRenderPriorityI, 0 },
+	{ "GetShotRenderPriorityI", StgStageScript::Func_GetShotRenderPriorityI, 0 },
+	{ "GetPlayerRenderPriorityI", StgStageScript::Func_GetPlayerRenderPriorityI, 0 },
+	{ "GetCameraFocusPermitPriorityI", StgStageScript::Func_GetCameraFocusPermitPriorityI, 0 },
+	{ "CloseStgScene", StgStageScript::Func_CloseStgScene, 0 },
+	{ "GetReplayFps", StgStageScript::Func_GetReplayFps, 0 },
 
 	//STG共通関数：自機
-	{"GetPlayerObjectID", StgStageScript::Func_GetPlayerObjectID, 0},
-	{"SetPlayerSpeed", StgStageScript::Func_SetPlayerSpeed, 2},
-	{"SetPlayerClip", StgStageScript::Func_SetPlayerClip, 4},
-	{"SetPlayerLife", StgStageScript::Func_SetPlayerLife, 1},
-	{"SetPlayerSpell", StgStageScript::Func_SetPlayerSpell, 1},
-	{"SetPlayerPower", StgStageScript::Func_SetPlayerPower, 1},
-	{"SetPlayerInvincibilityFrame", StgStageScript::Func_SetPlayerInvincibilityFrame, 1},
-	{"SetPlayerDownStateFrame", StgStageScript::Func_SetPlayerDownStateFrame, 1},
-	{"SetPlayerRebirthFrame", StgStageScript::Func_SetPlayerRebirthFrame, 1},
-	{"SetPlayerRebirthLossFrame", StgStageScript::Func_SetPlayerRebirthLossFrame, 1},
-	{"SetPlayerAutoItemCollectLine", StgStageScript::Func_SetPlayerAutoItemCollectLine, 1},
-	{"SetForbidPlayerShot", StgStageScript::Func_SetForbidPlayerShot, 1},
-	{"SetForbidPlayerSpell", StgStageScript::Func_SetForbidPlayerSpell, 1},
-	{"GetPlayerX", StgStageScript::Func_GetPlayerX, 0},
-	{"GetPlayerY", StgStageScript::Func_GetPlayerY, 0},
-	{"GetPlayerState", StgStageScript::Func_GetPlayerState, 0},
-	{"GetPlayerSpeed", StgStageScript::Func_GetPlayerSpeed, 0},
-	{"GetPlayerClip", StgStageScript::Func_GetPlayerClip, 0},
-	{"GetPlayerLife", StgStageScript::Func_GetPlayerLife, 0},
-	{"GetPlayerSpell", StgStageScript::Func_GetPlayerSpell, 0},
-	{"GetPlayerPower", StgStageScript::Func_GetPlayerPower, 0},
-	{"GetPlayerInvincibilityFrame", StgStageScript::Func_GetPlayerInvincibilityFrame, 0},
-	{"GetPlayerDownStateFrame", StgStageScript::Func_GetPlayerDownStateFrame, 0},
-	{"GetPlayerRebirthFrame", StgStageScript::Func_GetPlayerRebirthFrame, 0},
-	{"GetAngleToPlayer", StgStageScript::Func_GetAngleToPlayer, 1},
-	{"IsPermitPlayerShot", StgStageScript::Func_IsPermitPlayerShot, 0},
-	{"IsPermitPlayerSpell", StgStageScript::Func_IsPermitPlayerSpell, 0},
-	{"IsPlayerLastSpellWait", StgStageScript::Func_IsPlayerLastSpellWait, 0},
-	{"IsPlayerSpellActive", StgStageScript::Func_IsPlayerSpellActive, 0},
-	{"GetPlayerScriptID", StgStageScript::Func_GetPlayerScriptID, 0},
+	{ "GetPlayerObjectID", StgStageScript::Func_GetPlayerObjectID, 0 },
+	{ "SetPlayerSpeed", StgStageScript::Func_SetPlayerSpeed, 2 },
+	{ "SetPlayerClip", StgStageScript::Func_SetPlayerClip, 4 },
+	{ "SetPlayerLife", StgStageScript::Func_SetPlayerLife, 1 },
+	{ "SetPlayerSpell", StgStageScript::Func_SetPlayerSpell, 1 },
+	{ "SetPlayerPower", StgStageScript::Func_SetPlayerPower, 1 },
+	{ "SetPlayerInvincibilityFrame", StgStageScript::Func_SetPlayerInvincibilityFrame, 1 },
+	{ "SetPlayerDownStateFrame", StgStageScript::Func_SetPlayerDownStateFrame, 1 },
+	{ "SetPlayerRebirthFrame", StgStageScript::Func_SetPlayerRebirthFrame, 1 },
+	{ "SetPlayerRebirthLossFrame", StgStageScript::Func_SetPlayerRebirthLossFrame, 1 },
+	{ "SetPlayerAutoItemCollectLine", StgStageScript::Func_SetPlayerAutoItemCollectLine, 1 },
+	{ "SetForbidPlayerShot", StgStageScript::Func_SetForbidPlayerShot, 1 },
+	{ "SetForbidPlayerSpell", StgStageScript::Func_SetForbidPlayerSpell, 1 },
+	{ "GetPlayerX", StgStageScript::Func_GetPlayerX, 0 },
+	{ "GetPlayerY", StgStageScript::Func_GetPlayerY, 0 },
+	{ "GetPlayerState", StgStageScript::Func_GetPlayerState, 0 },
+	{ "GetPlayerSpeed", StgStageScript::Func_GetPlayerSpeed, 0 },
+	{ "GetPlayerClip", StgStageScript::Func_GetPlayerClip, 0 },
+	{ "GetPlayerLife", StgStageScript::Func_GetPlayerLife, 0 },
+	{ "GetPlayerSpell", StgStageScript::Func_GetPlayerSpell, 0 },
+	{ "GetPlayerPower", StgStageScript::Func_GetPlayerPower, 0 },
+	{ "GetPlayerInvincibilityFrame", StgStageScript::Func_GetPlayerInvincibilityFrame, 0 },
+	{ "GetPlayerDownStateFrame", StgStageScript::Func_GetPlayerDownStateFrame, 0 },
+	{ "GetPlayerRebirthFrame", StgStageScript::Func_GetPlayerRebirthFrame, 0 },
+	{ "GetAngleToPlayer", StgStageScript::Func_GetAngleToPlayer, 1 },
+	{ "IsPermitPlayerShot", StgStageScript::Func_IsPermitPlayerShot, 0 },
+	{ "IsPermitPlayerSpell", StgStageScript::Func_IsPermitPlayerSpell, 0 },
+	{ "IsPlayerLastSpellWait", StgStageScript::Func_IsPlayerLastSpellWait, 0 },
+	{ "IsPlayerSpellActive", StgStageScript::Func_IsPlayerSpellActive, 0 },
+	{ "GetPlayerScriptID", StgStageScript::Func_GetPlayerScriptID, 0 },
 
 	//STG共通関数：敵
-	{"GetEnemyBossSceneObjectID", StgStageScript::Func_GetEnemyBossSceneObjectID, 0},
-	{"GetEnemyBossObjectID", StgStageScript::Func_GetEnemyBossObjectID, 0},
-	{"GetAllEnemyID", StgStageScript::Func_GetAllEnemyID, 0},
-	{"GetIntersectionRegistedEnemyID", StgStageScript::Func_GetIntersectionRegistedEnemyID, 0},
-	{"GetAllEnemyIntersectionPosition", StgStageScript::Func_GetAllEnemyIntersectionPosition, 0},
-	{"GetEnemyIntersectionPosition", StgStageScript::Func_GetEnemyIntersectionPosition, 3},
-	{"GetEnemyIntersectionPositionByIdA1", StgStageScript::Func_GetEnemyIntersectionPositionByIdA1, 1},
-	{"GetEnemyIntersectionPositionByIdA2", StgStageScript::Func_GetEnemyIntersectionPositionByIdA2, 3},
-	{"LoadEnemyShotData", StgStageScript::Func_LoadEnemyShotData, 1},
-	{"ReloadEnemyShotData", StgStageScript::Func_ReloadEnemyShotData, 1},
+	{ "GetEnemyBossSceneObjectID", StgStageScript::Func_GetEnemyBossSceneObjectID, 0 },
+	{ "GetEnemyBossObjectID", StgStageScript::Func_GetEnemyBossObjectID, 0 },
+	{ "GetAllEnemyID", StgStageScript::Func_GetAllEnemyID, 0 },
+	{ "GetIntersectionRegistedEnemyID", StgStageScript::Func_GetIntersectionRegistedEnemyID, 0 },
+	{ "GetAllEnemyIntersectionPosition", StgStageScript::Func_GetAllEnemyIntersectionPosition, 0 },
+	{ "GetEnemyIntersectionPosition", StgStageScript::Func_GetEnemyIntersectionPosition, 3 },
+	{ "GetEnemyIntersectionPositionByIdA1", StgStageScript::Func_GetEnemyIntersectionPositionByIdA1, 1 },
+	{ "GetEnemyIntersectionPositionByIdA2", StgStageScript::Func_GetEnemyIntersectionPositionByIdA2, 3 },
+	{ "LoadEnemyShotData", StgStageScript::Func_LoadEnemyShotData, 1 },
+	{ "ReloadEnemyShotData", StgStageScript::Func_ReloadEnemyShotData, 1 },
 
 	//STG共通関数：弾
-	{"DeleteShotAll", StgStageScript::Func_DeleteShotAll, 2},
-	{"DeleteShotInCircle", StgStageScript::Func_DeleteShotInCircle, 5},
-	{"CreateShotA1", StgStageScript::Func_CreateShotA1, 6},
-	{"CreateShotA2", StgStageScript::Func_CreateShotA2, 8},
-	{"CreateShotOA1", StgStageScript::Func_CreateShotOA1, 5},
-	{"CreateShotB1", StgStageScript::Func_CreateShotB1, 6},
-	{"CreateShotB2", StgStageScript::Func_CreateShotB2, 10},
-	{"CreateShotOB1", StgStageScript::Func_CreateShotOB1, 5},
-	{"CreateLooseLaserA1", StgStageScript::Func_CreateLooseLaserA1, 8},
-	{"CreateStraightLaserA1", StgStageScript::Func_CreateStraightLaserA1, 8},
-	{"CreateCurveLaserA1", StgStageScript::Func_CreateCurveLaserA1, 8},
-	//{"StgStraightLaserA1", StgStageScript::Func_CreateStraightLaserA1, 8},
-	{"SetShotIntersectionCircle", StgStageScript::Func_SetShotIntersectionCircle, 3},
-	{"SetShotIntersectionLine", StgStageScript::Func_SetShotIntersectionLine, 5},
-	{"GetShotIdInCircleA1", StgStageScript::Func_GetShotIdInCircleA1, 3},
-	{"GetShotIdInCircleA2", StgStageScript::Func_GetShotIdInCircleA2, 4},
-	{"GetShotCount", StgStageScript::Func_GetShotCount, 1},
-	{"SetShotAutoDeleteClip", StgStageScript::Func_SetShotAutoDeleteClip, 4},
-	{"GetShotDataInfoA1", StgStageScript::Func_GetShotDataInfoA1, 3},
-	{"StartShotScript", StgStageScript::Func_StartShotScript, 1},
+	{ "DeleteShotAll", StgStageScript::Func_DeleteShotAll, 2 },
+	{ "DeleteShotInCircle", StgStageScript::Func_DeleteShotInCircle, 5 },
+	{ "CreateShotA1", StgStageScript::Func_CreateShotA1, 6 },
+	{ "CreateShotA2", StgStageScript::Func_CreateShotA2, 8 },
+	{ "CreateShotOA1", StgStageScript::Func_CreateShotOA1, 5 },
+	{ "CreateShotB1", StgStageScript::Func_CreateShotB1, 6 },
+	{ "CreateShotB2", StgStageScript::Func_CreateShotB2, 10 },
+	{ "CreateShotOB1", StgStageScript::Func_CreateShotOB1, 5 },
+	{ "CreateLooseLaserA1", StgStageScript::Func_CreateLooseLaserA1, 8 },
+	{ "CreateStraightLaserA1", StgStageScript::Func_CreateStraightLaserA1, 8 },
+	{ "CreateCurveLaserA1", StgStageScript::Func_CreateCurveLaserA1, 8 },
+	// { "StgStraightLaserA1", StgStageScript::Func_CreateStraightLaserA1, 8 },
+	{ "SetShotIntersectionCircle", StgStageScript::Func_SetShotIntersectionCircle, 3 },
+	{ "SetShotIntersectionLine", StgStageScript::Func_SetShotIntersectionLine, 5 },
+	{ "GetShotIdInCircleA1", StgStageScript::Func_GetShotIdInCircleA1, 3 },
+	{ "GetShotIdInCircleA2", StgStageScript::Func_GetShotIdInCircleA2, 4 },
+	{ "GetShotCount", StgStageScript::Func_GetShotCount, 1 },
+	{ "SetShotAutoDeleteClip", StgStageScript::Func_SetShotAutoDeleteClip, 4 },
+	{ "GetShotDataInfoA1", StgStageScript::Func_GetShotDataInfoA1, 3 },
+	{ "StartShotScript", StgStageScript::Func_StartShotScript, 1 },
 
 	//STG共通関数：アイテム
-	{"CreateItemA1", StgStageScript::Func_CreateItemA1, 4},
-	{"CreateItemA2", StgStageScript::Func_CreateItemA2, 6},
-	{"CreateItemU1", StgStageScript::Func_CreateItemU1, 4},
-	{"CreateItemU2", StgStageScript::Func_CreateItemU2, 6},
-	{"CreateItemScore", StgStageScript::Func_CreateItemScore, 3},
-	{"CollectAllItems", StgStageScript::Func_CollectAllItems, 0},
-	{"CollectItemsByType", StgStageScript::Func_CollectItemsByType, 1},
-	{"CollectItemsInCircle", StgStageScript::Func_CollectItemsInCircle, 3},
-	{"CancelCollectItems", StgStageScript::Func_CancelCollectItems, 0},
-	{"StartItemScript", StgStageScript::Func_StartItemScript, 1},
-	{"SetDefaultBonusItemEnable", StgStageScript::Func_SetDefaultBonusItemEnable, 1},
-	{"LoadItemData", StgStageScript::Func_LoadItemData, 1},
-	{"ReloadItemData", StgStageScript::Func_ReloadItemData, 1},
+	{ "CreateItemA1", StgStageScript::Func_CreateItemA1, 4 },
+	{ "CreateItemA2", StgStageScript::Func_CreateItemA2, 6 },
+	{ "CreateItemU1", StgStageScript::Func_CreateItemU1, 4 },
+	{ "CreateItemU2", StgStageScript::Func_CreateItemU2, 6 },
+	{ "CreateItemScore", StgStageScript::Func_CreateItemScore, 3 },
+	{ "CollectAllItems", StgStageScript::Func_CollectAllItems, 0 },
+	{ "CollectItemsByType", StgStageScript::Func_CollectItemsByType, 1 },
+	{ "CollectItemsInCircle", StgStageScript::Func_CollectItemsInCircle, 3 },
+	{ "CancelCollectItems", StgStageScript::Func_CancelCollectItems, 0 },
+	{ "StartItemScript", StgStageScript::Func_StartItemScript, 1 },
+	{ "SetDefaultBonusItemEnable", StgStageScript::Func_SetDefaultBonusItemEnable, 1 },
+	{ "LoadItemData", StgStageScript::Func_LoadItemData, 1 },
+	{ "ReloadItemData", StgStageScript::Func_ReloadItemData, 1 },
 
 	//STG共通関数：その他
-	{"StartSlow", StgStageScript::Func_StartSlow, 2},
-	{"StopSlow", StgStageScript::Func_StopSlow, 1},
-	{"IsIntersected_Line_Circle", StgStageScript::Func_IsIntersected_Line_Circle, 8},
-	{"IsIntersected_Obj_Obj", StgStageScript::Func_IsIntersected_Obj_Obj, 2},
+	{ "StartSlow", StgStageScript::Func_StartSlow, 2 },
+	{ "StopSlow", StgStageScript::Func_StopSlow, 1 },
+	{ "IsIntersected_Line_Circle", StgStageScript::Func_IsIntersected_Line_Circle, 8 },
+	{ "IsIntersected_Obj_Obj", StgStageScript::Func_IsIntersected_Obj_Obj, 2 },
 
 	//STG共通関数：移動オブジェクト操作
-	{"ObjMove_SetX", StgStageScript::Func_ObjMove_SetX, 2},
-	{"ObjMove_SetY", StgStageScript::Func_ObjMove_SetY, 2},
-	{"ObjMove_SetPosition", StgStageScript::Func_ObjMove_SetPosition, 3},
-	{"ObjMove_SetSpeed", StgStageScript::Func_ObjMove_SetSpeed, 2},
-	{"ObjMove_SetAngle", StgStageScript::Func_ObjMove_SetAngle, 2},
-	{"ObjMove_SetAcceleration", StgStageScript::Func_ObjMove_SetAcceleration, 2},
-	{"ObjMove_SetMaxSpeed", StgStageScript::Func_ObjMove_SetMaxSpeed, 2},
-	{"ObjMove_SetAngularVelocity", StgStageScript::Func_ObjMove_SetAngularVelocity, 2},
-	{"ObjMove_SetDestAtSpeed", StgStageScript::Func_ObjMove_SetDestAtSpeed, 4},
-	{"ObjMove_SetDestAtFrame", StgStageScript::Func_ObjMove_SetDestAtFrame, 4},
-	{"ObjMove_SetDestAtWeight", StgStageScript::Func_ObjMove_SetDestAtWeight, 5},
-	{"ObjMove_AddPatternA1", StgStageScript::Func_ObjMove_AddPatternA1, 4},
-	{"ObjMove_AddPatternA2", StgStageScript::Func_ObjMove_AddPatternA2, 7},
-	{"ObjMove_AddPatternA3", StgStageScript::Func_ObjMove_AddPatternA3, 8},
-	{"ObjMove_AddPatternA4", StgStageScript::Func_ObjMove_AddPatternA4, 9},
-	{"ObjMove_AddPatternB1", StgStageScript::Func_ObjMove_AddPatternB1, 4},
-	{"ObjMove_AddPatternB2", StgStageScript::Func_ObjMove_AddPatternB2, 8},
-	{"ObjMove_AddPatternB3", StgStageScript::Func_ObjMove_AddPatternB3, 9},
-	{"ObjMove_GetX", StgStageScript::Func_ObjMove_GetX, 1},
-	{"ObjMove_GetY", StgStageScript::Func_ObjMove_GetY, 1},
-	{"ObjMove_GetSpeed", StgStageScript::Func_ObjMove_GetSpeed, 1},
-	{"ObjMove_GetAngle", StgStageScript::Func_ObjMove_GetAngle, 1},
+	{ "ObjMove_SetX", StgStageScript::Func_ObjMove_SetX, 2 },
+	{ "ObjMove_SetY", StgStageScript::Func_ObjMove_SetY, 2 },
+	{ "ObjMove_SetPosition", StgStageScript::Func_ObjMove_SetPosition, 3 },
+	{ "ObjMove_SetSpeed", StgStageScript::Func_ObjMove_SetSpeed, 2 },
+	{ "ObjMove_SetAngle", StgStageScript::Func_ObjMove_SetAngle, 2 },
+	{ "ObjMove_SetAcceleration", StgStageScript::Func_ObjMove_SetAcceleration, 2 },
+	{ "ObjMove_SetMaxSpeed", StgStageScript::Func_ObjMove_SetMaxSpeed, 2 },
+	{ "ObjMove_SetAngularVelocity", StgStageScript::Func_ObjMove_SetAngularVelocity, 2 },
+	{ "ObjMove_SetDestAtSpeed", StgStageScript::Func_ObjMove_SetDestAtSpeed, 4 },
+	{ "ObjMove_SetDestAtFrame", StgStageScript::Func_ObjMove_SetDestAtFrame, 4 },
+	{ "ObjMove_SetDestAtWeight", StgStageScript::Func_ObjMove_SetDestAtWeight, 5 },
+	{ "ObjMove_AddPatternA1", StgStageScript::Func_ObjMove_AddPatternA1, 4 },
+	{ "ObjMove_AddPatternA2", StgStageScript::Func_ObjMove_AddPatternA2, 7 },
+	{ "ObjMove_AddPatternA3", StgStageScript::Func_ObjMove_AddPatternA3, 8 },
+	{ "ObjMove_AddPatternA4", StgStageScript::Func_ObjMove_AddPatternA4, 9 },
+	{ "ObjMove_AddPatternB1", StgStageScript::Func_ObjMove_AddPatternB1, 4 },
+	{ "ObjMove_AddPatternB2", StgStageScript::Func_ObjMove_AddPatternB2, 8 },
+	{ "ObjMove_AddPatternB3", StgStageScript::Func_ObjMove_AddPatternB3, 9 },
+	{ "ObjMove_GetX", StgStageScript::Func_ObjMove_GetX, 1 },
+	{ "ObjMove_GetY", StgStageScript::Func_ObjMove_GetY, 1 },
+	{ "ObjMove_GetSpeed", StgStageScript::Func_ObjMove_GetSpeed, 1 },
+	{ "ObjMove_GetAngle", StgStageScript::Func_ObjMove_GetAngle, 1 },
 
 	//STG共通関数：敵オブジェクト操作
-	{"ObjEnemy_Create", StgStageScript::Func_ObjEnemy_Create, 1},
-	{"ObjEnemy_Regist", StgStageScript::Func_ObjEnemy_Regist, 1},
-	{"ObjEnemy_GetInfo", StgStageScript::Func_ObjEnemy_GetInfo, 2},
-	{"ObjEnemy_SetLife", StgStageScript::Func_ObjEnemy_SetLife, 2},
-	{"ObjEnemy_AddLife", StgStageScript::Func_ObjEnemy_AddLife, 2},
-	{"ObjEnemy_SetDamageRate", StgStageScript::Func_ObjEnemy_SetDamageRate, 3},
-	{"ObjEnemy_AddIntersectionCircleA", StgStageScript::Func_ObjEnemy_AddIntersectionCircleA, 4},
-	{"ObjEnemy_SetIntersectionCircleToShot", StgStageScript::Func_ObjEnemy_SetIntersectionCircleToShot, 4},
-	{"ObjEnemy_SetIntersectionCircleToPlayer", StgStageScript::Func_ObjEnemy_SetIntersectionCircleToPlayer, 4},
+	{ "ObjEnemy_Create", StgStageScript::Func_ObjEnemy_Create, 1 },
+	{ "ObjEnemy_Regist", StgStageScript::Func_ObjEnemy_Regist, 1 },
+	{ "ObjEnemy_GetInfo", StgStageScript::Func_ObjEnemy_GetInfo, 2 },
+	{ "ObjEnemy_SetLife", StgStageScript::Func_ObjEnemy_SetLife, 2 },
+	{ "ObjEnemy_AddLife", StgStageScript::Func_ObjEnemy_AddLife, 2 },
+	{ "ObjEnemy_SetDamageRate", StgStageScript::Func_ObjEnemy_SetDamageRate, 3 },
+	{ "ObjEnemy_AddIntersectionCircleA", StgStageScript::Func_ObjEnemy_AddIntersectionCircleA, 4 },
+	{ "ObjEnemy_SetIntersectionCircleToShot", StgStageScript::Func_ObjEnemy_SetIntersectionCircleToShot, 4 },
+	{ "ObjEnemy_SetIntersectionCircleToPlayer", StgStageScript::Func_ObjEnemy_SetIntersectionCircleToPlayer, 4 },
 
 	//STG共通関数：敵ボスシーンオブジェクト操作
-	{"ObjEnemyBossScene_Create", StgStageScript::Func_ObjEnemyBossScene_Create, 0},
-	{"ObjEnemyBossScene_Regist", StgStageScript::Func_ObjEnemyBossScene_Regist, 1},
-	{"ObjEnemyBossScene_Add", StgStageScript::Func_ObjEnemyBossScene_Add, 3},
-	{"ObjEnemyBossScene_LoadInThread", StgStageScript::Func_ObjEnemyBossScene_LoadInThread, 1},
-	{"ObjEnemyBossScene_GetInfo", StgStageScript::Func_ObjEnemyBossScene_GetInfo, 2},
-	{"ObjEnemyBossScene_SetSpellTimer", StgStageScript::Func_ObjEnemyBossScene_SetSpellTimer, 2},
-	{"ObjEnemyBossScene_StartSpell", StgStageScript::Func_ObjEnemyBossScene_StartSpell, 1},
+	{ "ObjEnemyBossScene_Create", StgStageScript::Func_ObjEnemyBossScene_Create, 0 },
+	{ "ObjEnemyBossScene_Regist", StgStageScript::Func_ObjEnemyBossScene_Regist, 1 },
+	{ "ObjEnemyBossScene_Add", StgStageScript::Func_ObjEnemyBossScene_Add, 3 },
+	{ "ObjEnemyBossScene_LoadInThread", StgStageScript::Func_ObjEnemyBossScene_LoadInThread, 1 },
+	{ "ObjEnemyBossScene_GetInfo", StgStageScript::Func_ObjEnemyBossScene_GetInfo, 2 },
+	{ "ObjEnemyBossScene_SetSpellTimer", StgStageScript::Func_ObjEnemyBossScene_SetSpellTimer, 2 },
+	{ "ObjEnemyBossScene_StartSpell", StgStageScript::Func_ObjEnemyBossScene_StartSpell, 1 },
 
 	//STG共通関数：弾オブジェクト操作
-	{"ObjShot_Create", StgStageScript::Func_ObjShot_Create, 1},
-	{"ObjShot_Regist", StgStageScript::Func_ObjShot_Regist, 1},
-	{"ObjShot_SetAutoDelete", StgStageScript::Func_ObjShot_SetAutoDelete, 2},
-	{"ObjShot_FadeDelete", StgStageScript::Func_ObjShot_FadeDelete, 1},
-	{"ObjShot_SetDeleteFrame", StgStageScript::Func_ObjShot_SetDeleteFrame, 2},
-	{"ObjShot_SetDelay", StgStageScript::Func_ObjShot_SetDelay, 2},
-	{"ObjShot_SetSpellResist", StgStageScript::Func_ObjShot_SetSpellResist, 2},
-	{"ObjShot_SetGraphic", StgStageScript::Func_ObjShot_SetGraphic, 2},
-	{"ObjShot_SetSourceBlendType", StgStageScript::Func_ObjShot_SetSourceBlendType, 2},
-	{"ObjShot_SetDamage", StgStageScript::Func_ObjShot_SetDamage, 2},
-	{"ObjShot_SetPenetration", StgStageScript::Func_ObjShot_SetPenetration, 2},
-	{"ObjShot_SetEraseShot", StgStageScript::Func_ObjShot_SetEraseShot, 2},
-	{"ObjShot_SetSpellFactor", StgStageScript::Func_ObjShot_SetSpellFactor, 2},
-	{"ObjShot_ToItem", StgStageScript::Func_ObjShot_ToItem, 1},
-	{"ObjShot_AddShotA1", StgStageScript::Func_ObjShot_AddShotA1, 3},
-	{"ObjShot_AddShotA2", StgStageScript::Func_ObjShot_AddShotA2, 5},
-	{"ObjShot_SetIntersectionCircleA1", StgStageScript::Func_ObjShot_SetIntersectionCircleA1, 2},
-	{"ObjShot_SetIntersectionCircleA2", StgStageScript::Func_ObjShot_SetIntersectionCircleA2, 4},
-	{"ObjShot_SetIntersectionLine", StgStageScript::Func_ObjShot_SetIntersectionLine, 6},
-	{"ObjShot_SetIntersectionEnable", StgStageScript::Func_ObjShot_SetIntersectionEnable, 2},
-	{"ObjShot_SetItemChange", StgStageScript::Func_ObjShot_SetItemChange, 2},
-	{"ObjShot_GetDelay", StgStageScript::Func_ObjShot_GetDelay, 1},
-	{"ObjShot_GetDamage", StgStageScript::Func_ObjShot_GetDamage, 1},
-	{"ObjShot_GetPenetration", StgStageScript::Func_ObjShot_GetPenetration, 1},
-	{"ObjShot_IsSpellResist", StgStageScript::Func_ObjShot_IsSpellResist, 1},
-	{"ObjShot_GetImageID", StgStageScript::Func_ObjShot_GetImageID, 1},
+	{ "ObjShot_Create", StgStageScript::Func_ObjShot_Create, 1 },
+	{ "ObjShot_Regist", StgStageScript::Func_ObjShot_Regist, 1 },
+	{ "ObjShot_SetAutoDelete", StgStageScript::Func_ObjShot_SetAutoDelete, 2 },
+	{ "ObjShot_FadeDelete", StgStageScript::Func_ObjShot_FadeDelete, 1 },
+	{ "ObjShot_SetDeleteFrame", StgStageScript::Func_ObjShot_SetDeleteFrame, 2 },
+	{ "ObjShot_SetDelay", StgStageScript::Func_ObjShot_SetDelay, 2 },
+	{ "ObjShot_SetSpellResist", StgStageScript::Func_ObjShot_SetSpellResist, 2 },
+	{ "ObjShot_SetGraphic", StgStageScript::Func_ObjShot_SetGraphic, 2 },
+	{ "ObjShot_SetSourceBlendType", StgStageScript::Func_ObjShot_SetSourceBlendType, 2 },
+	{ "ObjShot_SetDamage", StgStageScript::Func_ObjShot_SetDamage, 2 },
+	{ "ObjShot_SetPenetration", StgStageScript::Func_ObjShot_SetPenetration, 2 },
+	{ "ObjShot_SetEraseShot", StgStageScript::Func_ObjShot_SetEraseShot, 2 },
+	{ "ObjShot_SetSpellFactor", StgStageScript::Func_ObjShot_SetSpellFactor, 2 },
+	{ "ObjShot_ToItem", StgStageScript::Func_ObjShot_ToItem, 1 },
+	{ "ObjShot_AddShotA1", StgStageScript::Func_ObjShot_AddShotA1, 3 },
+	{ "ObjShot_AddShotA2", StgStageScript::Func_ObjShot_AddShotA2, 5 },
+	{ "ObjShot_SetIntersectionCircleA1", StgStageScript::Func_ObjShot_SetIntersectionCircleA1, 2 },
+	{ "ObjShot_SetIntersectionCircleA2", StgStageScript::Func_ObjShot_SetIntersectionCircleA2, 4 },
+	{ "ObjShot_SetIntersectionLine", StgStageScript::Func_ObjShot_SetIntersectionLine, 6 },
+	{ "ObjShot_SetIntersectionEnable", StgStageScript::Func_ObjShot_SetIntersectionEnable, 2 },
+	{ "ObjShot_SetItemChange", StgStageScript::Func_ObjShot_SetItemChange, 2 },
+	{ "ObjShot_GetDelay", StgStageScript::Func_ObjShot_GetDelay, 1 },
+	{ "ObjShot_GetDamage", StgStageScript::Func_ObjShot_GetDamage, 1 },
+	{ "ObjShot_GetPenetration", StgStageScript::Func_ObjShot_GetPenetration, 1 },
+	{ "ObjShot_IsSpellResist", StgStageScript::Func_ObjShot_IsSpellResist, 1 },
+	{ "ObjShot_GetImageID", StgStageScript::Func_ObjShot_GetImageID, 1 },
 
-	{"ObjLaser_SetLength", StgStageScript::Func_ObjLaser_SetLength, 2},
-	{"ObjLaser_SetRenderWidth", StgStageScript::Func_ObjLaser_SetRenderWidth, 2},
-	{"ObjLaser_SetIntersectionWidth", StgStageScript::Func_ObjLaser_SetIntersectionWidth, 2},
-	{"ObjLaser_SetInvalidLength", StgStageScript::Func_ObjLaser_SetInvalidLength, 3},
-	{"ObjLaser_SetGrazeInvalidFrame", StgStageScript::Func_ObjLaser_SetGrazeInvalidFrame, 2},
-	{"ObjLaser_SetItemDistance", StgStageScript::Func_ObjLaser_SetItemDistance, 2},
-	{"ObjLaser_GetLength", StgStageScript::Func_ObjLaser_GetLength, 1},
-	{"ObjLaser_GetRenderWidth", StgStageScript::Func_ObjLaser_GetRenderWidth, 1},
-	{"ObjLaser_GetIntersectionWidth", StgStageScript::Func_ObjLaser_GetIntersectionWidth, 1},
-	{"ObjStLaser_SetAngle", StgStageScript::Func_ObjStLaser_SetAngle, 2},
-	{"ObjStLaser_GetAngle", StgStageScript::Func_ObjStLaser_GetAngle, 1},
-	{"ObjStLaser_SetSource", StgStageScript::Func_ObjStLaser_SetSource, 2},
-	{"ObjCrLaser_SetTipDecrement", StgStageScript::Func_ObjCrLaser_SetTipDecrement, 2},
+	{ "ObjLaser_SetLength", StgStageScript::Func_ObjLaser_SetLength, 2 },
+	{ "ObjLaser_SetRenderWidth", StgStageScript::Func_ObjLaser_SetRenderWidth, 2 },
+	{ "ObjLaser_SetIntersectionWidth", StgStageScript::Func_ObjLaser_SetIntersectionWidth, 2 },
+	{ "ObjLaser_SetInvalidLength", StgStageScript::Func_ObjLaser_SetInvalidLength, 3 },
+	{ "ObjLaser_SetGrazeInvalidFrame", StgStageScript::Func_ObjLaser_SetGrazeInvalidFrame, 2 },
+	{ "ObjLaser_SetItemDistance", StgStageScript::Func_ObjLaser_SetItemDistance, 2 },
+	{ "ObjLaser_GetLength", StgStageScript::Func_ObjLaser_GetLength, 1 },
+	{ "ObjLaser_GetRenderWidth", StgStageScript::Func_ObjLaser_GetRenderWidth, 1 },
+	{ "ObjLaser_GetIntersectionWidth", StgStageScript::Func_ObjLaser_GetIntersectionWidth, 1 },
+	{ "ObjStLaser_SetAngle", StgStageScript::Func_ObjStLaser_SetAngle, 2 },
+	{ "ObjStLaser_GetAngle", StgStageScript::Func_ObjStLaser_GetAngle, 1 },
+	{ "ObjStLaser_SetSource", StgStageScript::Func_ObjStLaser_SetSource, 2 },
+	{ "ObjCrLaser_SetTipDecrement", StgStageScript::Func_ObjCrLaser_SetTipDecrement, 2 },
 
 	//STG共通関数：アイテムオブジェクト操作
-	{"ObjItem_Create", StgStageScript::Func_ObjItem_Create, 1},
-	{"ObjItem_Regist", StgStageScript::Func_ObjItem_Regist, 1},
-	{"ObjItem_SetItemID", StgStageScript::Func_ObjItem_SetItemID, 2},
-	{"ObjItem_SetRenderScoreEnable", StgStageScript::Func_ObjItem_SetRenderScoreEnable, 2},
-	{"ObjItem_SetAutoCollectEnable", StgStageScript::Func_ObjItem_SetAutoCollectEnable, 2},
-	{"ObjItem_SetDefinedMovePatternA1", StgStageScript::Func_ObjItem_SetDefinedMovePatternA1, 2},
-	{"ObjItem_GetInfo", StgStageScript::Func_ObjItem_GetInfo, 2},
+	{ "ObjItem_Create", StgStageScript::Func_ObjItem_Create, 1 },
+	{ "ObjItem_Regist", StgStageScript::Func_ObjItem_Regist, 1 },
+	{ "ObjItem_SetItemID", StgStageScript::Func_ObjItem_SetItemID, 2 },
+	{ "ObjItem_SetRenderScoreEnable", StgStageScript::Func_ObjItem_SetRenderScoreEnable, 2 },
+	{ "ObjItem_SetAutoCollectEnable", StgStageScript::Func_ObjItem_SetAutoCollectEnable, 2 },
+	{ "ObjItem_SetDefinedMovePatternA1", StgStageScript::Func_ObjItem_SetDefinedMovePatternA1, 2 },
+	{ "ObjItem_GetInfo", StgStageScript::Func_ObjItem_GetInfo, 2 },
 
 	//STG共通関数：自機オブジェクト操作
-	{"ObjPlayer_AddIntersectionCircleA1", StgStageScript::Func_ObjPlayer_AddIntersectionCircleA1, 5},
-	{"ObjPlayer_AddIntersectionCircleA2", StgStageScript::Func_ObjPlayer_AddIntersectionCircleA2, 4},
-	{"ObjPlayer_ClearIntersection", StgStageScript::Func_ObjPlayer_ClearIntersection, 1},
+	{ "ObjPlayer_AddIntersectionCircleA1", StgStageScript::Func_ObjPlayer_AddIntersectionCircleA1, 5 },
+	{ "ObjPlayer_AddIntersectionCircleA2", StgStageScript::Func_ObjPlayer_AddIntersectionCircleA2, 4 },
+	{ "ObjPlayer_ClearIntersection", StgStageScript::Func_ObjPlayer_ClearIntersection, 1 },
 
 	//STG共通関数：当たり判定オブジェクト操作
-	{"ObjCol_IsIntersected", StgStageScript::Func_ObjCol_IsIntersected, 1},
-	{"ObjCol_GetListOfIntersectedEnemyID", StgStageScript::Func_ObjCol_GetListOfIntersectedEnemyID, 1},
-	{"ObjCol_GetIntersectedCount", StgStageScript::Func_ObjCol_GetIntersectedCount, 1},
+	{ "ObjCol_IsIntersected", StgStageScript::Func_ObjCol_IsIntersected, 1 },
+	{ "ObjCol_GetListOfIntersectedEnemyID", StgStageScript::Func_ObjCol_GetListOfIntersectedEnemyID, 1 },
+	{ "ObjCol_GetIntersectedCount", StgStageScript::Func_ObjCol_GetIntersectedCount, 1 },
 
 	//定数
-	{"SCREEN_WIDTH", constant<640>::func, 0},
-	{"SCREEN_HEIGHT", constant<480>::func, 0},
-	{"TYPE_ALL", constant<StgStageScript::TYPE_ALL>::func, 0},
-	{"TYPE_SHOT", constant<StgStageScript::TYPE_SHOT>::func, 0},
-	{"TYPE_CHILD", constant<StgStageScript::TYPE_CHILD>::func, 0},
-	{"TYPE_IMMEDIATE", constant<StgStageScript::TYPE_IMMEDIATE>::func, 0},
-	{"TYPE_FADE", constant<StgStageScript::TYPE_FADE>::func, 0},
-	{"TYPE_ITEM", constant<StgStageScript::TYPE_ITEM>::func, 0},
+	{ "SCREEN_WIDTH", constant<640>::func, 0 },
+	{ "SCREEN_HEIGHT", constant<480>::func, 0 },
+	{ "TYPE_ALL", constant<StgStageScript::TYPE_ALL>::func, 0 },
+	{ "TYPE_SHOT", constant<StgStageScript::TYPE_SHOT>::func, 0 },
+	{ "TYPE_CHILD", constant<StgStageScript::TYPE_CHILD>::func, 0 },
+	{ "TYPE_IMMEDIATE", constant<StgStageScript::TYPE_IMMEDIATE>::func, 0 },
+	{ "TYPE_FADE", constant<StgStageScript::TYPE_FADE>::func, 0 },
+	{ "TYPE_ITEM", constant<StgStageScript::TYPE_ITEM>::func, 0 },
 
-	{"STATE_NORMAL", constant<StgPlayerObject::STATE_NORMAL>::func, 0},
-	{"STATE_HIT", constant<StgPlayerObject::STATE_HIT>::func, 0},
-	{"STATE_DOWN", constant<StgPlayerObject::STATE_DOWN>::func, 0},
-	{"STATE_END", constant<StgPlayerObject::STATE_END>::func, 0},
+	{ "STATE_NORMAL", constant<StgPlayerObject::STATE_NORMAL>::func, 0 },
+	{ "STATE_HIT", constant<StgPlayerObject::STATE_HIT>::func, 0 },
+	{ "STATE_DOWN", constant<StgPlayerObject::STATE_DOWN>::func, 0 },
+	{ "STATE_END", constant<StgPlayerObject::STATE_END>::func, 0 },
 
-	{"ITEM_1UP", constant<StgItemObject::ITEM_1UP>::func, 0},
-	{"ITEM_1UP_S", constant<StgItemObject::ITEM_1UP_S>::func, 0},
-	{"ITEM_SPELL", constant<StgItemObject::ITEM_SPELL>::func, 0},
-	{"ITEM_SPELL_S", constant<StgItemObject::ITEM_SPELL_S>::func, 0},
-	{"ITEM_POWER", constant<StgItemObject::ITEM_POWER>::func, 0},
-	{"ITEM_POWER_S", constant<StgItemObject::ITEM_POWER_S>::func, 0},
-	{"ITEM_POINT", constant<StgItemObject::ITEM_POINT>::func, 0},
-	{"ITEM_POINT_S", constant<StgItemObject::ITEM_POINT_S>::func, 0},
-	{"ITEM_USER", constant<StgItemObject::ITEM_USER>::func, 0},
+	{ "ITEM_1UP", constant<StgItemObject::ITEM_1UP>::func, 0 },
+	{ "ITEM_1UP_S", constant<StgItemObject::ITEM_1UP_S>::func, 0 },
+	{ "ITEM_SPELL", constant<StgItemObject::ITEM_SPELL>::func, 0 },
+	{ "ITEM_SPELL_S", constant<StgItemObject::ITEM_SPELL_S>::func, 0 },
+	{ "ITEM_POWER", constant<StgItemObject::ITEM_POWER>::func, 0 },
+	{ "ITEM_POWER_S", constant<StgItemObject::ITEM_POWER_S>::func, 0 },
+	{ "ITEM_POINT", constant<StgItemObject::ITEM_POINT>::func, 0 },
+	{ "ITEM_POINT_S", constant<StgItemObject::ITEM_POINT_S>::func, 0 },
+	{ "ITEM_USER", constant<StgItemObject::ITEM_USER>::func, 0 },
 
-	{"ITEM_MOVE_DOWN", constant<StgMovePattern_Item::MOVE_DOWN>::func, 0},
-	{"ITEM_MOVE_TOPLAYER", constant<StgMovePattern_Item::MOVE_TOPLAYER>::func, 0},
+	{ "ITEM_MOVE_DOWN", constant<StgMovePattern_Item::MOVE_DOWN>::func, 0 },
+	{ "ITEM_MOVE_TOPLAYER", constant<StgMovePattern_Item::MOVE_TOPLAYER>::func, 0 },
 
-	{"OBJ_PLAYER", constant<StgStageScript::OBJ_PLAYER>::func, 0},
-	{"OBJ_SPELL_MANAGE", constant<StgStageScript::OBJ_SPELL_MANAGE>::func, 0},
-	{"OBJ_SPELL", constant<StgStageScript::OBJ_SPELL>::func, 0},
-	{"OBJ_ENEMY", constant<StgStageScript::OBJ_ENEMY>::func, 0},
-	{"OBJ_ENEMY_BOSS", constant<StgStageScript::OBJ_ENEMY_BOSS>::func, 0},
-	{"OBJ_ENEMY_BOSS_SCENE", constant<StgStageScript::OBJ_ENEMY_BOSS_SCENE>::func, 0},
-	{"OBJ_SHOT", constant<StgStageScript::OBJ_SHOT>::func, 0},
-	{"OBJ_LOOSE_LASER", constant<StgStageScript::OBJ_LOOSE_LASER>::func, 0},
-	{"OBJ_STRAIGHT_LASER", constant<StgStageScript::OBJ_STRAIGHT_LASER>::func, 0},
-	{"OBJ_CURVE_LASER", constant<StgStageScript::OBJ_CURVE_LASER>::func, 0},
-	{"OBJ_ITEM", constant<StgStageScript::OBJ_ITEM>::func, 0},
+	{ "OBJ_PLAYER", constant<StgStageScript::OBJ_PLAYER>::func, 0 },
+	{ "OBJ_SPELL_MANAGE", constant<StgStageScript::OBJ_SPELL_MANAGE>::func, 0 },
+	{ "OBJ_SPELL", constant<StgStageScript::OBJ_SPELL>::func, 0 },
+	{ "OBJ_ENEMY", constant<StgStageScript::OBJ_ENEMY>::func, 0 },
+	{ "OBJ_ENEMY_BOSS", constant<StgStageScript::OBJ_ENEMY_BOSS>::func, 0 },
+	{ "OBJ_ENEMY_BOSS_SCENE", constant<StgStageScript::OBJ_ENEMY_BOSS_SCENE>::func, 0 },
+	{ "OBJ_SHOT", constant<StgStageScript::OBJ_SHOT>::func, 0 },
+	{ "OBJ_LOOSE_LASER", constant<StgStageScript::OBJ_LOOSE_LASER>::func, 0 },
+	{ "OBJ_STRAIGHT_LASER", constant<StgStageScript::OBJ_STRAIGHT_LASER>::func, 0 },
+	{ "OBJ_CURVE_LASER", constant<StgStageScript::OBJ_CURVE_LASER>::func, 0 },
+	{ "OBJ_ITEM", constant<StgStageScript::OBJ_ITEM>::func, 0 },
 
-	{"INFO_LIFE", constant<StgStageScript::INFO_LIFE>::func, 0},
-	{"INFO_DAMAGE_RATE_SHOT", constant<StgStageScript::INFO_DAMAGE_RATE_SHOT>::func, 0},
-	{"INFO_DAMAGE_RATE_SPELL", constant<StgStageScript::INFO_DAMAGE_RATE_SPELL>::func, 0},
-	{"INFO_SHOT_HIT_COUNT", constant<StgStageScript::INFO_SHOT_HIT_COUNT>::func, 0},
-	{"INFO_TIMER", constant<StgStageScript::INFO_TIMER>::func, 0},
-	{"INFO_TIMERF", constant<StgStageScript::INFO_TIMERF>::func, 0},
-	{"INFO_ORGTIMERF", constant<StgStageScript::INFO_ORGTIMERF>::func, 0},
-	{"INFO_IS_SPELL", constant<StgStageScript::INFO_IS_SPELL>::func, 0},
-	{"INFO_IS_LAST_SPELL", constant<StgStageScript::INFO_IS_LAST_SPELL>::func, 0},
-	{"INFO_IS_DURABLE_SPELL", constant<StgStageScript::INFO_IS_DURABLE_SPELL>::func, 0},
-	{"INFO_SPELL_SCORE", constant<StgStageScript::INFO_SPELL_SCORE>::func, 0},
-	{"INFO_REMAIN_STEP_COUNT", constant<StgStageScript::INFO_REMAIN_STEP_COUNT>::func, 0},
-	{"INFO_ACTIVE_STEP_LIFE_COUNT", constant<StgStageScript::INFO_ACTIVE_STEP_LIFE_COUNT>::func, 0},
-	{"INFO_ACTIVE_STEP_TOTAL_MAX_LIFE", constant<StgStageScript::INFO_ACTIVE_STEP_TOTAL_MAX_LIFE>::func, 0},
-	{"INFO_ACTIVE_STEP_TOTAL_LIFE", constant<StgStageScript::INFO_ACTIVE_STEP_TOTAL_LIFE>::func, 0},
-	{"INFO_ACTIVE_STEP_LIFE_RATE_LIST", constant<StgStageScript::INFO_ACTIVE_STEP_LIFE_RATE_LIST>::func, 0},
-	{"INFO_IS_LAST_STEP", constant<StgStageScript::INFO_IS_LAST_STEP>::func, 0},
-	{"INFO_PLAYER_SHOOTDOWN_COUNT", constant<StgStageScript::INFO_PLAYER_SHOOTDOWN_COUNT>::func, 0},
-	{"INFO_PLAYER_SPELL_COUNT", constant<StgStageScript::INFO_PLAYER_SPELL_COUNT>::func, 0},
-	{"INFO_CURRENT_LIFE", constant<StgStageScript::INFO_CURRENT_LIFE>::func, 0},
-	{"INFO_CURRENT_LIFE_MAX", constant<StgStageScript::INFO_CURRENT_LIFE_MAX>::func, 0},
+	{ "INFO_LIFE", constant<StgStageScript::INFO_LIFE>::func, 0 },
+	{ "INFO_DAMAGE_RATE_SHOT", constant<StgStageScript::INFO_DAMAGE_RATE_SHOT>::func, 0 },
+	{ "INFO_DAMAGE_RATE_SPELL", constant<StgStageScript::INFO_DAMAGE_RATE_SPELL>::func, 0 },
+	{ "INFO_SHOT_HIT_COUNT", constant<StgStageScript::INFO_SHOT_HIT_COUNT>::func, 0 },
+	{ "INFO_TIMER", constant<StgStageScript::INFO_TIMER>::func, 0 },
+	{ "INFO_TIMERF", constant<StgStageScript::INFO_TIMERF>::func, 0 },
+	{ "INFO_ORGTIMERF", constant<StgStageScript::INFO_ORGTIMERF>::func, 0 },
+	{ "INFO_IS_SPELL", constant<StgStageScript::INFO_IS_SPELL>::func, 0 },
+	{ "INFO_IS_LAST_SPELL", constant<StgStageScript::INFO_IS_LAST_SPELL>::func, 0 },
+	{ "INFO_IS_DURABLE_SPELL", constant<StgStageScript::INFO_IS_DURABLE_SPELL>::func, 0 },
+	{ "INFO_SPELL_SCORE", constant<StgStageScript::INFO_SPELL_SCORE>::func, 0 },
+	{ "INFO_REMAIN_STEP_COUNT", constant<StgStageScript::INFO_REMAIN_STEP_COUNT>::func, 0 },
+	{ "INFO_ACTIVE_STEP_LIFE_COUNT", constant<StgStageScript::INFO_ACTIVE_STEP_LIFE_COUNT>::func, 0 },
+	{ "INFO_ACTIVE_STEP_TOTAL_MAX_LIFE", constant<StgStageScript::INFO_ACTIVE_STEP_TOTAL_MAX_LIFE>::func, 0 },
+	{ "INFO_ACTIVE_STEP_TOTAL_LIFE", constant<StgStageScript::INFO_ACTIVE_STEP_TOTAL_LIFE>::func, 0 },
+	{ "INFO_ACTIVE_STEP_LIFE_RATE_LIST", constant<StgStageScript::INFO_ACTIVE_STEP_LIFE_RATE_LIST>::func, 0 },
+	{ "INFO_IS_LAST_STEP", constant<StgStageScript::INFO_IS_LAST_STEP>::func, 0 },
+	{ "INFO_PLAYER_SHOOTDOWN_COUNT", constant<StgStageScript::INFO_PLAYER_SHOOTDOWN_COUNT>::func, 0 },
+	{ "INFO_PLAYER_SPELL_COUNT", constant<StgStageScript::INFO_PLAYER_SPELL_COUNT>::func, 0 },
+	{ "INFO_CURRENT_LIFE", constant<StgStageScript::INFO_CURRENT_LIFE>::func, 0 },
+	{ "INFO_CURRENT_LIFE_MAX", constant<StgStageScript::INFO_CURRENT_LIFE_MAX>::func, 0 },
 
-	{"INFO_ITEM_SCORE", constant<StgStageScript::INFO_ITEM_SCORE>::func, 0},
+	{ "INFO_ITEM_SCORE", constant<StgStageScript::INFO_ITEM_SCORE>::func, 0 },
 
-	{"INFO_RECT", constant<StgStageScript::INFO_RECT>::func, 0},
-	{"INFO_DELAY_COLOR", constant<StgStageScript::INFO_DELAY_COLOR>::func, 0},
-	{"INFO_BLEND", constant<StgStageScript::INFO_BLEND>::func, 0},
-	{"INFO_COLLISION", constant<StgStageScript::INFO_COLLISION>::func, 0},
-	{"INFO_COLLISION_LIST", constant<StgStageScript::INFO_COLLISION_LIST>::func, 0},
+	{ "INFO_RECT", constant<StgStageScript::INFO_RECT>::func, 0 },
+	{ "INFO_DELAY_COLOR", constant<StgStageScript::INFO_DELAY_COLOR>::func, 0 },
+	{ "INFO_BLEND", constant<StgStageScript::INFO_BLEND>::func, 0 },
+	{ "INFO_COLLISION", constant<StgStageScript::INFO_COLLISION>::func, 0 },
+	{ "INFO_COLLISION_LIST", constant<StgStageScript::INFO_COLLISION_LIST>::func, 0 },
 
-	{"EV_REQUEST_LIFE", constant<StgStageScript::EV_REQUEST_LIFE>::func, 0},
-	{"EV_REQUEST_TIMER", constant<StgStageScript::EV_REQUEST_TIMER>::func, 0},
-	{"EV_REQUEST_IS_SPELL", constant<StgStageScript::EV_REQUEST_IS_SPELL>::func, 0},
-	{"EV_REQUEST_IS_LAST_SPELL", constant<StgStageScript::EV_REQUEST_IS_LAST_SPELL>::func, 0},
-	{"EV_REQUEST_IS_DURABLE_SPELL", constant<StgStageScript::EV_REQUEST_IS_DURABLE_SPELL>::func, 0},
-	{"EV_REQUEST_SPELL_SCORE", constant<StgStageScript::EV_REQUEST_SPELL_SCORE>::func, 0},
-	{"EV_REQUEST_REPLAY_TARGET_COMMON_AREA", constant<StgStageScript::EV_REQUEST_REPLAY_TARGET_COMMON_AREA>::func, 0},
+	{ "EV_REQUEST_LIFE", constant<StgStageScript::EV_REQUEST_LIFE>::func, 0 },
+	{ "EV_REQUEST_TIMER", constant<StgStageScript::EV_REQUEST_TIMER>::func, 0 },
+	{ "EV_REQUEST_IS_SPELL", constant<StgStageScript::EV_REQUEST_IS_SPELL>::func, 0 },
+	{ "EV_REQUEST_IS_LAST_SPELL", constant<StgStageScript::EV_REQUEST_IS_LAST_SPELL>::func, 0 },
+	{ "EV_REQUEST_IS_DURABLE_SPELL", constant<StgStageScript::EV_REQUEST_IS_DURABLE_SPELL>::func, 0 },
+	{ "EV_REQUEST_SPELL_SCORE", constant<StgStageScript::EV_REQUEST_SPELL_SCORE>::func, 0 },
+	{ "EV_REQUEST_REPLAY_TARGET_COMMON_AREA", constant<StgStageScript::EV_REQUEST_REPLAY_TARGET_COMMON_AREA>::func, 0 },
 
-	{"EV_TIMEOUT", constant<StgStageScript::EV_TIMEOUT>::func, 0},
-	{"EV_START_BOSS_SPELL", constant<StgStageScript::EV_START_BOSS_SPELL>::func, 0},
-	{"EV_GAIN_SPELL", constant<StgStageScript::EV_GAIN_SPELL>::func, 0},
-	{"EV_START_BOSS_STEP", constant<StgStageScript::EV_START_BOSS_STEP>::func, 0},
-	{"EV_END_BOSS_STEP", constant<StgStageScript::EV_END_BOSS_STEP>::func, 0},
+	{ "EV_TIMEOUT", constant<StgStageScript::EV_TIMEOUT>::func, 0 },
+	{ "EV_START_BOSS_SPELL", constant<StgStageScript::EV_START_BOSS_SPELL>::func, 0 },
+	{ "EV_GAIN_SPELL", constant<StgStageScript::EV_GAIN_SPELL>::func, 0 },
+	{ "EV_START_BOSS_STEP", constant<StgStageScript::EV_START_BOSS_STEP>::func, 0 },
+	{ "EV_END_BOSS_STEP", constant<StgStageScript::EV_END_BOSS_STEP>::func, 0 },
 
-	{"EV_PLAYER_SHOOTDOWN", constant<StgStageScript::EV_PLAYER_SHOOTDOWN>::func, 0},
-	{"EV_PLAYER_SPELL", constant<StgStageScript::EV_PLAYER_SPELL>::func, 0},
-	{"EV_PLAYER_REBIRTH", constant<StgStageScript::EV_PLAYER_REBIRTH>::func, 0},
+	{ "EV_PLAYER_SHOOTDOWN", constant<StgStageScript::EV_PLAYER_SHOOTDOWN>::func, 0 },
+	{ "EV_PLAYER_SPELL", constant<StgStageScript::EV_PLAYER_SPELL>::func, 0 },
+	{ "EV_PLAYER_REBIRTH", constant<StgStageScript::EV_PLAYER_REBIRTH>::func, 0 },
 
-	{"EV_PAUSE_ENTER", constant<StgStageScript::EV_PAUSE_ENTER>::func, 0},
-	{"EV_PAUSE_LEAVE", constant<StgStageScript::EV_PAUSE_LEAVE>::func, 0},
+	{ "EV_PAUSE_ENTER", constant<StgStageScript::EV_PAUSE_ENTER>::func, 0 },
+	{ "EV_PAUSE_LEAVE", constant<StgStageScript::EV_PAUSE_LEAVE>::func, 0 },
 
-	{"TARGET_ALL", constant<StgStageScript::TARGET_ALL>::func, 0},
-	{"TARGET_ENEMY", constant<StgStageScript::TARGET_ENEMY>::func, 0},
-	{"TARGET_PLAYER", constant<StgStageScript::TARGET_PLAYER>::func, 0},
+	{ "TARGET_ALL", constant<StgStageScript::TARGET_ALL>::func, 0 },
+	{ "TARGET_ENEMY", constant<StgStageScript::TARGET_ENEMY>::func, 0 },
+	{ "TARGET_PLAYER", constant<StgStageScript::TARGET_PLAYER>::func, 0 },
 
-	{"NO_CHANGE", constant<StgMovePattern::NO_CHANGE>::func, 0},
+	{ "NO_CHANGE", constant<StgMovePattern::NO_CHANGE>::func, 0 },
 };
-StgStageScript::StgStageScript(StgStageController* stageController) : StgControlScript(stageController->GetSystemController())
+StgStageScript::StgStageScript(StgStageController* stageController)
+	: StgControlScript(stageController->GetSystemController())
 {
 	stageController_ = stageController;
 
@@ -577,9 +554,8 @@ ref_count_ptr<StgStageScriptObjectManager> StgStageScript::GetStgObjectManager()
 	return objectManager;
 }
 
-
 //STG制御共通関数：共通データ
-gstd::value StgStageScript::Func_SaveCommonDataAreaToReplayFile(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SaveCommonDataAreaToReplayFile(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -587,12 +563,12 @@ gstd::value StgStageScript::Func_SaveCommonDataAreaToReplayFile(gstd::script_mac
 	ref_count_ptr<ReplayInformation::StageData> replayStageData = infoStage->GetReplayData();
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 
-	if(infoStage->IsReplay())
+	if (infoStage->IsReplay())
 		script->RaiseError(L"call only in normal play (not replay)");
 
 	std::string area = to_mbcs(argv[0].as_string());
 	ref_count_ptr<ScriptCommonData> commonDataO = commonDataManager->GetData(area);
-	if(commonDataO == NULL)
+	if (commonDataO == NULL)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	ref_count_ptr<ScriptCommonData> commonDataS = new ScriptCommonData();
@@ -601,7 +577,7 @@ gstd::value StgStageScript::Func_SaveCommonDataAreaToReplayFile(gstd::script_mac
 
 	return value(machine->get_engine()->get_boolean_type(), true);
 }
-gstd::value StgStageScript::Func_LoadCommonDataAreaFromReplayFile(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_LoadCommonDataAreaFromReplayFile(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -609,12 +585,12 @@ gstd::value StgStageScript::Func_LoadCommonDataAreaFromReplayFile(gstd::script_m
 	ref_count_ptr<ReplayInformation::StageData> replayStageData = infoStage->GetReplayData();
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 
-	if(!infoStage->IsReplay())
+	if (!infoStage->IsReplay())
 		script->RaiseError(L"call only in replay");
 
 	std::string area = to_mbcs(argv[0].as_string());
 	ref_count_ptr<ScriptCommonData> commonDataS = replayStageData->GetCommonData(area);
-	if(commonDataS == NULL)
+	if (commonDataS == NULL)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	ref_count_ptr<ScriptCommonData> commonDataO = new ScriptCommonData();
@@ -625,7 +601,7 @@ gstd::value StgStageScript::Func_LoadCommonDataAreaFromReplayFile(gstd::script_m
 }
 
 //STG共通関数：システム関連
-gstd::value StgStageScript::Func_GetMainStgScriptPath(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetMainStgScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -635,8 +611,8 @@ gstd::value StgStageScript::Func_GetMainStgScriptPath(gstd::script_machine* mach
 	path = PathProperty::GetUnique(path);
 
 	return value(machine->get_engine()->get_string_type(), path);
-}	
-gstd::value StgStageScript::Func_GetMainStgScriptDirectory(gstd::script_machine* machine, int argc, gstd::value const * argv)
+}
+gstd::value StgStageScript::Func_GetMainStgScriptDirectory(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -649,7 +625,7 @@ gstd::value StgStageScript::Func_GetMainStgScriptDirectory(gstd::script_machine*
 
 	return value(machine->get_engine()->get_string_type(), dir);
 }
-gstd::value StgStageScript::Func_SetStgFrame(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetStgFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -670,57 +646,57 @@ gstd::value StgStageScript::Func_SetStgFrame(gstd::script_machine* machine, int 
 	return value();
 }
 
-gstd::value StgStageScript::Func_SetItemRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetItemRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgStageInformation> info = stageController->GetStageInformation();
 	int pri = (int)argv[0].as_real();
-	//pri = min(pri, info->GetStgFrameMaxPriority());
-	//pri = max(pri, info->GetStgFrameMinPriority());
+	// pri = min(pri, info->GetStgFrameMaxPriority());
+	// pri = max(pri, info->GetStgFrameMinPriority());
 	info->SetItemObjectPriority(pri);
 	return value();
 }
-gstd::value StgStageScript::Func_SetShotRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetShotRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgStageInformation> info = stageController->GetStageInformation();
 	int pri = (int)argv[0].as_real();
-	//pri = min(pri, info->GetStgFrameMaxPriority());
-	//pri = max(pri, info->GetStgFrameMinPriority());
+	// pri = min(pri, info->GetStgFrameMaxPriority());
+	// pri = max(pri, info->GetStgFrameMinPriority());
 	info->SetShotObjectPriority(pri);
 	return value();
 }
-gstd::value StgStageScript::Func_GetStgFrameRenderPriorityMinI(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetStgFrameRenderPriorityMinI(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	long double res = stageController->GetStageInformation()->GetStgFrameMinPriority();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgStageScript::Func_GetStgFrameRenderPriorityMaxI(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetStgFrameRenderPriorityMaxI(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	long double res = stageController->GetStageInformation()->GetStgFrameMaxPriority();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgStageScript::Func_GetItemRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetItemRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	long double res = stageController->GetStageInformation()->GetItemObjectPriority();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgStageScript::Func_GetShotRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetShotRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	long double res = stageController->GetStageInformation()->GetShotObjectPriority();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgStageScript::Func_GetPlayerRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetPlayerRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = script->GetStgObjectManager();
@@ -728,15 +704,14 @@ gstd::value StgStageScript::Func_GetPlayerRenderPriorityI(gstd::script_machine* 
 
 	long double res = 30;
 	StgPlayerObject* obj = dynamic_cast<StgPlayerObject*>(script->GetObjectPointer(idObjPlayer));
-	if(obj != NULL)
-	{
+	if (obj != NULL) {
 		double pri = obj->GetRenderPriority();
 		int vacket = objectManager->GetRenderBucketCapacity();
-		res = pri * (vacket - 1);		
+		res = pri * (vacket - 1);
 	}
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgStageScript::Func_GetCameraFocusPermitPriorityI(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetCameraFocusPermitPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -744,7 +719,7 @@ gstd::value StgStageScript::Func_GetCameraFocusPermitPriorityI(gstd::script_mach
 	return value(machine->get_engine()->get_real_type(), res);
 }
 
-gstd::value StgStageScript::Func_CloseStgScene(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CloseStgScene(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgSystemController* systemController = script->stageController_->GetSystemController();
@@ -755,15 +730,14 @@ gstd::value StgStageScript::Func_CloseStgScene(gstd::script_machine* machine, in
 
 	return value();
 }
-gstd::value StgStageScript::Func_GetReplayFps(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetReplayFps(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgStageInformation> infoStage = stageController->GetStageInformation();
 
 	int fps = 0;
-	if(infoStage->IsReplay())
-	{
+	if (infoStage->IsReplay()) {
 		ref_count_ptr<ReplayInformation::StageData> replayStageData = infoStage->GetReplayData();
 		int frame = infoStage->GetCurrentFrame();
 		fps = replayStageData->GetFramePerSecond(frame);
@@ -773,14 +747,14 @@ gstd::value StgStageScript::Func_GetReplayFps(gstd::script_machine* machine, int
 }
 
 //STG共通関数：自機
-gstd::value StgStageScript::Func_GetPlayerObjectID(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetPlayerObjectID(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = script->GetStgObjectManager();
 	long double res = objectManager->GetPlayerObjectID();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgStageScript::Func_GetPlayerScriptID(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetPlayerScriptID(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -789,12 +763,13 @@ gstd::value StgStageScript::Func_GetPlayerScriptID(gstd::script_machine* machine
 	_int64 res = scriptManager->GetPlayerScriptID();
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_SetPlayerSpeed(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetPlayerSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double speedFast = argv[0].as_real();
 	double speedSlow = argv[1].as_real();
@@ -802,14 +777,15 @@ gstd::value StgStageScript::Func_SetPlayerSpeed(gstd::script_machine* machine, i
 	obj->SetSlowSpeed(speedSlow);
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerClip(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetPlayerClip(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = script->GetStgObjectManager();
 	int idObjPlayer = objectManager->GetPlayerObjectID();
 
 	StgPlayerObject* obj = dynamic_cast<StgPlayerObject*>(script->GetObjectPointer(idObjPlayer));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	RECT rect;
 	rect.left = (int)argv[0].as_real();
@@ -820,72 +796,78 @@ gstd::value StgStageScript::Func_SetPlayerClip(gstd::script_machine* machine, in
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerLife(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetPlayerLife(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double life = argv[0].as_real();
 	obj->SetLife(life);
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double spell = argv[0].as_real();
 	obj->SetSpell(spell);
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerPower(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetPlayerPower(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double power = argv[0].as_real();
 	obj->SetPower(power);
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int invi = (int)argv[0].as_real();
 	obj->SetInvincibilityFrame(invi);
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerDownStateFrame(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetPlayerDownStateFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int frame = (int)argv[0].as_real();
 	obj->SetDownStateFrame(frame);
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerRebirthFrame(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetPlayerRebirthFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int frame = (int)argv[0].as_real();
 	obj->SetRebirthFrame(frame);
@@ -893,55 +875,59 @@ gstd::value StgStageScript::Func_SetPlayerRebirthFrame(gstd::script_machine* mac
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerRebirthLossFrame(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetPlayerRebirthLossFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int frame = (int)argv[0].as_real();
 	obj->SetRebirthLossFrame(frame);
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerAutoItemCollectLine(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetPlayerAutoItemCollectLine(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int posY = (int)argv[0].as_real();
 	obj->SetAutoItemCollectY(posY);
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetForbidPlayerShot(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetForbidPlayerShot(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	bool bForbid = argv[0].as_boolean();
 	obj->SetForbidShot(bForbid);
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetForbidPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetForbidPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	bool bForbid = argv[0].as_boolean();
 	obj->SetForbidSpell(bForbid);
 
 	return value();
 }
-gstd::value StgStageScript::Func_GetPlayerX(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetPlayerX(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -949,7 +935,7 @@ gstd::value StgStageScript::Func_GetPlayerX(gstd::script_machine* machine, int a
 	double res = obj != NULL ? obj->GetX() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerY(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetPlayerY(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -957,7 +943,7 @@ gstd::value StgStageScript::Func_GetPlayerY(gstd::script_machine* machine, int a
 	double res = obj != NULL ? obj->GetY() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerState(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetPlayerState(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -965,7 +951,7 @@ gstd::value StgStageScript::Func_GetPlayerState(gstd::script_machine* machine, i
 	double res = obj != NULL ? obj->GetState() : StgPlayerObject::STATE_END;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerSpeed(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetPlayerSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -978,7 +964,7 @@ gstd::value StgStageScript::Func_GetPlayerSpeed(gstd::script_machine* machine, i
 	gstd::value res = script->CreateRealArrayValue(listValue);
 	return res;
 }
-gstd::value StgStageScript::Func_GetPlayerClip(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetPlayerClip(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -994,7 +980,7 @@ gstd::value StgStageScript::Func_GetPlayerClip(gstd::script_machine* machine, in
 	gstd::value res = script->CreateRealArrayValue(listValue);
 	return res;
 }
-gstd::value StgStageScript::Func_GetPlayerLife(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetPlayerLife(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1002,7 +988,7 @@ gstd::value StgStageScript::Func_GetPlayerLife(gstd::script_machine* machine, in
 	double res = obj != NULL ? obj->GetLife() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1010,7 +996,7 @@ gstd::value StgStageScript::Func_GetPlayerSpell(gstd::script_machine* machine, i
 	double res = obj != NULL ? obj->GetSpell() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerPower(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetPlayerPower(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1018,7 +1004,7 @@ gstd::value StgStageScript::Func_GetPlayerPower(gstd::script_machine* machine, i
 	double res = obj != NULL ? obj->GetPower() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1026,7 +1012,7 @@ gstd::value StgStageScript::Func_GetPlayerInvincibilityFrame(gstd::script_machin
 	double res = obj != NULL ? obj->GetInvincibilityFrame() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerDownStateFrame(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetPlayerDownStateFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1034,7 +1020,7 @@ gstd::value StgStageScript::Func_GetPlayerDownStateFrame(gstd::script_machine* m
 	double res = obj != NULL ? obj->GetDownStateFrame() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerRebirthFrame(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetPlayerRebirthFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1042,27 +1028,28 @@ gstd::value StgStageScript::Func_GetPlayerRebirthFrame(gstd::script_machine* mac
 	double res = obj != NULL ? obj->GetRebirthFrame() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetAngleToPlayer(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetAngleToPlayer(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController->GetPlayerObject();
-	if(objPlayer == NULL)return value(machine->get_engine()->get_real_type(), (long double)-1);
+	if (objPlayer == NULL)
+		return value(machine->get_engine()->get_real_type(), (long double)-1);
 	double px = objPlayer->GetPositionX();
 	double py = objPlayer->GetPositionY();
 
 	int id = (int)argv[0].as_real();
-	ref_count_ptr<DxScriptRenderObject>::unsync objMove = 
-		ref_count_ptr<DxScriptRenderObject>::unsync::DownCast(script->GetObject(id));
-	if(objMove == NULL)return value(machine->get_engine()->get_real_type(), (long double)-1);
+	ref_count_ptr<DxScriptRenderObject>::unsync objMove = ref_count_ptr<DxScriptRenderObject>::unsync::DownCast(script->GetObject(id));
+	if (objMove == NULL)
+		return value(machine->get_engine()->get_real_type(), (long double)-1);
 	double tx = objMove->GetPosition().x;
 	double ty = objMove->GetPosition().y;
 
-	long double angle = atan2(py-ty, px-tx) * 180 / PAI;
+	long double angle = atan2(py - ty, px - tx) * 180 / PAI;
 	return value(machine->get_engine()->get_real_type(), (long double)angle);
 }
 
-gstd::value StgStageScript::Func_IsPermitPlayerShot(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_IsPermitPlayerShot(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1070,7 +1057,7 @@ gstd::value StgStageScript::Func_IsPermitPlayerShot(gstd::script_machine* machin
 	bool res = obj != NULL ? obj->IsPermitShot() : false;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStageScript::Func_IsPermitPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_IsPermitPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1078,7 +1065,7 @@ gstd::value StgStageScript::Func_IsPermitPlayerSpell(gstd::script_machine* machi
 	bool res = obj != NULL ? obj->IsPermitSpell() : false;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStageScript::Func_IsPlayerLastSpellWait(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_IsPlayerLastSpellWait(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1086,37 +1073,35 @@ gstd::value StgStageScript::Func_IsPlayerLastSpellWait(gstd::script_machine* mac
 	bool res = obj != NULL ? obj->IsWaitLastSpell() : false;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStageScript::Func_IsPlayerSpellActive(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_IsPlayerSpellActive(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	bool res = false;
 	ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController->GetPlayerObject();
-	if(objPlayer != NULL)
-	{
+	if (objPlayer != NULL) {
 		ref_count_ptr<StgPlayerSpellManageObject>::unsync objSpell = objPlayer->GetSpellManageObject();
 		res = (objSpell != NULL && !objSpell->IsDeleted());
 	}
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
 
-
 //STG共通関数：敵
-gstd::value StgStageScript::Func_GetEnemyBossSceneObjectID(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetEnemyBossSceneObjectID(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgEnemyManager* enemyManager = stageController->GetEnemyManager();
-	
+
 	int res = ID_INVALID;
 	ref_count_ptr<StgEnemyBossSceneObject>::unsync obj = enemyManager->GetBossSceneObject();
-	if(obj != NULL && !obj->IsDeleted())
+	if (obj != NULL && !obj->IsDeleted())
 		res = obj->GetObjectID();
 
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetEnemyBossObjectID(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetEnemyBossObjectID(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1124,16 +1109,14 @@ gstd::value StgStageScript::Func_GetEnemyBossObjectID(gstd::script_machine* mach
 	ref_count_ptr<StgEnemyBossSceneObject>::unsync scene = enemyManager->GetBossSceneObject();
 
 	std::vector<long double> listLD;
-	if(scene != NULL)
-	{
+	if (scene != NULL) {
 		ref_count_ptr<StgEnemyBossSceneData>::unsync data = scene->GetActiveData();
-		if(data != NULL)
-		{
-			std::vector<ref_count_ptr<StgEnemyBossObject>::unsync > listEnemy = data->GetEnemyObjectList();
-			for(int iEnemy = 0 ; iEnemy < listEnemy.size() ; iEnemy++)
-			{
+		if (data != NULL) {
+			std::vector<ref_count_ptr<StgEnemyBossObject>::unsync> listEnemy = data->GetEnemyObjectList();
+			for (int iEnemy = 0; iEnemy < listEnemy.size(); iEnemy++) {
 				ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemy[iEnemy];
-				if(obj->IsDeleted())continue;
+				if (obj->IsDeleted())
+					continue;
 				int id = obj->GetObjectID();
 				listLD.push_back(id);
 			}
@@ -1142,27 +1125,27 @@ gstd::value StgStageScript::Func_GetEnemyBossObjectID(gstd::script_machine* mach
 
 	return script->CreateRealArrayValue(listLD);
 }
-gstd::value StgStageScript::Func_GetAllEnemyID(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetAllEnemyID(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgEnemyManager* enemyManager = stageController->GetEnemyManager();
 
-	std::list<ref_count_ptr<StgEnemyObject>::unsync >& listEnemy = enemyManager->GetEnemyList();
+	std::list<ref_count_ptr<StgEnemyObject>::unsync>& listEnemy = enemyManager->GetEnemyList();
 
 	std::vector<long double> listLD;
-	std::list<ref_count_ptr<StgEnemyObject>::unsync >::iterator itr = listEnemy.begin();
-	for(; itr != listEnemy.end() ; itr++)
-	{
+	std::list<ref_count_ptr<StgEnemyObject>::unsync>::iterator itr = listEnemy.begin();
+	for (; itr != listEnemy.end(); itr++) {
 		ref_count_ptr<StgEnemyObject>::unsync obj = (*itr);
-		if(obj->IsDeleted())continue;
+		if (obj->IsDeleted())
+			continue;
 		int id = obj->GetObjectID();
 		listLD.push_back(id);
 	}
 
 	return script->CreateRealArrayValue(listLD);
 }
-gstd::value StgStageScript::Func_GetIntersectionRegistedEnemyID(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetIntersectionRegistedEnemyID(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1170,8 +1153,7 @@ gstd::value StgStageScript::Func_GetIntersectionRegistedEnemyID(gstd::script_mac
 
 	std::vector<long double> listLD;
 	std::vector<StgIntersectionTargetPoint>* listPoint = interSectionManager->GetAllEnemyTargetPoint();
-	for(int iPoint = 0 ; iPoint < listPoint->size() ; iPoint++)
-	{
+	for (int iPoint = 0; iPoint < listPoint->size(); iPoint++) {
 		StgIntersectionTargetPoint& target = listPoint->at(iPoint);
 		int id = target.GetObjectID();
 		listLD.push_back(id);
@@ -1179,7 +1161,7 @@ gstd::value StgStageScript::Func_GetIntersectionRegistedEnemyID(gstd::script_mac
 
 	return script->CreateRealArrayValue(listLD);
 }
-gstd::value StgStageScript::Func_GetAllEnemyIntersectionPosition(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetAllEnemyIntersectionPosition(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1187,8 +1169,7 @@ gstd::value StgStageScript::Func_GetAllEnemyIntersectionPosition(gstd::script_ma
 
 	std::vector<gstd::value> listV;
 	std::vector<StgIntersectionTargetPoint>* listPoint = interSectionManager->GetAllEnemyTargetPoint();
-	for(int iPoint = 0 ; iPoint < listPoint->size() ; iPoint++)
-	{
+	for (int iPoint = 0; iPoint < listPoint->size(); iPoint++) {
 		StgIntersectionTargetPoint& target = listPoint->at(iPoint);
 		POINT pos = target.GetPoint();
 		std::vector<long double> listLD;
@@ -1199,28 +1180,24 @@ gstd::value StgStageScript::Func_GetAllEnemyIntersectionPosition(gstd::script_ma
 	}
 	return script->CreateValueArrayValue(listV);
 }
-gstd::value StgStageScript::Func_GetEnemyIntersectionPosition(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetEnemyIntersectionPosition(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 
-	struct SortDistance
-	{
+	struct SortDistance {
 		static std::vector<POINT> Sort(int posX, int posY, std::vector<_int64>& listDist, std::vector<POINT>& listRes)
 		{
 			std::sort(listDist.begin(), listDist.end());
 			std::vector<POINT> listResCopy = listRes;
 			std::vector<_int64> listDistCopy = listDist;
 
-			for(int iRes = 0 ; iRes < listResCopy.size(); iRes++)
-			{
+			for (int iRes = 0; iRes < listResCopy.size(); iRes++) {
 				POINT& pos = listResCopy[iRes];
 				_int64 dist = (pos.x - posX) * (pos.x - posX) + (pos.y - posY) * (pos.y - posY);
-				for(int iDist = 0 ;iDist < listDistCopy.size() ; iDist++)
-				{
-					if(dist == listDistCopy[iDist])
-					{
+				for (int iDist = 0; iDist < listDistCopy.size(); iDist++) {
+					if (dist == listDistCopy[iDist]) {
 						listRes[iDist] = pos;
 						listDistCopy[iDist] = -1;
 						break;
@@ -1240,30 +1217,24 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPosition(gstd::script_machi
 	std::vector<POINT> listRes;
 	std::vector<_int64> listDist;
 	int iPoint = 0;
-	for(iPoint = 0; iPoint < listPoint->size() && countRes > 0; iPoint++)
-	{
+	for (iPoint = 0; iPoint < listPoint->size() && countRes > 0; iPoint++) {
 		StgIntersectionTargetPoint& target = listPoint->at(iPoint);
 		POINT pos = target.GetPoint();
-		if(listRes.size() < countRes)
-		{
+		if (listRes.size() < countRes) {
 			listRes.push_back(pos);
 			listDist.push_back((pos.x - posX) * (pos.x - posX) + (pos.y - posY) * (pos.y - posY));
 
-			if(listRes.size() == countRes)
-			{
+			if (listRes.size() == countRes) {
 				listRes = SortDistance::Sort(posX, posY, listDist, listRes);
 			}
-		}
-		else
-		{
+		} else {
 			_int64 dist = (pos.x - posX) * (pos.x - posX) + (pos.y - posY) * (pos.y - posY);
 			_int64 target = listDist[listDist.size() - 1];
-			if(dist >= target)continue;
-			
-			for(int iDist = 0 ;iDist < listDist.size() ; iDist++)
-			{
-				if(dist < listDist[iDist])
-				{
+			if (dist >= target)
+				continue;
+
+			for (int iDist = 0; iDist < listDist.size(); iDist++) {
+				if (dist < listDist[iDist]) {
 					listRes.insert(listRes.begin() + iDist, pos);
 					listRes.pop_back();
 					listDist.insert(listDist.begin() + iDist, dist);
@@ -1275,8 +1246,7 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPosition(gstd::script_machi
 
 	std::vector<gstd::value> listV;
 	listRes = SortDistance::Sort(posX, posY, listDist, listRes);
-	for(iPoint = 0 ; iPoint < listRes.size() ; iPoint++)
-	{
+	for (iPoint = 0; iPoint < listRes.size(); iPoint++) {
 		POINT& pos = listRes[iPoint];
 		std::vector<long double> listLD;
 		listLD.push_back(pos.x);
@@ -1286,7 +1256,7 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPosition(gstd::script_machi
 	}
 	return script->CreateValueArrayValue(listV);
 }
-gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	//引数1（敵オブジェクトID）自機からもアクセス可能
 	//指定した敵オブジェクトIDが持つ自機ショットへの当たり判定位置を全て取得
@@ -1296,18 +1266,17 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA1(gstd::script
 	StgEnemyObject* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
 
 	std::vector<gstd::value> listV;
-	if(obj != NULL)
-	{
+	if (obj != NULL) {
 		std::map<_int64, POINT> mapPos;
 		int enemyX = obj->GetPositionX();
 		int enemyY = obj->GetPositionY();
 		StgStageController* stageController = script->stageController_;
 		StgIntersectionManager* interSectionManager = stageController->GetIntersectionManager();
 		std::vector<StgIntersectionTargetPoint>* listPoint = interSectionManager->GetAllEnemyTargetPoint();
-		for(int iPoint = 0 ; iPoint < listPoint->size() ; iPoint++)
-		{
+		for (int iPoint = 0; iPoint < listPoint->size(); iPoint++) {
 			StgIntersectionTargetPoint& target = listPoint->at(iPoint);
-			if(target.GetObjectID() != id)continue;
+			if (target.GetObjectID() != id)
+				continue;
 
 			POINT pos = target.GetPoint();
 			_int64 dist = (pos.x - enemyX) * (pos.x - enemyX) + (pos.y - enemyY) * (pos.y - enemyY);
@@ -1315,8 +1284,7 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA1(gstd::script
 		}
 
 		std::map<_int64, POINT>::iterator itr = mapPos.begin();
-		for(; itr != mapPos.end(); itr++)
-		{
+		for (; itr != mapPos.end(); itr++) {
 			POINT pos = (itr->second);
 			std::vector<long double> listLD;
 			listLD.push_back(pos.x);
@@ -1328,7 +1296,7 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA1(gstd::script
 
 	return script->CreateValueArrayValue(listV);
 }
-gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA2(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	//引数3（敵オブジェクトID・x座標・y座標）自機からもアクセス可能
 	//指定した敵オブジェクトIDが持つ、自機ショットへの当たり判定のうち、指定座標に最も近い1つを取得
@@ -1339,18 +1307,17 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA2(gstd::script
 	StgEnemyObject* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
 
 	std::vector<gstd::value> listV;
-	if(obj != NULL)
-	{
+	if (obj != NULL) {
 		std::map<_int64, POINT> mapPos;
 		int tX = (int)argv[1].as_real();
 		int tY = (int)argv[2].as_real();
 		StgStageController* stageController = script->stageController_;
 		StgIntersectionManager* interSectionManager = stageController->GetIntersectionManager();
 		std::vector<StgIntersectionTargetPoint>* listPoint = interSectionManager->GetAllEnemyTargetPoint();
-		for(int iPoint = 0 ; iPoint < listPoint->size() ; iPoint++)
-		{
+		for (int iPoint = 0; iPoint < listPoint->size(); iPoint++) {
 			StgIntersectionTargetPoint& target = listPoint->at(iPoint);
-			if(target.GetObjectID() != id)continue;
+			if (target.GetObjectID() != id)
+				continue;
 
 			POINT pos = target.GetPoint();
 			_int64 dist = (pos.x - tX) * (pos.x - tX) + (pos.y - tY) * (pos.y - tY);
@@ -1358,8 +1325,7 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA2(gstd::script
 		}
 
 		std::map<_int64, POINT>::iterator itr = mapPos.begin();
-		for(; itr != mapPos.end(); itr++)
-		{
+		for (; itr != mapPos.end(); itr++) {
 			POINT pos = (itr->second);
 			std::vector<long double> listLD;
 			listLD.push_back(pos.x);
@@ -1372,7 +1338,7 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA2(gstd::script
 	return script->CreateValueArrayValue(listV);
 }
 
-gstd::value StgStageScript::Func_LoadEnemyShotData(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_LoadEnemyShotData(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1385,7 +1351,7 @@ gstd::value StgStageScript::Func_LoadEnemyShotData(gstd::script_machine* machine
 
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStageScript::Func_ReloadEnemyShotData(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ReloadEnemyShotData(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1400,7 +1366,7 @@ gstd::value StgStageScript::Func_ReloadEnemyShotData(gstd::script_machine* machi
 }
 
 //STG共通関数：弾
-gstd::value StgStageScript::Func_DeleteShotAll(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_DeleteShotAll(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1408,25 +1374,35 @@ gstd::value StgStageScript::Func_DeleteShotAll(gstd::script_machine* machine, in
 	int typeDel = (int)argv[0].as_real();
 	int typeTo = (int)argv[1].as_real();
 
-	switch(typeDel)
-	{
-	case TYPE_ALL:typeDel = StgShotManager::DEL_TYPE_ALL;break;
-	case TYPE_SHOT:typeDel = StgShotManager::DEL_TYPE_SHOT;break;
-	case TYPE_CHILD:typeDel = StgShotManager::DEL_TYPE_CHILD;break;
+	switch (typeDel) {
+	case TYPE_ALL:
+		typeDel = StgShotManager::DEL_TYPE_ALL;
+		break;
+	case TYPE_SHOT:
+		typeDel = StgShotManager::DEL_TYPE_SHOT;
+		break;
+	case TYPE_CHILD:
+		typeDel = StgShotManager::DEL_TYPE_CHILD;
+		break;
 	}
 
-	switch(typeTo)
-	{
-	case TYPE_IMMEDIATE:typeTo = StgShotManager::TO_TYPE_IMMEDIATE;break;
-	case TYPE_FADE:typeTo = StgShotManager::TO_TYPE_FADE;break;
-	case TYPE_ITEM:typeTo = StgShotManager::TO_TYPE_ITEM;break;
+	switch (typeTo) {
+	case TYPE_IMMEDIATE:
+		typeTo = StgShotManager::TO_TYPE_IMMEDIATE;
+		break;
+	case TYPE_FADE:
+		typeTo = StgShotManager::TO_TYPE_FADE;
+		break;
+	case TYPE_ITEM:
+		typeTo = StgShotManager::TO_TYPE_ITEM;
+		break;
 	}
 
-	stageController->GetShotManager()->DeleteInCircle(typeDel, typeTo, StgShotObject::OWNER_ENEMY, 0, 0, 256*256);
+	stageController->GetShotManager()->DeleteInCircle(typeDel, typeTo, StgShotObject::OWNER_ENEMY, 0, 0, 256 * 256);
 
 	return value();
 }
-gstd::value StgStageScript::Func_DeleteShotInCircle(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_DeleteShotInCircle(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1437,25 +1413,35 @@ gstd::value StgStageScript::Func_DeleteShotInCircle(gstd::script_machine* machin
 	int posY = (int)argv[3].as_real();
 	double radius = argv[4].as_real();
 
-	switch(typeDel)
-	{
-	case TYPE_ALL:typeDel = StgShotManager::DEL_TYPE_ALL;break;
-	case TYPE_SHOT:typeDel = StgShotManager::DEL_TYPE_SHOT;break;
-	case TYPE_CHILD:typeDel = StgShotManager::DEL_TYPE_CHILD;break;
+	switch (typeDel) {
+	case TYPE_ALL:
+		typeDel = StgShotManager::DEL_TYPE_ALL;
+		break;
+	case TYPE_SHOT:
+		typeDel = StgShotManager::DEL_TYPE_SHOT;
+		break;
+	case TYPE_CHILD:
+		typeDel = StgShotManager::DEL_TYPE_CHILD;
+		break;
 	}
 
-	switch(typeTo)
-	{
-	case TYPE_IMMEDIATE:typeTo = StgShotManager::TO_TYPE_IMMEDIATE;break;
-	case TYPE_FADE:typeTo = StgShotManager::TO_TYPE_FADE;break;
-	case TYPE_ITEM:typeTo = StgShotManager::TO_TYPE_ITEM;break;
+	switch (typeTo) {
+	case TYPE_IMMEDIATE:
+		typeTo = StgShotManager::TO_TYPE_IMMEDIATE;
+		break;
+	case TYPE_FADE:
+		typeTo = StgShotManager::TO_TYPE_FADE;
+		break;
+	case TYPE_ITEM:
+		typeTo = StgShotManager::TO_TYPE_ITEM;
+		break;
 	}
 
 	stageController->GetShotManager()->DeleteInCircle(typeDel, typeTo, StgShotObject::OWNER_ENEMY, posX, posY, radius);
 
 	return value();
 }
-gstd::value StgStageScript::Func_CreateShotA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CreateShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1463,8 +1449,7 @@ gstd::value StgStageScript::Func_CreateShotA1(gstd::script_machine* machine, int
 	ref_count_ptr<StgNormalShotObject>::unsync obj = new StgNormalShotObject(stageController);
 	obj->SetObjectManager(script->objManager_.GetPointer());
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		stageController->GetShotManager()->AddShot(obj);
 		long double posX = argv[0].as_real();
 		long double posY = argv[1].as_real();
@@ -1472,8 +1457,7 @@ gstd::value StgStageScript::Func_CreateShotA1(gstd::script_machine* machine, int
 		long double angle = argv[3].as_real();
 		int idShot = (int)argv[4].as_real();
 		int delay = (int)argv[5].as_real();
-		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? 
-			StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
+		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
 
 		obj->SetX(posX);
 		obj->SetY(posY);
@@ -1483,10 +1467,10 @@ gstd::value StgStageScript::Func_CreateShotA1(gstd::script_machine* machine, int
 		obj->SetDelay(delay);
 		obj->SetOwnerType(typeOwner);
 	}
-	
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateShotA2(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CreateShotA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1494,8 +1478,7 @@ gstd::value StgStageScript::Func_CreateShotA2(gstd::script_machine* machine, int
 	ref_count_ptr<StgNormalShotObject>::unsync obj = new StgNormalShotObject(stageController);
 	obj->SetObjectManager(script->objManager_.GetPointer());
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		stageController->GetShotManager()->AddShot(obj);
 		long double posX = argv[0].as_real();
 		long double posY = argv[1].as_real();
@@ -1505,8 +1488,7 @@ gstd::value StgStageScript::Func_CreateShotA2(gstd::script_machine* machine, int
 		long double maxSpeed = argv[5].as_real();
 		int idShot = (int)argv[6].as_real();
 		int delay = (int)argv[7].as_real();
-		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? 
-			StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
+		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
 
 		obj->SetX(posX);
 		obj->SetY(posY);
@@ -1521,18 +1503,18 @@ gstd::value StgStageScript::Func_CreateShotA2(gstd::script_machine* machine, int
 		pattern->SetAcceleration(accele);
 		pattern->SetMaxSpeed(maxSpeed);
 	}
-	
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateShotOA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CreateShotOA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int tId = (int)argv[0].as_real();
 	DxScriptRenderObject* tObj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(tId));
-	if(tObj == NULL)
-		return value(machine->get_engine()->get_real_type(),(long double)ID_INVALID);
+	if (tObj == NULL)
+		return value(machine->get_engine()->get_real_type(), (long double)ID_INVALID);
 
 	double posX = tObj->GetPosition().x;
 	double posY = tObj->GetPosition().y;
@@ -1540,15 +1522,13 @@ gstd::value StgStageScript::Func_CreateShotOA1(gstd::script_machine* machine, in
 	ref_count_ptr<StgNormalShotObject>::unsync obj = new StgNormalShotObject(stageController);
 	obj->SetObjectManager(script->objManager_.GetPointer());
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		stageController->GetShotManager()->AddShot(obj);
 		long double speed = argv[1].as_real();
 		long double angle = argv[2].as_real();
 		int idShot = (int)argv[3].as_real();
 		int delay = (int)argv[4].as_real();
-		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? 
-			StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
+		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
 
 		obj->SetX(posX);
 		obj->SetY(posY);
@@ -1558,10 +1538,10 @@ gstd::value StgStageScript::Func_CreateShotOA1(gstd::script_machine* machine, in
 		obj->SetDelay(delay);
 		obj->SetOwnerType(typeOwner);
 	}
-	
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateShotB1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CreateShotB1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1569,8 +1549,7 @@ gstd::value StgStageScript::Func_CreateShotB1(gstd::script_machine* machine, int
 	ref_count_ptr<StgNormalShotObject>::unsync obj = new StgNormalShotObject(stageController);
 	obj->SetObjectManager(script->objManager_.GetPointer());
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		stageController->GetShotManager()->AddShot(obj);
 		long double posX = argv[0].as_real();
 		long double posY = argv[1].as_real();
@@ -1578,8 +1557,7 @@ gstd::value StgStageScript::Func_CreateShotB1(gstd::script_machine* machine, int
 		long double speedY = argv[3].as_real();
 		int idShot = (int)argv[4].as_real();
 		int delay = (int)argv[5].as_real();
-		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? 
-			StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
+		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
 
 		obj->SetX(posX);
 		obj->SetY(posY);
@@ -1592,10 +1570,10 @@ gstd::value StgStageScript::Func_CreateShotB1(gstd::script_machine* machine, int
 		pattern->SetSpeedY(speedY);
 		obj->SetPattern(pattern);
 	}
-	
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateShotB2(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CreateShotB2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1603,8 +1581,7 @@ gstd::value StgStageScript::Func_CreateShotB2(gstd::script_machine* machine, int
 	ref_count_ptr<StgNormalShotObject>::unsync obj = new StgNormalShotObject(stageController);
 	obj->SetObjectManager(script->objManager_.GetPointer());
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		stageController->GetShotManager()->AddShot(obj);
 		long double posX = argv[0].as_real();
 		long double posY = argv[1].as_real();
@@ -1616,8 +1593,7 @@ gstd::value StgStageScript::Func_CreateShotB2(gstd::script_machine* machine, int
 		long double maxSpeedY = argv[7].as_real();
 		int idShot = (int)argv[8].as_real();
 		int delay = (int)argv[9].as_real();
-		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? 
-			StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
+		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
 
 		obj->SetX(posX);
 		obj->SetY(posY);
@@ -1634,18 +1610,18 @@ gstd::value StgStageScript::Func_CreateShotB2(gstd::script_machine* machine, int
 		pattern->SetMaxSpeedY(maxSpeedY);
 		obj->SetPattern(pattern);
 	}
-	
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateShotOB1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CreateShotOB1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int tId = (int)argv[0].as_real();
 	DxScriptRenderObject* tObj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(tId));
-	if(tObj == NULL)
-		return value(machine->get_engine()->get_real_type(),(long double)ID_INVALID);
+	if (tObj == NULL)
+		return value(machine->get_engine()->get_real_type(), (long double)ID_INVALID);
 
 	double posX = tObj->GetPosition().x;
 	double posY = tObj->GetPosition().y;
@@ -1653,15 +1629,13 @@ gstd::value StgStageScript::Func_CreateShotOB1(gstd::script_machine* machine, in
 	ref_count_ptr<StgNormalShotObject>::unsync obj = new StgNormalShotObject(stageController);
 	obj->SetObjectManager(script->objManager_.GetPointer());
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		stageController->GetShotManager()->AddShot(obj);
 		long double speedX = argv[1].as_real();
 		long double speedY = argv[2].as_real();
 		int idShot = (int)argv[3].as_real();
 		int delay = (int)argv[4].as_real();
-		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? 
-			StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
+		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
 
 		obj->SetX(posX);
 		obj->SetY(posY);
@@ -1674,11 +1648,11 @@ gstd::value StgStageScript::Func_CreateShotOB1(gstd::script_machine* machine, in
 		pattern->SetSpeedY(speedY);
 		obj->SetPattern(pattern);
 	}
-	
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
 
-gstd::value StgStageScript::Func_CreateLooseLaserA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CreateLooseLaserA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1686,8 +1660,7 @@ gstd::value StgStageScript::Func_CreateLooseLaserA1(gstd::script_machine* machin
 	ref_count_ptr<StgLooseLaserObject>::unsync obj = new StgLooseLaserObject(stageController);
 	obj->SetObjectManager(script->objManager_.GetPointer());
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		stageController->GetShotManager()->AddShot(obj);
 		long double posX = argv[0].as_real();
 		long double posY = argv[1].as_real();
@@ -1697,8 +1670,7 @@ gstd::value StgStageScript::Func_CreateLooseLaserA1(gstd::script_machine* machin
 		int width = argv[5].as_real();
 		int idShot = (int)argv[6].as_real();
 		int delay = (int)argv[7].as_real();
-		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? 
-			StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
+		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
 
 		obj->SetX(posX);
 		obj->SetY(posY);
@@ -1710,11 +1682,11 @@ gstd::value StgStageScript::Func_CreateLooseLaserA1(gstd::script_machine* machin
 		obj->SetDelay(delay);
 		obj->SetOwnerType(typeOwner);
 	}
-	
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
 
-gstd::value StgStageScript::Func_CreateStraightLaserA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CreateStraightLaserA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1722,8 +1694,7 @@ gstd::value StgStageScript::Func_CreateStraightLaserA1(gstd::script_machine* mac
 	ref_count_ptr<StgStraightLaserObject>::unsync obj = new StgStraightLaserObject(stageController);
 	obj->SetObjectManager(script->objManager_.GetPointer());
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		stageController->GetShotManager()->AddShot(obj);
 		long double posX = argv[0].as_real();
 		long double posY = argv[1].as_real();
@@ -1733,8 +1704,7 @@ gstd::value StgStageScript::Func_CreateStraightLaserA1(gstd::script_machine* mac
 		int deleteFrame = (int)argv[5].as_real();
 		int idShot = (int)argv[6].as_real();
 		int delay = (int)argv[7].as_real();
-		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? 
-			StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
+		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
 
 		obj->SetX(posX);
 		obj->SetY(posY);
@@ -1746,9 +1716,9 @@ gstd::value StgStageScript::Func_CreateStraightLaserA1(gstd::script_machine* mac
 		obj->SetDelay(delay);
 		obj->SetOwnerType(typeOwner);
 	}
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateCurveLaserA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CreateCurveLaserA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1756,8 +1726,7 @@ gstd::value StgStageScript::Func_CreateCurveLaserA1(gstd::script_machine* machin
 	ref_count_ptr<StgCurveLaserObject>::unsync obj = new StgCurveLaserObject(stageController);
 	obj->SetObjectManager(script->objManager_.GetPointer());
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		stageController->GetShotManager()->AddShot(obj);
 		long double posX = argv[0].as_real();
 		long double posY = argv[1].as_real();
@@ -1767,8 +1736,7 @@ gstd::value StgStageScript::Func_CreateCurveLaserA1(gstd::script_machine* machin
 		int width = argv[5].as_real();
 		int idShot = (int)argv[6].as_real();
 		int delay = (int)argv[7].as_real();
-		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? 
-			StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
+		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
 
 		obj->SetX(posX);
 		obj->SetY(posY);
@@ -1780,17 +1748,16 @@ gstd::value StgStageScript::Func_CreateCurveLaserA1(gstd::script_machine* machin
 		obj->SetDelay(delay);
 		obj->SetOwnerType(typeOwner);
 	}
-	
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
 
-gstd::value StgStageScript::Func_SetShotIntersectionCircle(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetShotIntersectionCircle(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
-	int typeTarget = script->GetScriptType() == TYPE_PLAYER ? 
-		StgIntersectionTarget::TYPE_PLAYER_SHOT : StgIntersectionTarget::TYPE_ENEMY_SHOT;
+	int typeTarget = script->GetScriptType() == TYPE_PLAYER ? StgIntersectionTarget::TYPE_PLAYER_SHOT : StgIntersectionTarget::TYPE_ENEMY_SHOT;
 
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 	int px = (int)argv[0].as_real();
@@ -1799,8 +1766,7 @@ gstd::value StgStageScript::Func_SetShotIntersectionCircle(gstd::script_machine*
 	DxCircle circle(px, py, radius);
 
 	//当たり判定
-	ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = 
-		ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
+	ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
 	target->SetTargetType(typeTarget);
 	target->SetCircle(circle);
 
@@ -1808,13 +1774,12 @@ gstd::value StgStageScript::Func_SetShotIntersectionCircle(gstd::script_machine*
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetShotIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetShotIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
-	int typeTarget = script->GetScriptType() == TYPE_PLAYER ? 
-		StgIntersectionTarget::TYPE_PLAYER_SHOT : StgIntersectionTarget::TYPE_ENEMY_SHOT;
+	int typeTarget = script->GetScriptType() == TYPE_PLAYER ? StgIntersectionTarget::TYPE_PLAYER_SHOT : StgIntersectionTarget::TYPE_ENEMY_SHOT;
 
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 	int px1 = (int)argv[0].as_real();
@@ -1825,8 +1790,7 @@ gstd::value StgStageScript::Func_SetShotIntersectionLine(gstd::script_machine* m
 	DxWidthLine line(px1, py1, px2, py2, width);
 
 	//当たり判定
-	ref_count_ptr<StgIntersectionTarget_Line>::unsync target = 
-		ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_LINE));
+	ref_count_ptr<StgIntersectionTarget_Line>::unsync target = ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_LINE));
 	target->SetTargetType(typeTarget);
 	target->SetLine(line);
 
@@ -1834,7 +1798,7 @@ gstd::value StgStageScript::Func_SetShotIntersectionLine(gstd::script_machine* m
 
 	return value();
 }
-gstd::value StgStageScript::Func_GetShotIdInCircleA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetShotIdInCircleA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1847,13 +1811,13 @@ gstd::value StgStageScript::Func_GetShotIdInCircleA1(gstd::script_machine* machi
 
 	std::vector<int> listID = shotManager->GetShotIdInCircle(typeOwner, px, py, radius);
 	std::vector<long double> listRes;
-	for(int iID = 0 ; iID < listID.size() ; iID++)
+	for (int iID = 0; iID < listID.size(); iID++)
 		listRes.push_back(listID[iID]);
 	gstd::value res = script->CreateRealArrayValue(listRes);
 
 	return res;
 }
-gstd::value StgStageScript::Func_GetShotIdInCircleA2(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetShotIdInCircleA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1865,22 +1829,27 @@ gstd::value StgStageScript::Func_GetShotIdInCircleA2(gstd::script_machine* machi
 	int target = (int)argv[3].as_real();
 
 	int typeOwner = StgShotObject::OWNER_NULL;
-	switch(target)
-	{
-	case TARGET_ALL:typeOwner = StgShotObject::OWNER_NULL;break;
-	case TARGET_PLAYER:typeOwner = StgShotObject::OWNER_PLAYER;break;
-	case TARGET_ENEMY:typeOwner = StgShotObject::OWNER_ENEMY;break;
+	switch (target) {
+	case TARGET_ALL:
+		typeOwner = StgShotObject::OWNER_NULL;
+		break;
+	case TARGET_PLAYER:
+		typeOwner = StgShotObject::OWNER_PLAYER;
+		break;
+	case TARGET_ENEMY:
+		typeOwner = StgShotObject::OWNER_ENEMY;
+		break;
 	}
 
 	std::vector<int> listID = shotManager->GetShotIdInCircle(typeOwner, px, py, radius);
 	std::vector<long double> listRes;
-	for(int iID = 0 ; iID < listID.size() ; iID++)
+	for (int iID = 0; iID < listID.size(); iID++)
 		listRes.push_back(listID[iID]);
 	gstd::value res = script->CreateRealArrayValue(listRes);
 
 	return res;
 }
-gstd::value StgStageScript::Func_GetShotCount(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetShotCount(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1888,17 +1857,22 @@ gstd::value StgStageScript::Func_GetShotCount(gstd::script_machine* machine, int
 
 	int target = (int)argv[0].as_real();
 	int typeOwner = StgShotObject::OWNER_NULL;
-	switch(target)
-	{
-	case TARGET_ALL:typeOwner = StgShotObject::OWNER_NULL;break;
-	case TARGET_PLAYER:typeOwner = StgShotObject::OWNER_PLAYER;break;
-	case TARGET_ENEMY:typeOwner = StgShotObject::OWNER_ENEMY;break;
+	switch (target) {
+	case TARGET_ALL:
+		typeOwner = StgShotObject::OWNER_NULL;
+		break;
+	case TARGET_PLAYER:
+		typeOwner = StgShotObject::OWNER_PLAYER;
+		break;
+	case TARGET_ENEMY:
+		typeOwner = StgShotObject::OWNER_ENEMY;
+		break;
 	}
-	
+
 	int res = shotManager->GetShotCount(typeOwner);
-	return value(machine->get_engine()->get_real_type(),(long double)res);
+	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_SetShotAutoDeleteClip(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetShotAutoDeleteClip(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1913,7 +1887,7 @@ gstd::value StgStageScript::Func_SetShotAutoDeleteClip(gstd::script_machine* mac
 
 	return value();
 }
-gstd::value StgStageScript::Func_GetShotDataInfoA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_GetShotDataInfoA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1922,96 +1896,87 @@ gstd::value StgStageScript::Func_GetShotDataInfoA1(gstd::script_machine* machine
 	int idShot = (int)argv[0].as_real();
 	int target = (int)argv[1].as_real();
 	int type = (int)argv[2].as_real();
-	
+
 	StgShotManager* shotManager = stageController->GetShotManager();
-	StgShotDataList* dataList = (target == TARGET_PLAYER) ?
-		shotManager->GetPlayerShotDataList() : shotManager->GetEnemyShotDataList();
+	StgShotDataList* dataList = (target == TARGET_PLAYER) ? shotManager->GetPlayerShotDataList() : shotManager->GetEnemyShotDataList();
 
 	ref_count_ptr<StgShotData>::unsync shotData = NULL;
-	if(dataList != NULL)
+	if (dataList != NULL)
 		shotData = dataList->GetData(idShot);
 
-	if(shotData == NULL)
+	if (shotData == NULL)
 		script->RaiseError(ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_OUTOFRANGE_INDEX));
 
 	gstd::value res;
-	switch(type)
-	{
-		case INFO_RECT:
-		{
-			RECT rect = shotData->GetRect(0);
+	switch (type) {
+	case INFO_RECT: {
+		RECT rect = shotData->GetRect(0);
+		std::vector<long double> list;
+		list.push_back(rect.left);
+		list.push_back(rect.top);
+		list.push_back(rect.right);
+		list.push_back(rect.bottom);
+		res = script->CreateRealArrayValue(list);
+		break;
+	}
+
+	case INFO_DELAY_COLOR: {
+		D3DCOLOR color = shotData->GetDelayColor();
+		int colorR = ColorAccess::GetColorR(color);
+		int colorG = ColorAccess::GetColorG(color);
+		int colorB = ColorAccess::GetColorB(color);
+
+		std::vector<long double> list;
+		list.push_back(colorR);
+		list.push_back(colorG);
+		list.push_back(colorB);
+		res = script->CreateRealArrayValue(list);
+		break;
+	}
+
+	case INFO_BLEND: {
+		int blendType = shotData->GetRenderType();
+		res = value(machine->get_engine()->get_real_type(), (long double)blendType);
+		break;
+	}
+
+	case INFO_COLLISION: {
+		double radius = 0;
+		std::vector<DxCircle>* listCircle = shotData->GetIntersectionCircleList();
+		if (listCircle->size() > 0) {
+			DxCircle circle = listCircle->at(0);
+			radius = circle.GetR();
+		}
+		res = value(machine->get_engine()->get_real_type(), (long double)radius);
+		break;
+	}
+
+	case INFO_COLLISION_LIST: {
+		std::vector<DxCircle>* listCircle = shotData->GetIntersectionCircleList();
+		std::vector<gstd::value> listValue;
+		for (int iCircle = 0; iCircle < listCircle->size(); iCircle++) {
+			DxCircle circle = listCircle->at(iCircle);
 			std::vector<long double> list;
-			list.push_back(rect.left);
-			list.push_back(rect.top);
-			list.push_back(rect.right);
-			list.push_back(rect.bottom);
-			res = script->CreateRealArrayValue(list);
-			break;
+			list.push_back(circle.GetR());
+			list.push_back(circle.GetX());
+			list.push_back(circle.GetY());
+			gstd::value val = script->CreateRealArrayValue(list);
+			listValue.push_back(val);
 		}
-
-		case INFO_DELAY_COLOR:
-		{
-			D3DCOLOR color = shotData->GetDelayColor();
-			int colorR = ColorAccess::GetColorR(color);
-			int colorG = ColorAccess::GetColorG(color);
-			int colorB = ColorAccess::GetColorB(color);
-
-			std::vector<long double> list;
-			list.push_back(colorR);
-			list.push_back(colorG);
-			list.push_back(colorB);
-			res = script->CreateRealArrayValue(list);
-			break;
-		}
-
-		case INFO_BLEND:
-		{
-			int blendType = shotData->GetRenderType();
-			res = value(machine->get_engine()->get_real_type(),(long double)blendType);
-			break;
-		}
-
-		case INFO_COLLISION:
-		{
-			double radius = 0;
-			std::vector<DxCircle>* listCircle = shotData->GetIntersectionCircleList();
-			if(listCircle->size() > 0)
-			{
-				DxCircle circle = listCircle->at(0);
-				radius = circle.GetR();
-			}
-			res = value(machine->get_engine()->get_real_type(),(long double)radius);
-			break;
-		}
-
-		case INFO_COLLISION_LIST:
-		{
-			std::vector<DxCircle>* listCircle = shotData->GetIntersectionCircleList();
-			std::vector<gstd::value> listValue;
-			for(int iCircle = 0 ; iCircle < listCircle->size() ; iCircle++)
-			{
-				DxCircle circle = listCircle->at(iCircle);
-				std::vector<long double> list;
-				list.push_back(circle.GetR());
-				list.push_back(circle.GetX());
-				list.push_back(circle.GetY());
-				gstd::value val = script->CreateRealArrayValue(list);
-				listValue.push_back(val);
-			}
-			res = script->CreateValueArrayValue(listValue);
-			break;
-		}
+		res = script->CreateValueArrayValue(listValue);
+		break;
+	}
 	}
 
 	return res;
 }
-gstd::value StgStageScript::Func_StartShotScript(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_StartShotScript(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgStageScriptManager* scriptManager = stageController->GetScriptManagerP();
 
-	if(scriptManager->GetShotScriptID() != StgControlScriptManager::ID_INVALID)
+	if (scriptManager->GetShotScriptID() != StgControlScriptManager::ID_INVALID)
 		script->RaiseError(L"already started shot script");
 
 	std::wstring path = argv[0].as_string();
@@ -2025,7 +1990,7 @@ gstd::value StgStageScript::Func_StartShotScript(gstd::script_machine* machine, 
 }
 
 //STG共通関数：アイテム
-gstd::value StgStageScript::Func_CreateItemA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CreateItemA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2034,21 +1999,20 @@ gstd::value StgStageScript::Func_CreateItemA1(gstd::script_machine* machine, int
 	int type = (int)argv[0].as_real();
 	ref_count_ptr<StgItemObject>::unsync obj = itemManager->CreateItem(type);
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		itemManager->AddItem(obj);
 		int posX = (int)argv[1].as_real();
 		int posY = (int)argv[2].as_real();
 		int score = (int)argv[3].as_real();
-		POINT to = {posX, posY - 128};
+		POINT to = { posX, posY - 128 };
 		obj->SetPositionX(posX);
 		obj->SetPositionY(posY);
 		obj->SetScore(score);
 		obj->SetToPosition(to);
 	}
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateItemA2(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CreateItemA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2057,38 +2021,35 @@ gstd::value StgStageScript::Func_CreateItemA2(gstd::script_machine* machine, int
 	int type = (int)argv[0].as_real();
 	ref_count_ptr<StgItemObject>::unsync obj = itemManager->CreateItem(type);
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		itemManager->AddItem(obj);
 		int posX = (int)argv[1].as_real();
 		int posY = (int)argv[2].as_real();
 		int score = (int)argv[5].as_real();
-		POINT to = {(int)argv[3].as_real(), (int)argv[4].as_real()};
+		POINT to = { (int)argv[3].as_real(), (int)argv[4].as_real() };
 		obj->SetPositionX(posX);
 		obj->SetPositionY(posY);
 		obj->SetScore(score);
 		obj->SetToPosition(to);
 	}
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateItemU1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CreateItemU1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgItemManager* itemManager = stageController->GetItemManager();
 
 	int type = StgItemObject::ITEM_USER;
-	ref_count_ptr<StgItemObject_User>::unsync obj = 
-		ref_count_ptr<StgItemObject_User>::unsync::DownCast(itemManager->CreateItem(type));
+	ref_count_ptr<StgItemObject_User>::unsync obj = ref_count_ptr<StgItemObject_User>::unsync::DownCast(itemManager->CreateItem(type));
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		itemManager->AddItem(obj);
 		int itemID = (int)argv[0].as_real();
 		int posX = (int)argv[1].as_real();
 		int posY = (int)argv[2].as_real();
 		int score = (int)argv[3].as_real();
-		POINT to = {posX, posY - 128};
+		POINT to = { posX, posY - 128 };
 
 		obj->SetPositionX(posX);
 		obj->SetPositionY(posY);
@@ -2097,26 +2058,24 @@ gstd::value StgStageScript::Func_CreateItemU1(gstd::script_machine* machine, int
 		obj->SetImageID(itemID);
 		obj->SetMoveType(StgMovePattern_Item::MOVE_TOPOSITION_A);
 	}
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateItemU2(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CreateItemU2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgItemManager* itemManager = stageController->GetItemManager();
 
 	int type = StgItemObject::ITEM_USER;
-	ref_count_ptr<StgItemObject_User>::unsync obj = 
-		ref_count_ptr<StgItemObject_User>::unsync::DownCast(itemManager->CreateItem(type));
+	ref_count_ptr<StgItemObject_User>::unsync obj = ref_count_ptr<StgItemObject_User>::unsync::DownCast(itemManager->CreateItem(type));
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		itemManager->AddItem(obj);
 		int itemID = (int)argv[0].as_real();
 		int posX = (int)argv[1].as_real();
 		int posY = (int)argv[2].as_real();
 		int score = (int)argv[5].as_real();
-		POINT to = {(int)argv[3].as_real(), (int)argv[4].as_real()};
+		POINT to = { (int)argv[3].as_real(), (int)argv[4].as_real() };
 		obj->SetPositionX(posX);
 		obj->SetPositionY(posY);
 		obj->SetScore(score);
@@ -2124,9 +2083,9 @@ gstd::value StgStageScript::Func_CreateItemU2(gstd::script_machine* machine, int
 		obj->SetImageID(itemID);
 		obj->SetMoveType(StgMovePattern_Item::MOVE_TOPOSITION_A);
 	}
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateItemScore(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CreateItemScore(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2138,17 +2097,16 @@ gstd::value StgStageScript::Func_CreateItemScore(gstd::script_machine* machine, 
 
 	ref_count_ptr<StgItemObject_Score>::unsync obj = new StgItemObject_Score(stageController);
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		itemManager->AddItem(obj);
 		obj->SetX(posX);
 		obj->SetY(posY);
 		obj->SetScore(score);
 	}
 
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CollectAllItems(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CollectAllItems(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2157,7 +2115,7 @@ gstd::value StgStageScript::Func_CollectAllItems(gstd::script_machine* machine, 
 
 	return value();
 }
-gstd::value StgStageScript::Func_CollectItemsByType(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CollectItemsByType(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2167,7 +2125,7 @@ gstd::value StgStageScript::Func_CollectItemsByType(gstd::script_machine* machin
 	itemManager->CollectItemsByType(type);
 	return value();
 }
-gstd::value StgStageScript::Func_CollectItemsInCircle(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CollectItemsInCircle(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2176,11 +2134,11 @@ gstd::value StgStageScript::Func_CollectItemsInCircle(gstd::script_machine* mach
 	int cx = (int)argv[0].as_real();
 	int cy = (int)argv[1].as_real();
 	int cr = (int)argv[2].as_real();
-	DxCircle circle(cx, cy ,cr);
+	DxCircle circle(cx, cy, cr);
 	itemManager->CollectItemsInCircle(circle);
 	return value();
 }
-gstd::value StgStageScript::Func_CancelCollectItems(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_CancelCollectItems(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2189,13 +2147,13 @@ gstd::value StgStageScript::Func_CancelCollectItems(gstd::script_machine* machin
 	itemManager->CancelCollectItems();
 	return value();
 }
-gstd::value StgStageScript::Func_StartItemScript(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_StartItemScript(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgStageScriptManager* scriptManager = stageController->GetScriptManagerP();
 
-	if(scriptManager->GetItemScriptID() != StgControlScriptManager::ID_INVALID)
+	if (scriptManager->GetItemScriptID() != StgControlScriptManager::ID_INVALID)
 		script->RaiseError(L"already started item script");
 
 	std::wstring path = argv[0].as_string();
@@ -2207,7 +2165,7 @@ gstd::value StgStageScript::Func_StartItemScript(gstd::script_machine* machine, 
 	scriptManager->SetItemScriptID(idScript);
 	return value();
 }
-gstd::value StgStageScript::Func_SetDefaultBonusItemEnable(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_SetDefaultBonusItemEnable(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2217,7 +2175,7 @@ gstd::value StgStageScript::Func_SetDefaultBonusItemEnable(gstd::script_machine*
 	itemManager->SetDefaultBonusItemEnable(bEnable);
 	return value();
 }
-gstd::value StgStageScript::Func_LoadItemData(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_LoadItemData(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2229,7 +2187,7 @@ gstd::value StgStageScript::Func_LoadItemData(gstd::script_machine* machine, int
 	bool res = itemManager->LoadItemData(path);
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStageScript::Func_ReloadItemData(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ReloadItemData(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2243,7 +2201,7 @@ gstd::value StgStageScript::Func_ReloadItemData(gstd::script_machine* machine, i
 }
 
 //STG共通関数：その他
-gstd::value StgStageScript::Func_StartSlow(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_StartSlow(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2252,15 +2210,14 @@ gstd::value StgStageScript::Func_StartSlow(gstd::script_machine* machine, int ar
 	int fps = (int)argv[1].as_real();
 
 	int slowTarget = PseudoSlowInformation::TARGET_ALL;
-	int typeOwner = script->GetScriptType() == TYPE_PLAYER ? 
-		PseudoSlowInformation::OWNER_PLAYER : PseudoSlowInformation::OWNER_ENEMY;
+	int typeOwner = script->GetScriptType() == TYPE_PLAYER ? PseudoSlowInformation::OWNER_PLAYER : PseudoSlowInformation::OWNER_ENEMY;
 
 	ref_count_ptr<PseudoSlowInformation> infoSlow = stageController->GetSlowInformation();
 	infoSlow->AddSlow(fps, typeOwner, slowTarget);
 
 	return value();
 }
-gstd::value StgStageScript::Func_StopSlow(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_StopSlow(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2268,55 +2225,50 @@ gstd::value StgStageScript::Func_StopSlow(gstd::script_machine* machine, int arg
 	int target = (int)argv[0].as_real();
 
 	int slowTarget = PseudoSlowInformation::TARGET_ALL;
-	int typeOwner = script->GetScriptType() == TYPE_PLAYER ? 
-		PseudoSlowInformation::OWNER_PLAYER : PseudoSlowInformation::OWNER_ENEMY;
+	int typeOwner = script->GetScriptType() == TYPE_PLAYER ? PseudoSlowInformation::OWNER_PLAYER : PseudoSlowInformation::OWNER_ENEMY;
 
 	ref_count_ptr<PseudoSlowInformation> infoSlow = stageController->GetSlowInformation();
 	infoSlow->RemoveSlow(typeOwner, slowTarget);
 
 	return value();
 }
-gstd::value StgStageScript::Func_IsIntersected_Line_Circle(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_IsIntersected_Line_Circle(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxWidthLine line(
 		argv[0].as_real(),
 		argv[1].as_real(),
 		argv[2].as_real(),
 		argv[3].as_real(),
-		argv[4].as_real()
-	);
+		argv[4].as_real());
 
 	DxCircle circle(
 		argv[5].as_real(),
 		argv[6].as_real(),
-		argv[7].as_real()
-	);
-	
+		argv[7].as_real());
+
 	bool res = DxMath::IsIntersected(circle, line);
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStageScript::Func_IsIntersected_Obj_Obj(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_IsIntersected_Obj_Obj(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id1 = (int)argv[0].as_real();
 	int id2 = (int)argv[1].as_real();
 
 	StgShotObject* obj1 = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id1));
-	if(obj1 == NULL)return value(machine->get_engine()->get_boolean_type(), false);
+	if (obj1 == NULL)
+		return value(machine->get_engine()->get_boolean_type(), false);
 
 	StgShotObject* obj2 = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id2));
-	if(obj2 == NULL)return value(machine->get_engine()->get_boolean_type(), false);
+	if (obj2 == NULL)
+		return value(machine->get_engine()->get_boolean_type(), false);
 
-	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > listTaget1 =
-		obj1->GetIntersectionTargetList();
-	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync > listTaget2 =
-		obj2->GetIntersectionTargetList();
+	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> listTaget1 = obj1->GetIntersectionTargetList();
+	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> listTaget2 = obj2->GetIntersectionTargetList();
 
 	bool res = false;
-	for(int iTarget1 = 0 ; iTarget1 < listTaget1.size() && !res; iTarget1++)
-	{
-		for(int iTarget2 = 0 ; iTarget2 < listTaget2.size() && !res ; iTarget2++)
-		{
+	for (int iTarget1 = 0; iTarget1 < listTaget1.size() && !res; iTarget1++) {
+		for (int iTarget2 = 0; iTarget2 < listTaget2.size() && !res; iTarget2++) {
 			ref_count_ptr<StgIntersectionTarget>::unsync target1 = listTaget1[iTarget1];
 			ref_count_ptr<StgIntersectionTarget>::unsync target2 = listTaget2[iTarget2];
 			res = StgIntersectionManager::IsIntersected(target1, target2);
@@ -2325,46 +2277,50 @@ gstd::value StgStageScript::Func_IsIntersected_Obj_Obj(gstd::script_machine* mac
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
 
-
 //STD共通関数：移動オブジェクト操作
-gstd::value StgStageScript::Func_ObjMove_SetX(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_SetX(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double pos = argv[1].as_real();
 	obj->SetPositionX(pos);
 
 	DxScriptRenderObject* objR = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if(objR == NULL)return value();
+	if (objR == NULL)
+		return value();
 	objR->SetX(pos);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetY(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_SetY(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double pos = argv[1].as_real();
 	obj->SetPositionY(pos);
 
 	DxScriptRenderObject* objR = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if(objR == NULL)return value();
+	if (objR == NULL)
+		return value();
 	objR->SetY(pos);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetPosition(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_SetPosition(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double posX = argv[1].as_real();
 	double posY = argv[2].as_real();
@@ -2372,43 +2328,46 @@ gstd::value StgStageScript::Func_ObjMove_SetPosition(gstd::script_machine* machi
 	obj->SetPositionY(posY);
 
 	DxScriptRenderObject* objR = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if(objR == NULL)return value();
+	if (objR == NULL)
+		return value();
 	objR->SetX(posX);
 	objR->SetY(posY);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetSpeed(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_SetSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double speed = argv[1].as_real();
 	obj->SetSpeed(speed);
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetAngle(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_SetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double angle = argv[1].as_real();
 	obj->SetDirectionAngle(angle);
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetAcceleration(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_SetAcceleration(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 	ref_count_ptr<StgMovePattern_Angle>::unsync pattern = ref_count_ptr<StgMovePattern_Angle>::unsync::DownCast(obj->GetPattern());
-	if(pattern == NULL)
-	{
+	if (pattern == NULL) {
 		pattern = new StgMovePattern_Angle(obj);
 		obj->SetPattern(pattern);
 	}
@@ -2417,16 +2376,15 @@ gstd::value StgStageScript::Func_ObjMove_SetAcceleration(gstd::script_machine* m
 	pattern->SetAcceleration(param);
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetAngularVelocity(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_SetAngularVelocity(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
-	ref_count_ptr<StgMovePattern_Angle>::unsync pattern = 
-		ref_count_ptr<StgMovePattern_Angle>::unsync::DownCast(obj->GetPattern());
-	if(pattern == NULL)
-	{
+	if (obj == NULL)
+		return value();
+	ref_count_ptr<StgMovePattern_Angle>::unsync pattern = ref_count_ptr<StgMovePattern_Angle>::unsync::DownCast(obj->GetPattern());
+	if (pattern == NULL) {
 		pattern = new StgMovePattern_Angle(obj);
 		obj->SetPattern(pattern);
 	}
@@ -2435,16 +2393,15 @@ gstd::value StgStageScript::Func_ObjMove_SetAngularVelocity(gstd::script_machine
 	pattern->SetAngularVelocity(param);
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetMaxSpeed(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_SetMaxSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
-	ref_count_ptr<StgMovePattern_Angle>::unsync pattern =
-		ref_count_ptr<StgMovePattern_Angle>::unsync::DownCast(obj->GetPattern());
-	if(pattern == NULL)
-	{
+	if (obj == NULL)
+		return value();
+	ref_count_ptr<StgMovePattern_Angle>::unsync pattern = ref_count_ptr<StgMovePattern_Angle>::unsync::DownCast(obj->GetPattern());
+	if (pattern == NULL) {
 		pattern = new StgMovePattern_Angle(obj);
 		obj->SetPattern(pattern);
 	}
@@ -2454,69 +2411,73 @@ gstd::value StgStageScript::Func_ObjMove_SetMaxSpeed(gstd::script_machine* machi
 	return value();
 }
 
-gstd::value StgStageScript::Func_ObjMove_SetDestAtSpeed(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_SetDestAtSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double tx = argv[1].as_real();
 	double ty = argv[2].as_real();
 	double speed = argv[3].as_real();
-	
+
 	ref_count_ptr<StgMovePattern_Line>::unsync pattern = new StgMovePattern_Line(obj);
 	pattern->SetAtSpeed(tx, ty, speed);
 	obj->SetPattern(pattern);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetDestAtFrame(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_SetDestAtFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double tx = argv[1].as_real();
 	double ty = argv[2].as_real();
 	int frame = (int)argv[3].as_real();
-	
+
 	ref_count_ptr<StgMovePattern_Line>::unsync pattern = new StgMovePattern_Line(obj);
 	pattern->SetAtFrame(tx, ty, frame);
 	obj->SetPattern(pattern);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetDestAtWeight(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_SetDestAtWeight(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double tx = argv[1].as_real();
 	double ty = argv[2].as_real();
 	double weight = argv[3].as_real();
 	double maxSpeed = argv[4].as_real();
-	
+
 	ref_count_ptr<StgMovePattern_Line>::unsync pattern = new StgMovePattern_Line(obj);
 	pattern->SetAtWait(tx, ty, weight, maxSpeed);
 	obj->SetPattern(pattern);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_AddPatternA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_AddPatternA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int frame = (int)argv[1].as_real();
 	double speed = argv[2].as_real();
 	double angle = argv[3].as_real();
-	
+
 	ref_count_ptr<StgMovePattern_Angle>::unsync pattern = new StgMovePattern_Angle(obj);
 	pattern->SetSpeed(speed);
 	pattern->SetDirectionAngle(angle);
@@ -2524,12 +2485,13 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternA1(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_AddPatternA2(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_AddPatternA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int frame = (int)argv[1].as_real();
 	double speed = argv[2].as_real();
@@ -2548,12 +2510,13 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternA2(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_AddPatternA3(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_AddPatternA3(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int frame = (int)argv[1].as_real();
 	double speed = argv[2].as_real();
@@ -2574,12 +2537,13 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternA3(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_AddPatternA4(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_AddPatternA4(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int frame = (int)argv[1].as_real();
 	double speed = argv[2].as_real();
@@ -2602,12 +2566,13 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternA4(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_AddPatternB1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_AddPatternB1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int frame = (int)argv[1].as_real();
 	double speedX = argv[2].as_real();
@@ -2620,12 +2585,13 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternB1(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_AddPatternB2(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_AddPatternB2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int frame = (int)argv[1].as_real();
 	double speedX = argv[2].as_real();
@@ -2646,12 +2612,13 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternB2(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_AddPatternB3(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_AddPatternB3(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int frame = (int)argv[1].as_real();
 	double speedX = argv[2].as_real();
@@ -2674,49 +2641,53 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternB3(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_GetX(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_GetX(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return script->CreateRealValue(0);
+	if (obj == NULL)
+		return script->CreateRealValue(0);
 
 	double pos = obj->GetPositionX();
-	return value(machine->get_engine()->get_real_type(),(long double)pos);
+	return value(machine->get_engine()->get_real_type(), (long double)pos);
 }
-gstd::value StgStageScript::Func_ObjMove_GetY(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_GetY(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return script->CreateRealValue(0);
+	if (obj == NULL)
+		return script->CreateRealValue(0);
 
 	double pos = obj->GetPositionY();
-	return value(machine->get_engine()->get_real_type(),(long double)pos);
+	return value(machine->get_engine()->get_real_type(), (long double)pos);
 }
-gstd::value StgStageScript::Func_ObjMove_GetSpeed(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_GetSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value(machine->get_engine()->get_real_type(),(long double)0);
+	if (obj == NULL)
+		return value(machine->get_engine()->get_real_type(), (long double)0);
 
 	double speed = obj->GetSpeed();
-	return value(machine->get_engine()->get_real_type(),(long double)speed);
+	return value(machine->get_engine()->get_real_type(), (long double)speed);
 }
-gstd::value StgStageScript::Func_ObjMove_GetAngle(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjMove_GetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value(machine->get_engine()->get_real_type(),(long double)0);
+	if (obj == NULL)
+		return value(machine->get_engine()->get_real_type(), (long double)0);
 
 	double angle = obj->GetDirectionAngle();
-	return value(machine->get_engine()->get_real_type(),(long double)angle);
+	return value(machine->get_engine()->get_real_type(), (long double)angle);
 }
 
 //STG共通関数：敵オブジェクト操作
-gstd::value StgStageScript::Func_ObjEnemy_Create(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemy_Create(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2724,42 +2695,35 @@ gstd::value StgStageScript::Func_ObjEnemy_Create(gstd::script_machine* machine, 
 
 	int type = (int)argv[0].as_real();
 	ref_count_ptr<DxScriptObjectBase>::unsync obj;
-	if(type == OBJ_ENEMY)
-	{
+	if (type == OBJ_ENEMY) {
 		obj = new StgEnemyObject(stageController);
-	}
-	else if(type == OBJ_ENEMY_BOSS)
-	{
+	} else if (type == OBJ_ENEMY_BOSS) {
 		ref_count_ptr<StgEnemyBossSceneObject>::unsync objScene = enemyManager->GetBossSceneObject();
-		if(objScene == NULL)
-		{
+		if (objScene == NULL) {
 			throw gstd::wexception(L"EnemyBossSceneが作成されていません");
 		}
-		
+
 		ref_count_ptr<StgEnemyBossSceneData>::unsync data = objScene->GetActiveData();
 		int id = data->GetEnemyBossIdInCreate();
 		return value(machine->get_engine()->get_real_type(), (long double)id);
 	}
 
 	int id = ID_INVALID;
-	if(obj != NULL)
-	{
+	if (obj != NULL) {
 		obj->SetObjectManager(script->objManager_.GetPointer());
 		id = script->AddObject(obj, false);
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_ObjEnemy_Regist(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemy_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
 
-	ref_count_ptr<StgEnemyObject>::unsync objEnemy = 
-		ref_count_ptr<StgEnemyObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
-	if(objEnemy != NULL)
-	{
+	ref_count_ptr<StgEnemyObject>::unsync objEnemy = ref_count_ptr<StgEnemyObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
+	if (objEnemy != NULL) {
 		StgEnemyManager* enemyManager = stageController->GetEnemyManager();
 		enemyManager->AddEnemy(objEnemy);
 		objEnemy->Activate();
@@ -2769,70 +2733,70 @@ gstd::value StgStageScript::Func_ObjEnemy_Regist(gstd::script_machine* machine, 
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemy_GetInfo(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemy_GetInfo(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	int type = (int)argv[1].as_real();
 
 	StgEnemyObject* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)
-	{
-		switch(type)
-		{
-			case INFO_LIFE:
-			case INFO_DAMAGE_RATE_SHOT:
-			case INFO_DAMAGE_RATE_SPELL:
-			case INFO_SHOT_HIT_COUNT:
-				return value(machine->get_engine()->get_real_type(), (long double)0);
+	if (obj == NULL) {
+		switch (type) {
+		case INFO_LIFE:
+		case INFO_DAMAGE_RATE_SHOT:
+		case INFO_DAMAGE_RATE_SPELL:
+		case INFO_SHOT_HIT_COUNT:
+			return value(machine->get_engine()->get_real_type(), (long double)0);
 		}
 		return value();
 	}
 
-	switch(type)
-	{
-		case INFO_LIFE:
-			return value(machine->get_engine()->get_real_type(), (long double)obj->GetLife());
-		case INFO_DAMAGE_RATE_SHOT:
-			return value(machine->get_engine()->get_real_type(), (long double)obj->GetShotDamageRate());
-		case INFO_DAMAGE_RATE_SPELL:
-			return value(machine->get_engine()->get_real_type(), (long double)obj->GetSpellDamageRate());
-		case INFO_SHOT_HIT_COUNT:
-			return value(machine->get_engine()->get_real_type(), (long double)obj->GetIntersectedPlayerShotCount());
+	switch (type) {
+	case INFO_LIFE:
+		return value(machine->get_engine()->get_real_type(), (long double)obj->GetLife());
+	case INFO_DAMAGE_RATE_SHOT:
+		return value(machine->get_engine()->get_real_type(), (long double)obj->GetShotDamageRate());
+	case INFO_DAMAGE_RATE_SPELL:
+		return value(machine->get_engine()->get_real_type(), (long double)obj->GetSpellDamageRate());
+	case INFO_SHOT_HIT_COUNT:
+		return value(machine->get_engine()->get_real_type(), (long double)obj->GetIntersectedPlayerShotCount());
 	}
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemy_SetLife(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemy_SetLife(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgEnemyObject* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double param = argv[1].as_real();
 	obj->SetLife(param);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemy_AddLife(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemy_AddLife(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgEnemyObject* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double inc = argv[1].as_real();
 	obj->AddLife(inc);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemy_SetDamageRate(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemy_SetDamageRate(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgEnemyObject* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double rateShot = argv[1].as_real();
 	double rateSpell = argv[2].as_real();
@@ -2840,16 +2804,16 @@ gstd::value StgStageScript::Func_ObjEnemy_SetDamageRate(gstd::script_machine* ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemy_AddIntersectionCircleA(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemy_AddIntersectionCircleA(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 
 	int id = (int)argv[0].as_real();
-	ref_count_ptr<StgEnemyObject>::unsync obj =
-		ref_count_ptr<StgEnemyObject>::unsync::DownCast(script->GetObject(id));
-	if(obj == NULL)return value();
+	ref_count_ptr<StgEnemyObject>::unsync obj = ref_count_ptr<StgEnemyObject>::unsync::DownCast(script->GetObject(id));
+	if (obj == NULL)
+		return value();
 
 	int px = (int)argv[1].as_real();
 	int py = (int)argv[2].as_real();
@@ -2859,8 +2823,7 @@ gstd::value StgStageScript::Func_ObjEnemy_AddIntersectionCircleA(gstd::script_ma
 
 	//当たり判定
 	ref_count_weak_ptr<StgEnemyObject>::unsync wObj = obj;
-	ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = 
-		ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
+	ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
 	target->SetTargetType(StgIntersectionTarget::TYPE_ENEMY);
 	target->SetObject(wObj);
 	target->SetCircle(circle);
@@ -2868,16 +2831,16 @@ gstd::value StgStageScript::Func_ObjEnemy_AddIntersectionCircleA(gstd::script_ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToShot(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToShot(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 
 	int id = (int)argv[0].as_real();
-	ref_count_ptr<StgEnemyObject>::unsync obj =
-		ref_count_ptr<StgEnemyObject>::unsync::DownCast(script->GetObject(id));
-	if(obj == NULL)return value();
+	ref_count_ptr<StgEnemyObject>::unsync obj = ref_count_ptr<StgEnemyObject>::unsync::DownCast(script->GetObject(id));
+	if (obj == NULL)
+		return value();
 
 	int px = (int)argv[1].as_real();
 	int py = (int)argv[2].as_real();
@@ -2887,8 +2850,7 @@ gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToShot(gstd::scri
 
 	//当たり判定
 	ref_count_weak_ptr<StgEnemyObject>::unsync wObj = obj;
-	ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = 
-		ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
+	ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
 	target->SetTargetType(StgIntersectionTarget::TYPE_ENEMY);
 	target->SetObject(wObj);
 	target->SetCircle(circle);
@@ -2896,16 +2858,16 @@ gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToShot(gstd::scri
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToPlayer(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToPlayer(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 
 	int id = (int)argv[0].as_real();
-	ref_count_ptr<StgEnemyObject>::unsync obj =
-		ref_count_ptr<StgEnemyObject>::unsync::DownCast(script->GetObject(id));
-	if(obj == NULL)return value();
+	ref_count_ptr<StgEnemyObject>::unsync obj = ref_count_ptr<StgEnemyObject>::unsync::DownCast(script->GetObject(id));
+	if (obj == NULL)
+		return value();
 
 	int px = (int)argv[1].as_real();
 	int py = (int)argv[2].as_real();
@@ -2915,8 +2877,7 @@ gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToPlayer(gstd::sc
 
 	//当たり判定
 	ref_count_weak_ptr<StgEnemyObject>::unsync wObj = obj;
-	ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = 
-		ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
+	ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
 	target->SetTargetType(StgIntersectionTarget::TYPE_ENEMY);
 	target->SetObject(wObj);
 	target->SetCircle(circle);
@@ -2926,7 +2887,7 @@ gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToPlayer(gstd::sc
 }
 
 //STG共通関数：敵ボスシーンオブジェクト操作
-gstd::value StgStageScript::Func_ObjEnemyBossScene_Create(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemyBossScene_Create(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	script->CheckRunInMainThread();
@@ -2936,14 +2897,13 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_Create(gstd::script_machine* 
 	ref_count_ptr<DxScriptObjectBase>::unsync obj = new StgEnemyBossSceneObject(stageController);
 
 	int id = ID_INVALID;
-	if(obj != NULL)
-	{
+	if (obj != NULL) {
 		obj->SetObjectManager(script->objManager_.GetPointer());
 		id = script->AddObject(obj, false);
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_ObjEnemyBossScene_Regist(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemyBossScene_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2952,10 +2912,8 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_Regist(gstd::script_machine* 
 
 	StgEnemyManager* enemyManager = stageController->GetEnemyManager();
 
-	ref_count_ptr<StgEnemyBossSceneObject>::unsync objScene = 
-		ref_count_ptr<StgEnemyBossSceneObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
-	if(objScene != NULL)
-	{
+	ref_count_ptr<StgEnemyBossSceneObject>::unsync objScene = ref_count_ptr<StgEnemyBossSceneObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
+	if (objScene != NULL) {
 		enemyManager->SetBossSceneObject(objScene);
 		objScene->Activate();
 		script->ActivateObject(objScene->GetObjectID(), true);
@@ -2963,12 +2921,13 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_Regist(gstd::script_machine* 
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemyBossScene_Add(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemyBossScene_Add(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgEnemyBossSceneObject* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int step = (int)argv[1].as_real();
 	std::wstring path = argv[2].as_string();
@@ -2980,197 +2939,182 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_Add(gstd::script_machine* mac
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemyBossScene_LoadInThread(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemyBossScene_LoadInThread(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgEnemyBossSceneObject* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	obj->LoadAllScriptInThread();
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemyBossScene_GetInfo(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemyBossScene_GetInfo(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	int type = (int)argv[1].as_real();
 
 	StgEnemyBossSceneObject* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)
-	{
-		switch(type)
-		{
-			case INFO_IS_SPELL:
-			case INFO_IS_LAST_SPELL:
-			case INFO_IS_DURABLE_SPELL:
-			case INFO_IS_LAST_STEP:
-				return value(machine->get_engine()->get_boolean_type(), false);
-			case INFO_TIMER:
-			case INFO_TIMERF:
-			case INFO_ORGTIMERF:
-			case INFO_SPELL_SCORE:
-			case INFO_REMAIN_STEP_COUNT:
-			case INFO_ACTIVE_STEP_LIFE_COUNT:
-			case INFO_ACTIVE_STEP_TOTAL_MAX_LIFE:
-			case INFO_ACTIVE_STEP_TOTAL_LIFE:
-			case INFO_PLAYER_SHOOTDOWN_COUNT:
-			case INFO_PLAYER_SPELL_COUNT:
-			case INFO_CURRENT_LIFE:
-			case INFO_CURRENT_LIFE_MAX:
-				return value(machine->get_engine()->get_real_type(), (long double)0);
-			case INFO_ACTIVE_STEP_LIFE_RATE_LIST:
-				return script->CreateRealArrayValue(std::vector<long double>());
-
+	if (obj == NULL) {
+		switch (type) {
+		case INFO_IS_SPELL:
+		case INFO_IS_LAST_SPELL:
+		case INFO_IS_DURABLE_SPELL:
+		case INFO_IS_LAST_STEP:
+			return value(machine->get_engine()->get_boolean_type(), false);
+		case INFO_TIMER:
+		case INFO_TIMERF:
+		case INFO_ORGTIMERF:
+		case INFO_SPELL_SCORE:
+		case INFO_REMAIN_STEP_COUNT:
+		case INFO_ACTIVE_STEP_LIFE_COUNT:
+		case INFO_ACTIVE_STEP_TOTAL_MAX_LIFE:
+		case INFO_ACTIVE_STEP_TOTAL_LIFE:
+		case INFO_PLAYER_SHOOTDOWN_COUNT:
+		case INFO_PLAYER_SPELL_COUNT:
+		case INFO_CURRENT_LIFE:
+		case INFO_CURRENT_LIFE_MAX:
+			return value(machine->get_engine()->get_real_type(), (long double)0);
+		case INFO_ACTIVE_STEP_LIFE_RATE_LIST:
+			return script->CreateRealArrayValue(std::vector<long double>());
 		}
 		return value();
 	}
 
 	ref_count_ptr<StgEnemyBossSceneData>::unsync sceneData = obj->GetActiveData();
-	switch(type)
-	{
-		case INFO_IS_SPELL:
-		{
-			bool res = false;
-			if(sceneData != NULL)res = sceneData->IsSpellCard();
-				return value(machine->get_engine()->get_boolean_type(), res);
+	switch (type) {
+	case INFO_IS_SPELL: {
+		bool res = false;
+		if (sceneData != NULL)
+			res = sceneData->IsSpellCard();
+		return value(machine->get_engine()->get_boolean_type(), res);
+	}
+	case INFO_IS_LAST_SPELL: {
+		bool res = false;
+		if (sceneData != NULL)
+			res = sceneData->IsLastSpell();
+		return value(machine->get_engine()->get_boolean_type(), res);
+	}
+	case INFO_IS_DURABLE_SPELL: {
+		bool res = false;
+		if (sceneData != NULL)
+			res = sceneData->IsDurable();
+		return value(machine->get_engine()->get_boolean_type(), res);
+	}
+	case INFO_TIMER: {
+		long double res = 0;
+		if (sceneData != NULL) {
+			int timer = sceneData->GetSpellTimer();
+			if (timer < 0)
+				res = 99;
+			else
+				res = timer / STANDARD_FPS;
 		}
-		case INFO_IS_LAST_SPELL:
-		{
-			bool res = false;
-			if(sceneData != NULL)res = sceneData->IsLastSpell();
-				return value(machine->get_engine()->get_boolean_type(), res);
+		return script->CreateRealValue(res);
+	}
+	case INFO_TIMERF: {
+		long double res = 0;
+		if (sceneData != NULL) {
+			res = sceneData->GetSpellTimer();
 		}
-		case INFO_IS_DURABLE_SPELL:
-		{
-			bool res = false;
-			if(sceneData != NULL)res = sceneData->IsDurable();
-			return value(machine->get_engine()->get_boolean_type(), res);
+		return script->CreateRealValue(res);
+	}
+	case INFO_ORGTIMERF: {
+		long double res = 0;
+		if (sceneData != NULL) {
+			res = sceneData->GetOriginalSpellTimer();
 		}
-		case INFO_TIMER:
-		{
-			long double res = 0;
-			if(sceneData != NULL)
-			{
-				int timer = sceneData->GetSpellTimer();
-				if(timer < 0)res = 99;
-				else res = timer / STANDARD_FPS;
+		return script->CreateRealValue(res);
+	}
+	case INFO_SPELL_SCORE: {
+		long double res = 0;
+		if (sceneData != NULL) {
+			res = sceneData->GetCurrentSpellScore();
+		}
+		return script->CreateRealValue(res);
+	}
+	case INFO_REMAIN_STEP_COUNT:
+		return script->CreateRealValue(obj->GetRemainStepCount());
+	case INFO_ACTIVE_STEP_LIFE_COUNT:
+		return script->CreateRealValue(obj->GetActiveStepLifeCount());
+	case INFO_ACTIVE_STEP_TOTAL_MAX_LIFE:
+		return script->CreateRealValue(obj->GetActiveStepTotalMaxLife());
+	case INFO_ACTIVE_STEP_TOTAL_LIFE:
+		return script->CreateRealValue(obj->GetActiveStepTotalLife());
+	case INFO_ACTIVE_STEP_LIFE_RATE_LIST: {
+		std::vector<long double> listLD;
+		std::vector<double> listD = obj->GetActiveStepLifeRateList();
+		for (int iLife = 0; iLife < listD.size(); iLife++)
+			listLD.push_back(listD[iLife]);
+		return script->CreateRealArrayValue(listLD);
+	}
+	case INFO_IS_LAST_STEP: {
+		bool res = obj->GetRemainStepCount() == 0;
+		res &= (obj->GetActiveStepTotalLife() == 0);
+		return value(machine->get_engine()->get_boolean_type(), res);
+	}
+	case INFO_PLAYER_SHOOTDOWN_COUNT: {
+		long double res = 0;
+		if (sceneData != NULL)
+			res = sceneData->GetPlayerShootDownCount();
+		return script->CreateRealValue(res);
+	}
+	case INFO_PLAYER_SPELL_COUNT: {
+		long double res = 0;
+		if (sceneData != NULL)
+			res = sceneData->GetPlayerSpellCount();
+		return script->CreateRealValue(res);
+	}
+	case INFO_CURRENT_LIFE: {
+		long double res = 0;
+		if (sceneData != NULL) {
+			int dataIndex = obj->GetDataIndex();
+			res = obj->GetActiveStepLife(dataIndex);
+		}
+		return script->CreateRealValue(res);
+	}
+	case INFO_CURRENT_LIFE_MAX: {
+		long double res = 0;
+		if (sceneData != NULL) {
+			int dataIndex = obj->GetDataIndex();
+			std::vector<double>& listLife = sceneData->GetLifeList();
+			for (int iLife = 0; iLife < listLife.size(); iLife++) {
+				res += listLife[iLife];
 			}
-			return script->CreateRealValue(res);
 		}
-		case INFO_TIMERF:
-		{
-			long double res = 0;
-			if(sceneData != NULL)
-			{
-				res = sceneData->GetSpellTimer();
-			}
-			return script->CreateRealValue(res);
-		}
-		case INFO_ORGTIMERF:
-		{
-			long double res = 0;
-			if(sceneData != NULL)
-			{
-				res = sceneData->GetOriginalSpellTimer();
-			}
-			return script->CreateRealValue(res);
-		}
-		case INFO_SPELL_SCORE:
-		{
-			long double res = 0;
-			if(sceneData != NULL)
-			{
-				res = sceneData->GetCurrentSpellScore();
-			}
-			return script->CreateRealValue(res);
-		}
-		case INFO_REMAIN_STEP_COUNT:
-			return script->CreateRealValue(obj->GetRemainStepCount());
-		case INFO_ACTIVE_STEP_LIFE_COUNT:
-			return script->CreateRealValue(obj->GetActiveStepLifeCount());
-		case INFO_ACTIVE_STEP_TOTAL_MAX_LIFE:
-			return script->CreateRealValue(obj->GetActiveStepTotalMaxLife());
-		case INFO_ACTIVE_STEP_TOTAL_LIFE:
-			return script->CreateRealValue(obj->GetActiveStepTotalLife());
-		case INFO_ACTIVE_STEP_LIFE_RATE_LIST:
-		{
-			std::vector<long double> listLD;
-			std::vector<double> listD = obj->GetActiveStepLifeRateList();
-			for(int iLife = 0 ; iLife < listD.size() ; iLife++)
-				listLD.push_back(listD[iLife]);
-			return script->CreateRealArrayValue(listLD);
-		}
-		case INFO_IS_LAST_STEP:
-		{
-			bool res = obj->GetRemainStepCount() == 0;
-			res &= (obj->GetActiveStepTotalLife() == 0);
-			return value(machine->get_engine()->get_boolean_type(), res);
-		}
-		case INFO_PLAYER_SHOOTDOWN_COUNT:
-		{
-			long double res = 0;
-			if(sceneData != NULL)
-				res = sceneData->GetPlayerShootDownCount();
-			return script->CreateRealValue(res);
-		}
-		case INFO_PLAYER_SPELL_COUNT:
-		{
-			long double res = 0;
-			if(sceneData != NULL)
-				res = sceneData->GetPlayerSpellCount();
-			return script->CreateRealValue(res);
-		}
-		case INFO_CURRENT_LIFE:
-		{
-			long double res = 0;
-			if(sceneData != NULL)
-			{
-				int dataIndex = obj->GetDataIndex();
-				res = obj->GetActiveStepLife(dataIndex);
-			}
-			return script->CreateRealValue(res);
-		}
-		case INFO_CURRENT_LIFE_MAX:
-		{
-			long double res = 0;
-			if(sceneData != NULL)
-			{
-				int dataIndex = obj->GetDataIndex();
-				std::vector<double>& listLife = sceneData->GetLifeList();
-				for(int iLife = 0 ; iLife < listLife.size(); iLife++)
-				{
-					res += listLife[iLife];
-				}
-			}
-			return script->CreateRealValue(res);
-		}
-
+		return script->CreateRealValue(res);
+	}
 	}
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemyBossScene_SetSpellTimer(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemyBossScene_SetSpellTimer(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgEnemyBossSceneObject* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 	ref_count_ptr<StgEnemyBossSceneData>::unsync sceneData = obj->GetActiveData();
-	if(sceneData == NULL)return value();
+	if (sceneData == NULL)
+		return value();
 
 	int timer = (int)argv[1].as_real();
 	sceneData->SetSpellTimer(timer);
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemyBossScene_StartSpell(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjEnemyBossScene_StartSpell(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgEnemyBossSceneObject* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 	ref_count_ptr<StgEnemyBossSceneData>::unsync sceneData = obj->GetActiveData();
-	if(sceneData == NULL)return value();
+	if (sceneData == NULL)
+		return value();
 
 	sceneData->SetSpellCard(true);
 	ScriptManager* scriptManager = script->scriptManager_;
@@ -3179,7 +3123,7 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_StartSpell(gstd::script_machi
 }
 
 //STG共通関数：弾オブジェクト操作
-gstd::value StgStageScript::Func_ObjShot_Create(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_Create(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	script->CheckRunInMainThread();
@@ -3187,28 +3131,19 @@ gstd::value StgStageScript::Func_ObjShot_Create(gstd::script_machine* machine, i
 
 	int type = (int)argv[0].as_real();
 	ref_count_ptr<StgShotObject>::unsync obj;
-	if(type == OBJ_SHOT)
-	{
+	if (type == OBJ_SHOT) {
 		obj = new StgNormalShotObject(stageController);
-	}
-	else if(type == OBJ_LOOSE_LASER)
-	{
+	} else if (type == OBJ_LOOSE_LASER) {
 		obj = new StgLooseLaserObject(stageController);
-	}
-	else if(type == OBJ_STRAIGHT_LASER)
-	{
+	} else if (type == OBJ_STRAIGHT_LASER) {
 		obj = new StgStraightLaserObject(stageController);
-	}
-	else if(type == OBJ_CURVE_LASER)
-	{
+	} else if (type == OBJ_CURVE_LASER) {
 		obj = new StgCurveLaserObject(stageController);
 	}
 
 	int id = ID_INVALID;
-	if(obj != NULL)
-	{
-		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? 
-			StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
+	if (obj != NULL) {
+		int typeOwner = script->GetScriptType() == TYPE_PLAYER ? StgShotObject::OWNER_PLAYER : StgShotObject::OWNER_ENEMY;
 		obj->SetOwnerType(typeOwner);
 
 		obj->SetObjectManager(script->objManager_.GetPointer());
@@ -3216,21 +3151,19 @@ gstd::value StgStageScript::Func_ObjShot_Create(gstd::script_machine* machine, i
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_ObjShot_Regist(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
 
-	ref_count_ptr<StgShotObject>::unsync objShot =
-		ref_count_ptr<StgShotObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
-	if(objShot != NULL)
-	{
-		if(script->GetScriptType() == TYPE_PLAYER)
-		{
+	ref_count_ptr<StgShotObject>::unsync objShot = ref_count_ptr<StgShotObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
+	if (objShot != NULL) {
+		if (script->GetScriptType() == TYPE_PLAYER) {
 			ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController->GetPlayerObject();
-			if(objPlayer != NULL && !objPlayer->IsPermitShot())return value();
+			if (objPlayer != NULL && !objPlayer->IsPermitShot())
+				return value();
 		}
 
 		StgShotManager* shotManager = stageController->GetShotManager();
@@ -3243,47 +3176,51 @@ gstd::value StgStageScript::Func_ObjShot_Regist(gstd::script_machine* machine, i
 	return value();
 }
 
-gstd::value StgStageScript::Func_ObjShot_SetAutoDelete(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetAutoDelete(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	bool bAutoDelete = argv[1].as_boolean();
 	obj->SetAutoDelete(bAutoDelete);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_FadeDelete(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_FadeDelete(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	obj->SetFadeDelete();
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetDeleteFrame(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetDeleteFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int frame = (int)argv[1].as_real();
 	obj->SetAutoDeleteFrame(frame);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetDelay(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetDelay(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int delay = (int)argv[1].as_real();
 	obj->SetDelay(delay);
@@ -3291,129 +3228,136 @@ gstd::value StgStageScript::Func_ObjShot_SetDelay(gstd::script_machine* machine,
 	return value();
 }
 
-gstd::value StgStageScript::Func_ObjShot_SetSpellResist(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetSpellResist(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	bool bRegist = argv[1].as_boolean();
 	double life = obj->GetLife();
-	if(bRegist)
-	{
+	if (bRegist) {
 		life = StgShotObject::LIFE_SPELL_REGIST;
-	}
-	else
-	{
-		if(life >= StgShotObject::LIFE_SPELL_UNREGIST)
+	} else {
+		if (life >= StgShotObject::LIFE_SPELL_UNREGIST)
 			life = StgShotObject::LIFE_SPELL_UNREGIST;
 	}
 	obj->SetLife(life);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetGraphic(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetGraphic(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int grf = (int)argv[1].as_real();
 	obj->SetShotDataID(grf);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetSourceBlendType(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetSourceBlendType(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int typeBlend = (int)argv[1].as_real();
 	obj->SetSourceBlendType(typeBlend);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetDamage(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetDamage(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double damage = argv[1].as_real();
 	obj->SetDamage(damage);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetPenetration(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetPenetration(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double life = argv[1].as_real();
 	obj->SetLife(life);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetEraseShot(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetEraseShot(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	bool bErase = argv[1].as_boolean();
 	obj->SetEraseShot(bErase);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetSpellFactor(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetSpellFactor(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	bool bErase = argv[1].as_boolean();
 	obj->SetSpellFactor(bErase);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_ToItem(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_ToItem(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	obj->ConvertToItem();
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_AddShotA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_AddShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int idShot = (int)argv[1].as_real();
 	int frame = (int)argv[2].as_real();
 	obj->AddShot(frame, idShot, 0, 0);
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_AddShotA2(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_AddShotA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int idShot = (int)argv[1].as_real();
 	int frame = (int)argv[2].as_real();
@@ -3422,18 +3366,19 @@ gstd::value StgStageScript::Func_ObjShot_AddShotA2(gstd::script_machine* machine
 	obj->AddShot(frame, idShot, radius, angle);
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
 	ref_count_ptr<StgShotObject>::unsync obj = ref_count_ptr<StgShotObject>::unsync::DownCast(script->GetObject(id));
-	if(obj == NULL)return value();
-	if(obj->GetDelay() > 0)return value();
+	if (obj == NULL)
+		return value();
+	if (obj->GetDelay() > 0)
+		return value();
 
 	obj->SetUserIntersectionMode(true);
-	int typeTarget = obj->GetOwnerType() == StgShotObject::OWNER_PLAYER ? 
-		StgIntersectionTarget::TYPE_PLAYER_SHOT : StgIntersectionTarget::TYPE_ENEMY_SHOT;
+	int typeTarget = obj->GetOwnerType() == StgShotObject::OWNER_PLAYER ? StgIntersectionTarget::TYPE_PLAYER_SHOT : StgIntersectionTarget::TYPE_ENEMY_SHOT;
 
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 	int px = (int)obj->GetPositionX();
@@ -3443,8 +3388,7 @@ gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA1(gstd::script_ma
 	ref_count_weak_ptr<StgShotObject>::unsync wObj = obj;
 
 	//当たり判定
-	ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = 
-		ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
+	ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
 	target->SetTargetType(typeTarget);
 	target->SetCircle(circle);
 	target->SetObject(wObj);
@@ -3453,18 +3397,19 @@ gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA1(gstd::script_ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA2(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
 	ref_count_ptr<StgShotObject>::unsync obj = ref_count_ptr<StgShotObject>::unsync::DownCast(script->GetObject(id));
-	if(obj == NULL)return value();
-	if(obj->GetDelay() > 0)return value();
+	if (obj == NULL)
+		return value();
+	if (obj->GetDelay() > 0)
+		return value();
 
 	obj->SetUserIntersectionMode(true);
-	int typeTarget = obj->GetOwnerType() == StgShotObject::OWNER_PLAYER ? 
-		StgIntersectionTarget::TYPE_PLAYER_SHOT : StgIntersectionTarget::TYPE_ENEMY_SHOT;
+	int typeTarget = obj->GetOwnerType() == StgShotObject::OWNER_PLAYER ? StgIntersectionTarget::TYPE_PLAYER_SHOT : StgIntersectionTarget::TYPE_ENEMY_SHOT;
 
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 	int px = (int)argv[1].as_real();
@@ -3474,8 +3419,7 @@ gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA2(gstd::script_ma
 	ref_count_weak_ptr<StgShotObject>::unsync wObj = obj;
 
 	//当たり判定
-	ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = 
-		ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
+	ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
 	target->SetTargetType(typeTarget);
 	target->SetCircle(circle);
 	target->SetObject(wObj);
@@ -3484,19 +3428,20 @@ gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA2(gstd::script_ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
 	ref_count_ptr<StgShotObject>::unsync obj = ref_count_ptr<StgShotObject>::unsync::DownCast(script->GetObject(id));
-	if(obj == NULL)return value();
-	if(obj->GetDelay() > 0)return value();
+	if (obj == NULL)
+		return value();
+	if (obj->GetDelay() > 0)
+		return value();
 
 	obj->SetUserIntersectionMode(true);
-	int typeTarget = obj->GetOwnerType() == StgShotObject::OWNER_PLAYER ? 
-		StgIntersectionTarget::TYPE_PLAYER_SHOT : StgIntersectionTarget::TYPE_ENEMY_SHOT;
+	int typeTarget = obj->GetOwnerType() == StgShotObject::OWNER_PLAYER ? StgIntersectionTarget::TYPE_PLAYER_SHOT : StgIntersectionTarget::TYPE_ENEMY_SHOT;
 
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 	int px1 = (int)argv[1].as_real();
@@ -3508,8 +3453,7 @@ gstd::value StgStageScript::Func_ObjShot_SetIntersectionLine(gstd::script_machin
 
 	//当たり判定
 	ref_count_weak_ptr<StgShotObject>::unsync wObjShot = obj;
-	ref_count_ptr<StgIntersectionTarget_Line>::unsync target = 
-		ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_LINE));
+	ref_count_ptr<StgIntersectionTarget_Line>::unsync target = ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_LINE));
 	target->SetTargetType(typeTarget);
 	target->SetObject(wObjShot);
 	target->SetLine(line);
@@ -3518,26 +3462,28 @@ gstd::value StgStageScript::Func_ObjShot_SetIntersectionLine(gstd::script_machin
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetIntersectionEnable(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetIntersectionEnable(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	bool bEnable = argv[1].as_boolean();
 	obj->SetIntersectionEnable(bEnable);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetItemChange(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_SetItemChange(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	bool bEnable = argv[1].as_boolean();
 	obj->SetItemChangeEnable(bEnable);
@@ -3545,106 +3491,114 @@ gstd::value StgStageScript::Func_ObjShot_SetItemChange(gstd::script_machine* mac
 	return value();
 }
 
-gstd::value StgStageScript::Func_ObjShot_GetDelay(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_GetDelay(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int res = obj->GetDelay();
-	return value(machine->get_engine()->get_real_type(),(long double)res);
+	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_ObjShot_GetDamage(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_GetDamage(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int res = obj->GetDamage();
-	return value(machine->get_engine()->get_real_type(),(long double)res);
+	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_ObjShot_GetPenetration(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_GetPenetration(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int res = obj->GetLife();
-	return value(machine->get_engine()->get_real_type(),(long double)res);
+	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_ObjShot_IsSpellResist(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_IsSpellResist(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	bool res = obj->GetLife() == StgShotObject::LIFE_SPELL_REGIST;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
 
-gstd::value StgStageScript::Func_ObjShot_GetImageID(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjShot_GetImageID(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
 	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int res = obj->GetShotDataID();
-	return value(machine->get_engine()->get_real_type(),(long double)res);
+	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 
-
-gstd::value StgStageScript::Func_ObjLaser_SetLength(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjLaser_SetLength(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int length = (int)argv[1].as_real();
 	obj->SetLength(length);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjLaser_SetRenderWidth(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjLaser_SetRenderWidth(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int width = (int)argv[1].as_real();
 	obj->SetRenderWidth(width);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjLaser_SetIntersectionWidth(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjLaser_SetIntersectionWidth(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
-	int width = (int)argv[1].as_real()/2;
+	int width = (int)argv[1].as_real() / 2;
 	obj->SetIntersectionWidth(width);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjLaser_SetInvalidLength(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjLaser_SetInvalidLength(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int start = (int)argv[1].as_real();
 	int end = (int)argv[2].as_real();
@@ -3652,100 +3606,109 @@ gstd::value StgStageScript::Func_ObjLaser_SetInvalidLength(gstd::script_machine*
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjLaser_SetGrazeInvalidFrame(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjLaser_SetGrazeInvalidFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int frame = (int)argv[1].as_real();
 	obj->SetGrazeInvalidFrame(frame);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjLaser_SetItemDistance(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjLaser_SetItemDistance(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double dist = argv[1].as_real();
 	obj->SetItemDistance(dist);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjLaser_GetLength(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjLaser_GetLength(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return script->CreateRealValue(0);
+	if (obj == NULL)
+		return script->CreateRealValue(0);
 
 	int length = obj->GetLength();
-	return value(machine->get_engine()->get_real_type(),(long double)length);
+	return value(machine->get_engine()->get_real_type(), (long double)length);
 }
-gstd::value StgStageScript::Func_ObjLaser_GetRenderWidth(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjLaser_GetRenderWidth(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return script->CreateRealValue(0);
+	if (obj == NULL)
+		return script->CreateRealValue(0);
 
 	int width = obj->GetRenderWidth();
-	return value(machine->get_engine()->get_real_type(),(long double)width);
+	return value(machine->get_engine()->get_real_type(), (long double)width);
 }
-gstd::value StgStageScript::Func_ObjLaser_GetIntersectionWidth(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjLaser_GetIntersectionWidth(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return script->CreateRealValue(0);
+	if (obj == NULL)
+		return script->CreateRealValue(0);
 
 	int width = obj->GetIntersectionWidth();
-	return value(machine->get_engine()->get_real_type(),(long double)width);
+	return value(machine->get_engine()->get_real_type(), (long double)width);
 }
-gstd::value StgStageScript::Func_ObjStLaser_SetAngle(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjStLaser_SetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgStraightLaserObject* obj = dynamic_cast<StgStraightLaserObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double angle = argv[1].as_real();
 	obj->SetLaserAngle(angle);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjStLaser_GetAngle(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjStLaser_GetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgStraightLaserObject* obj = dynamic_cast<StgStraightLaserObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return script->CreateRealValue(0);
+	if (obj == NULL)
+		return script->CreateRealValue(0);
 
 	double angle = obj->GetLaserAngle();
-	return value(machine->get_engine()->get_real_type(),(long double)angle);
+	return value(machine->get_engine()->get_real_type(), (long double)angle);
 }
-gstd::value StgStageScript::Func_ObjStLaser_SetSource(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjStLaser_SetSource(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgStraightLaserObject* obj = dynamic_cast<StgStraightLaserObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	bool bEnable = argv[1].as_boolean();
 	obj->SetSourceEnable(bEnable);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjCrLaser_SetTipDecrement(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjCrLaser_SetTipDecrement(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgCurveLaserObject* obj = dynamic_cast<StgCurveLaserObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	double dec = argv[1].as_real();
 	dec = min(dec, 1);
@@ -3756,7 +3719,7 @@ gstd::value StgStageScript::Func_ObjCrLaser_SetTipDecrement(gstd::script_machine
 }
 
 //STG共通関数：アイテムオブジェクト操作
-gstd::value StgStageScript::Func_ObjItem_Create(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjItem_Create(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	script->CheckRunInMainThread();
@@ -3764,30 +3727,26 @@ gstd::value StgStageScript::Func_ObjItem_Create(gstd::script_machine* machine, i
 
 	int type = (int)argv[0].as_real();
 	ref_count_ptr<StgItemObject>::unsync obj;
-	if(type == StgItemObject::ITEM_USER)
-	{
+	if (type == StgItemObject::ITEM_USER) {
 		obj = new StgItemObject_User(stageController);
 	}
 
 	int id = ID_INVALID;
-	if(obj != NULL)
-	{
+	if (obj != NULL) {
 		obj->SetObjectManager(script->objManager_.GetPointer());
 		id = script->AddObject(obj, false);
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_ObjItem_Regist(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjItem_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
 
-	ref_count_ptr<StgItemObject>::unsync objItem =
-		ref_count_ptr<StgItemObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
-	if(objItem != NULL)
-	{
+	ref_count_ptr<StgItemObject>::unsync objItem = ref_count_ptr<StgItemObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
+	if (objItem != NULL) {
 		StgItemManager* itemManager = stageController->GetItemManager();
 		itemManager->AddItem(objItem);
 		objItem->Activate();
@@ -3797,48 +3756,52 @@ gstd::value StgStageScript::Func_ObjItem_Regist(gstd::script_machine* machine, i
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjItem_SetItemID(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjItem_SetItemID(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgItemObject_User* obj = dynamic_cast<StgItemObject_User*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int grf = (int)argv[1].as_real();
 	obj->SetImageID(grf);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjItem_SetRenderScoreEnable(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjItem_SetRenderScoreEnable(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgItemObject* obj = dynamic_cast<StgItemObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	bool bEnable = (bool)argv[1].as_boolean();
 	obj->SetChangeItemScore(bEnable);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjItem_SetAutoCollectEnable(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjItem_SetAutoCollectEnable(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgItemObject* obj = dynamic_cast<StgItemObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	bool bEnable = (bool)argv[1].as_boolean();
 	obj->SetPermitMoveToPlayer(bEnable);
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjItem_SetDefinedMovePatternA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjItem_SetDefinedMovePatternA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	StgItemObject* obj = dynamic_cast<StgItemObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)return value();
+	if (obj == NULL)
+		return value();
 
 	int type = (int)argv[1].as_real();
 	ref_count_ptr<StgMovePattern_Item>::unsync move = new StgMovePattern_Item(obj);
@@ -3847,40 +3810,37 @@ gstd::value StgStageScript::Func_ObjItem_SetDefinedMovePatternA1(gstd::script_ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjItem_GetInfo(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjItem_GetInfo(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	int type = (int)argv[1].as_real();
 
 	StgItemObject* obj = dynamic_cast<StgItemObject*>(script->GetObjectPointer(id));
-	if(obj == NULL)
-	{
-		switch(type)
-		{
-			case INFO_ITEM_SCORE:
-				return value(machine->get_engine()->get_real_type(), (long double)0);
+	if (obj == NULL) {
+		switch (type) {
+		case INFO_ITEM_SCORE:
+			return value(machine->get_engine()->get_real_type(), (long double)0);
 		}
 		return value();
 	}
 
-	switch(type)
-	{
-		case INFO_ITEM_SCORE:
-			return value(machine->get_engine()->get_real_type(), (long double)obj->GetScore());
+	switch (type) {
+	case INFO_ITEM_SCORE:
+		return value(machine->get_engine()->get_real_type(), (long double)obj->GetScore());
 	}
 
 	return value();
 }
 
 //STG共通関数：自機オブジェクト操作
-gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	ref_count_ptr<StgPlayerObject>::unsync obj = 
-		ref_count_ptr<StgPlayerObject>::unsync::DownCast(script->GetObject(id));
-	if(obj == NULL)return value();
+	ref_count_ptr<StgPlayerObject>::unsync obj = ref_count_ptr<StgPlayerObject>::unsync::DownCast(script->GetObject(id));
+	if (obj == NULL)
+		return value();
 
 	int px = (int)argv[1].as_real();
 	int py = (int)argv[2].as_real();
@@ -3905,13 +3865,13 @@ gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA1(gstd::script_
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA2(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	ref_count_ptr<StgPlayerObject>::unsync obj = 
-		ref_count_ptr<StgPlayerObject>::unsync::DownCast(script->GetObject(id));
-	if(obj == NULL)return value();
+	ref_count_ptr<StgPlayerObject>::unsync obj = ref_count_ptr<StgPlayerObject>::unsync::DownCast(script->GetObject(id));
+	if (obj == NULL)
+		return value();
 
 	int px = (int)argv[1].as_real();
 	int py = (int)argv[2].as_real();
@@ -3929,67 +3889,66 @@ gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA2(gstd::script_
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjPlayer_ClearIntersection(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjPlayer_ClearIntersection(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	ref_count_ptr<StgPlayerObject>::unsync obj = 
-		ref_count_ptr<StgPlayerObject>::unsync::DownCast(script->GetObject(id));
-	if(obj == NULL)return value();
+	ref_count_ptr<StgPlayerObject>::unsync obj = ref_count_ptr<StgPlayerObject>::unsync::DownCast(script->GetObject(id));
+	if (obj == NULL)
+		return value();
 	obj->ClearIntersectionRelativeTarget();
 
 	return value();
 }
 
 //STG共通関数：当たり判定オブジェクト操作
-gstd::value StgStageScript::Func_ObjCol_IsIntersected(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjCol_IsIntersected(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	DxScriptObjectBase* objBase = dynamic_cast<DxScriptObjectBase*>(script->GetObjectPointer(id));
-	if(objBase == NULL)return value();
+	if (objBase == NULL)
+		return value();
 
-	ref_count_ptr<StgIntersectionObject>::unsync obj = 
-		ref_count_ptr<StgIntersectionObject>::unsync::DownCast(script->GetObject(id));
-	if(obj == NULL)return value();
-	
+	ref_count_ptr<StgIntersectionObject>::unsync obj = ref_count_ptr<StgIntersectionObject>::unsync::DownCast(script->GetObject(id));
+	if (obj == NULL)
+		return value();
+
 	bool res = obj->IsIntersected();
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStageScript::Func_ObjCol_GetListOfIntersectedEnemyID(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjCol_GetListOfIntersectedEnemyID(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	DxScriptObjectBase* objBase = dynamic_cast<DxScriptObjectBase*>(script->GetObjectPointer(id));
-	if(objBase == NULL)return value();
+	if (objBase == NULL)
+		return value();
 
-	ref_count_ptr<StgIntersectionObject>::unsync obj = 
-		ref_count_ptr<StgIntersectionObject>::unsync::DownCast(script->GetObject(id));
-	if(obj == NULL)return value();
-	
+	ref_count_ptr<StgIntersectionObject>::unsync obj = ref_count_ptr<StgIntersectionObject>::unsync::DownCast(script->GetObject(id));
+	if (obj == NULL)
+		return value();
+
 	std::vector<int>& list = obj->GetIntersectedIdList();
 	std::vector<long double> listLD;
-	for(int iList = 0 ; iList < list.size() ; iList++)
-	{
+	for (int iList = 0; iList < list.size(); iList++) {
 		int idObject = list[iList];
-		ref_count_ptr<StgEnemyObject>::unsync objEnemy = 
-			ref_count_ptr<StgEnemyObject>::unsync::DownCast(script->GetObject(idObject));
-		if(objEnemy != NULL)
+		ref_count_ptr<StgEnemyObject>::unsync objEnemy = ref_count_ptr<StgEnemyObject>::unsync::DownCast(script->GetObject(idObject));
+		if (objEnemy != NULL)
 			listLD.push_back(idObject);
 	}
 
 	gstd::value res = script->CreateRealArrayValue(listLD);
 	return res;
 }
-gstd::value StgStageScript::Func_ObjCol_GetIntersectedCount(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageScript::Func_ObjCol_GetIntersectedCount(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	ref_count_ptr<StgIntersectionObject>::unsync obj = 
-		ref_count_ptr<StgIntersectionObject>::unsync::DownCast(script->GetObject(id));
-	if(obj == NULL)
+	ref_count_ptr<StgIntersectionObject>::unsync obj = ref_count_ptr<StgIntersectionObject>::unsync::DownCast(script->GetObject(id));
+	if (obj == NULL)
 		return value(machine->get_engine()->get_real_type(), (long double)0);
-	
+
 	std::vector<int>& list = obj->GetIntersectedIdList();
 	long double res = list.size();
 	return value(machine->get_engine()->get_real_type(), res);
@@ -3998,15 +3957,14 @@ gstd::value StgStageScript::Func_ObjCol_GetIntersectedCount(gstd::script_machine
 /**********************************************************
 //StgSystemScript
 **********************************************************/
-function const stgSystemFunction[] =  
-{
+function const stgSystemFunction[] = {
 	//関数：
 
-
 	//定数
-	{"__stgSystemFunction__",constant<0>::func, 0},
+	{ "__stgSystemFunction__", constant<0>::func, 0 },
 };
-StgStageSystemScript::StgStageSystemScript(StgStageController* stageController) : StgStageScript(stageController)
+StgStageSystemScript::StgStageSystemScript(StgStageController* stageController)
+	: StgStageScript(stageController)
 {
 	typeScript_ = TYPE_SYSTEM;
 	_AddFunction(stgSystemFunction, sizeof(stgSystemFunction) / sizeof(function));
@@ -4018,15 +3976,15 @@ StgStageSystemScript::~StgStageSystemScript()
 /**********************************************************
 //StgStageItemScript
 **********************************************************/
-function const stgItemFunction[] =  
-{
+function const stgItemFunction[] = {
 	//定数
-	{"EV_GET_ITEM", constant<StgStageItemScript::EV_GET_ITEM>::func, 0},
-	{"EV_DELETE_SHOT_TO_ITEM", constant<StgStageItemScript::EV_DELETE_SHOT_TO_ITEM>::func, 0},
+	{ "EV_GET_ITEM", constant<StgStageItemScript::EV_GET_ITEM>::func, 0 },
+	{ "EV_DELETE_SHOT_TO_ITEM", constant<StgStageItemScript::EV_DELETE_SHOT_TO_ITEM>::func, 0 },
 
-	{"EV_GRAZE", constant<StgStagePlayerScript::EV_GRAZE>::func, 0},
+	{ "EV_GRAZE", constant<StgStagePlayerScript::EV_GRAZE>::func, 0 },
 };
-StgStageItemScript::StgStageItemScript(StgStageController* stageController) : StgStageScript(stageController)
+StgStageItemScript::StgStageItemScript(StgStageController* stageController)
+	: StgStageScript(stageController)
 {
 	typeScript_ = TYPE_ITEM;
 	_AddFunction(stgItemFunction, sizeof(stgItemFunction) / sizeof(function));
@@ -4038,16 +3996,16 @@ StgStageItemScript::~StgStageItemScript()
 /**********************************************************
 //StgStageShotScript
 **********************************************************/
-function const stgShotFunction[] =  
-{
+function const stgShotFunction[] = {
 	//定数
-	{"EV_DELETE_SHOT_IMMEDIATE", constant<StgStageScript::EV_DELETE_SHOT_IMMEDIATE>::func, 0},
-	{"EV_DELETE_SHOT_TO_ITEM", constant<StgStageScript::EV_DELETE_SHOT_TO_ITEM>::func, 0},
-	{"EV_DELETE_SHOT_FADE", constant<StgStageScript::EV_DELETE_SHOT_FADE>::func, 0},
+	{ "EV_DELETE_SHOT_IMMEDIATE", constant<StgStageScript::EV_DELETE_SHOT_IMMEDIATE>::func, 0 },
+	{ "EV_DELETE_SHOT_TO_ITEM", constant<StgStageScript::EV_DELETE_SHOT_TO_ITEM>::func, 0 },
+	{ "EV_DELETE_SHOT_FADE", constant<StgStageScript::EV_DELETE_SHOT_FADE>::func, 0 },
 
-	{"SetShotDeleteEventEnable", StgStageShotScript::Func_SetShotDeleteEventEnable, 2},
+	{ "SetShotDeleteEventEnable", StgStageShotScript::Func_SetShotDeleteEventEnable, 2 },
 };
-StgStageShotScript::StgStageShotScript(StgStageController* stageController) : StgStageScript(stageController)
+StgStageShotScript::StgStageShotScript(StgStageController* stageController)
+	: StgStageScript(stageController)
 {
 	typeScript_ = TYPE_SHOT;
 	_AddFunction(stgShotFunction, sizeof(stgShotFunction) / sizeof(function));
@@ -4056,7 +4014,7 @@ StgStageShotScript::~StgStageShotScript()
 {
 }
 
-gstd::value StgStageShotScript::Func_SetShotDeleteEventEnable(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStageShotScript::Func_SetShotDeleteEventEnable(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStageShotScript* script = (StgStageShotScript*)machine->data;
 	int type = (int)argv[0].as_real();
@@ -4072,32 +4030,32 @@ gstd::value StgStageShotScript::Func_SetShotDeleteEventEnable(gstd::script_machi
 /**********************************************************
 //StgPlayerScript
 **********************************************************/
-function const stgPlayerFunction[] =  
-{
+function const stgPlayerFunction[] = {
 	//関数：
-	{"CreatePlayerShotA1", StgStagePlayerScript::Func_CreatePlayerShotA1, 7},
-	{"CallSpell", StgStagePlayerScript::Func_CallSpell, 0},
-	{"LoadPlayerShotData", StgStagePlayerScript::Func_LoadPlayerShotData, 1},
-	{"ReloadPlayerShotData", StgStagePlayerScript::Func_ReloadPlayerShotData, 1},
-	{"GetSpellManageObject", StgStagePlayerScript::Func_GetSpellManageObject, 0},
+	{ "CreatePlayerShotA1", StgStagePlayerScript::Func_CreatePlayerShotA1, 7 },
+	{ "CallSpell", StgStagePlayerScript::Func_CallSpell, 0 },
+	{ "LoadPlayerShotData", StgStagePlayerScript::Func_LoadPlayerShotData, 1 },
+	{ "ReloadPlayerShotData", StgStagePlayerScript::Func_ReloadPlayerShotData, 1 },
+	{ "GetSpellManageObject", StgStagePlayerScript::Func_GetSpellManageObject, 0 },
 
 	//自機専用関数：スペルオブジェクト操作
-	{"ObjSpell_Create", StgStagePlayerScript::Func_ObjSpell_Create, 0},
-	{"ObjSpell_Regist", StgStagePlayerScript::Func_ObjSpell_Regist, 1},
-	{"ObjSpell_SetDamage", StgStagePlayerScript::Func_ObjSpell_SetDamage, 2},
-	{"ObjSpell_SetPenetration", StgStagePlayerScript::Func_ObjSpell_SetPenetration, 2},
-	{"ObjSpell_SetEraseShot", StgStagePlayerScript::Func_ObjSpell_SetEraseShot, 2},
-	{"ObjSpell_SetIntersectionCircle", StgStagePlayerScript::Func_ObjSpell_SetIntersectionCircle, 4},
-	{"ObjSpell_SetIntersectionLine", StgStagePlayerScript::Func_ObjSpell_SetIntersectionLine, 6},
+	{ "ObjSpell_Create", StgStagePlayerScript::Func_ObjSpell_Create, 0 },
+	{ "ObjSpell_Regist", StgStagePlayerScript::Func_ObjSpell_Regist, 1 },
+	{ "ObjSpell_SetDamage", StgStagePlayerScript::Func_ObjSpell_SetDamage, 2 },
+	{ "ObjSpell_SetPenetration", StgStagePlayerScript::Func_ObjSpell_SetPenetration, 2 },
+	{ "ObjSpell_SetEraseShot", StgStagePlayerScript::Func_ObjSpell_SetEraseShot, 2 },
+	{ "ObjSpell_SetIntersectionCircle", StgStagePlayerScript::Func_ObjSpell_SetIntersectionCircle, 4 },
+	{ "ObjSpell_SetIntersectionLine", StgStagePlayerScript::Func_ObjSpell_SetIntersectionLine, 6 },
 
 	//定数
-	{"EV_REQUEST_SPELL", constant<StgStagePlayerScript::EV_REQUEST_SPELL>::func, 0},
-	{"EV_GRAZE", constant<StgStagePlayerScript::EV_GRAZE>::func, 0},
-	{"EV_HIT", constant<StgStagePlayerScript::EV_HIT>::func, 0},
+	{ "EV_REQUEST_SPELL", constant<StgStagePlayerScript::EV_REQUEST_SPELL>::func, 0 },
+	{ "EV_GRAZE", constant<StgStagePlayerScript::EV_GRAZE>::func, 0 },
+	{ "EV_HIT", constant<StgStagePlayerScript::EV_HIT>::func, 0 },
 
-	{"EV_GET_ITEM", constant<StgStageItemScript::EV_GET_ITEM>::func, 0},
+	{ "EV_GET_ITEM", constant<StgStageItemScript::EV_GET_ITEM>::func, 0 },
 };
-StgStagePlayerScript::StgStagePlayerScript(StgStageController* stageController) : StgStageScript(stageController)
+StgStagePlayerScript::StgStagePlayerScript(StgStageController* stageController)
+	: StgStageScript(stageController)
 {
 	typeScript_ = TYPE_PLAYER;
 	_AddFunction(stgPlayerFunction, sizeof(stgPlayerFunction) / sizeof(function));
@@ -4107,19 +4065,19 @@ StgStagePlayerScript::~StgStagePlayerScript()
 }
 
 //自機専用関数
-gstd::value StgStagePlayerScript::Func_CreatePlayerShotA1(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStagePlayerScript::Func_CreatePlayerShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController->GetPlayerObject();
-	if(objPlayer != NULL && !objPlayer->IsPermitShot())return value();
+	if (objPlayer != NULL && !objPlayer->IsPermitShot())
+		return value();
 
 	ref_count_ptr<StgNormalShotObject>::unsync obj = new StgNormalShotObject(stageController);
 	obj->SetObjectManager(script->objManager_.GetPointer());
 	int id = script->AddObject(obj);
-	if(id != ID_INVALID)
-	{
+	if (id != ID_INVALID) {
 		stageController->GetShotManager()->AddShot(obj);
 		long double posX = argv[0].as_real();
 		long double posY = argv[1].as_real();
@@ -4138,22 +4096,23 @@ gstd::value StgStagePlayerScript::Func_CreatePlayerShotA1(gstd::script_machine* 
 		obj->SetDamage(damage);
 		obj->SetShotDataID(idShot);
 	}
-	
-	return value(machine->get_engine()->get_real_type(),(long double)id);
+
+	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStagePlayerScript::Func_CallSpell(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStagePlayerScript::Func_CallSpell(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController->GetPlayerObject();
-	if(objPlayer == NULL)return value();
+	if (objPlayer == NULL)
+		return value();
 
 	objPlayer->CallSpell();
-	
+
 	return value();
 }
-gstd::value StgStagePlayerScript::Func_LoadPlayerShotData(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStagePlayerScript::Func_LoadPlayerShotData(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -4165,7 +4124,7 @@ gstd::value StgStagePlayerScript::Func_LoadPlayerShotData(gstd::script_machine* 
 	bool res = shotManager->LoadPlayerShotData(path);
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStagePlayerScript::Func_ReloadPlayerShotData(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStagePlayerScript::Func_ReloadPlayerShotData(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -4177,18 +4136,16 @@ gstd::value StgStagePlayerScript::Func_ReloadPlayerShotData(gstd::script_machine
 	bool res = shotManager->LoadPlayerShotData(path, true);
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStagePlayerScript::Func_GetSpellManageObject(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStagePlayerScript::Func_GetSpellManageObject(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
 	int id = ID_INVALID;
-	if(obj != NULL)
-	{
+	if (obj != NULL) {
 		ref_count_ptr<StgPlayerSpellManageObject>::unsync objManage = obj->GetSpellManageObject();
-		if(objManage != NULL)
-		{
+		if (objManage != NULL) {
 			id = objManage->GetObjectID();
 		}
 	}
@@ -4196,7 +4153,7 @@ gstd::value StgStagePlayerScript::Func_GetSpellManageObject(gstd::script_machine
 }
 
 //自機専用関数：スペルオブジェクト操作
-gstd::value StgStagePlayerScript::Func_ObjSpell_Create(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStagePlayerScript::Func_ObjSpell_Create(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	script->CheckRunInMainThread();
@@ -4205,80 +4162,77 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_Create(gstd::script_machine* mac
 	ref_count_ptr<StgPlayerSpellObject>::unsync obj = new StgPlayerSpellObject(stageController);
 
 	int id = ID_INVALID;
-	if(obj != NULL)
-	{
+	if (obj != NULL) {
 		obj->SetObjectManager(script->objManager_.GetPointer());
 		id = script->AddObject(obj, false);
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStagePlayerScript::Func_ObjSpell_Regist(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStagePlayerScript::Func_ObjSpell_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
-	ref_count_ptr<StgPlayerSpellObject>::unsync objSpell = 
-		ref_count_ptr<StgPlayerSpellObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
-	if(objSpell != NULL)
-	{
+	ref_count_ptr<StgPlayerSpellObject>::unsync objSpell = ref_count_ptr<StgPlayerSpellObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
+	if (objSpell != NULL) {
 		script->ActivateObject(objSpell->GetObjectID(), true);
 	}
 
 	return value();
 }
-gstd::value StgStagePlayerScript::Func_ObjSpell_SetDamage(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStagePlayerScript::Func_ObjSpell_SetDamage(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
-	ref_count_ptr<StgPlayerSpellObject>::unsync objSpell = 
-		ref_count_ptr<StgPlayerSpellObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
-	if(objSpell == NULL)return value();
+	ref_count_ptr<StgPlayerSpellObject>::unsync objSpell = ref_count_ptr<StgPlayerSpellObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
+	if (objSpell == NULL)
+		return value();
 
 	double damage = argv[1].as_real();
 	objSpell->SetDamage(damage);
 	return value();
 }
-gstd::value StgStagePlayerScript::Func_ObjSpell_SetPenetration(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStagePlayerScript::Func_ObjSpell_SetPenetration(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
-	ref_count_ptr<StgPlayerSpellObject>::unsync objSpell = 
-		ref_count_ptr<StgPlayerSpellObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
-	if(objSpell == NULL)return value();
+	ref_count_ptr<StgPlayerSpellObject>::unsync objSpell = ref_count_ptr<StgPlayerSpellObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
+	if (objSpell == NULL)
+		return value();
 
 	double life = argv[1].as_real();
 	objSpell->SetLife(life);
 	return value();
 }
-gstd::value StgStagePlayerScript::Func_ObjSpell_SetEraseShot(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStagePlayerScript::Func_ObjSpell_SetEraseShot(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
-	ref_count_ptr<StgPlayerSpellObject>::unsync objSpell = 
-		ref_count_ptr<StgPlayerSpellObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
-	if(objSpell == NULL)return value();
+	ref_count_ptr<StgPlayerSpellObject>::unsync objSpell = ref_count_ptr<StgPlayerSpellObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
+	if (objSpell == NULL)
+		return value();
 
 	bool bEraseShot = argv[1].as_boolean();
 	objSpell->SetEraseShot(bEraseShot);
 	return value();
 }
-gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionCircle(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionCircle(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
 
-	ref_count_ptr<StgPlayerSpellObject>::unsync objSpell =
-		ref_count_ptr<StgPlayerSpellObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
-	if(objSpell == NULL)return value();
+	ref_count_ptr<StgPlayerSpellObject>::unsync objSpell = ref_count_ptr<StgPlayerSpellObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
+	if (objSpell == NULL)
+		return value();
 
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 	int px = (int)argv[1].as_real();
@@ -4288,8 +4242,7 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionCircle(gstd::scri
 
 	//当たり判定
 	ref_count_weak_ptr<StgPlayerSpellObject>::unsync wObjSpell = objSpell;
-	ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = 
-		ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
+	ref_count_ptr<StgIntersectionTarget_Circle>::unsync target = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_CIRCLE));
 	target->SetTargetType(StgIntersectionTarget::TYPE_PLAYER_SPELL);
 	target->SetObject(wObjSpell);
 	target->SetCircle(circle);
@@ -4298,16 +4251,16 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionCircle(gstd::scri
 
 	return value();
 }
-gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const * argv)
+gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
 
-	ref_count_ptr<StgPlayerSpellObject>::unsync objSpell =
-		ref_count_ptr<StgPlayerSpellObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
-	if(objSpell == NULL)return value();
+	ref_count_ptr<StgPlayerSpellObject>::unsync objSpell = ref_count_ptr<StgPlayerSpellObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
+	if (objSpell == NULL)
+		return value();
 
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 	int px1 = (int)argv[1].as_real();
@@ -4319,8 +4272,7 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionLine(gstd::script
 
 	//当たり判定
 	ref_count_weak_ptr<StgPlayerSpellObject>::unsync wObjSpell = objSpell;
-	ref_count_ptr<StgIntersectionTarget_Line>::unsync target = 
-		ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_LINE));
+	ref_count_ptr<StgIntersectionTarget_Line>::unsync target = ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(intersectionManager->GetPoolObject(StgIntersectionTarget::SHAPE_LINE));
 	target->SetTargetType(StgIntersectionTarget::TYPE_PLAYER_SPELL);
 	target->SetObject(wObjSpell);
 	target->SetLine(line);
@@ -4329,4 +4281,3 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionLine(gstd::script
 
 	return value();
 }
-

--- a/source/TouhouDanmakufu/Common/StgStageScript.hpp
+++ b/source/TouhouDanmakufu/Common/StgStageScript.hpp
@@ -1,473 +1,450 @@
 #ifndef __TOUHOUDANMAKUFU_DNHSTG_STAGESCRIPT__
 #define __TOUHOUDANMAKUFU_DNHSTG_STAGESCRIPT__
 
-#include"StgCommon.hpp"
-#include"StgControlScript.hpp"
+#include "StgCommon.hpp"
+#include "StgControlScript.hpp"
 
 class StgStageScriptObjectManager;
 class StgStageScript;
 
-
 /**********************************************************
 //StgStageScriptManager
 **********************************************************/
-class StgStageScriptManager : public StgControlScriptManager
-{
-	protected:
-		StgStageController* stageController_;
-		ref_count_ptr<StgStageScriptObjectManager> objManager_;
+class StgStageScriptManager : public StgControlScriptManager {
+public:
+	StgStageScriptManager(StgStageController* stageController);
+	virtual ~StgStageScriptManager();
 
-		_int64 idPlayerScript_;
-		_int64 idItemScript_;
-		_int64 idShotScript_;
+	virtual void SetError(std::wstring error);
+	virtual bool IsError();
 
-	public:
-		StgStageScriptManager(StgStageController* stageController);
-		virtual ~StgStageScriptManager();
+	gstd::ref_count_ptr<StgStageScriptObjectManager> GetObjectManager() { return objManager_; }
+	virtual ref_count_ptr<ManagedScript> Create(int type);
 
-		virtual void SetError(std::wstring error);
-		virtual bool IsError();
+	_int64 GetPlayerScriptID() { return idPlayerScript_; }
+	void SetPlayerScriptID(_int64 id) { idPlayerScript_ = id; }
+	_int64 GetItemScriptID() { return idItemScript_; }
+	void SetItemScriptID(_int64 id) { idItemScript_ = id; }
+	ref_count_ptr<ManagedScript> GetItemScript();
+	_int64 GetShotScriptID() { return idShotScript_; }
+	void SetShotScriptID(_int64 id) { idShotScript_ = id; }
+	ref_count_ptr<ManagedScript> GetShotScript();
 
-		gstd::ref_count_ptr<StgStageScriptObjectManager> GetObjectManager(){return objManager_;}
-		virtual ref_count_ptr<ManagedScript> Create(int type);
+protected:
+	StgStageController* stageController_;
+	ref_count_ptr<StgStageScriptObjectManager> objManager_;
 
-		_int64 GetPlayerScriptID(){return idPlayerScript_;}
-		void SetPlayerScriptID(_int64 id){idPlayerScript_ = id;}
-		_int64 GetItemScriptID(){return idItemScript_;}
-		void SetItemScriptID(_int64 id){idItemScript_ = id;}
-		ref_count_ptr<ManagedScript> GetItemScript();
-		_int64 GetShotScriptID(){return idShotScript_;}
-		void SetShotScriptID(_int64 id){idShotScript_ = id;}
-		ref_count_ptr<ManagedScript> GetShotScript();
+	_int64 idPlayerScript_;
+	_int64 idItemScript_;
+	_int64 idShotScript_;
 };
 
 /**********************************************************
 //StgStageScriptObjectManager
 **********************************************************/
-class StgStageScriptObjectManager : public DxScriptObjectManager
-{
-		StgStageController* stageController_;
+class StgStageScriptObjectManager : public DxScriptObjectManager {
+public:
+	StgStageScriptObjectManager(StgStageController* stageController);
+	~StgStageScriptObjectManager();
+	virtual void RenderObject();
+	virtual void RenderObject(int priMin, int priMax);
 
-		int idObjPleyer_;
+	int GetPlayerObjectID() { return idObjPleyer_; }
+	int CreatePlayerObject();
 
-	public:
-		StgStageScriptObjectManager(StgStageController* stageController);
-		~StgStageScriptObjectManager();
-		virtual void RenderObject();
-		virtual void RenderObject(int priMin, int priMax);
+private:
+	StgStageController* stageController_;
 
-		int GetPlayerObjectID(){return idObjPleyer_;}
-		int CreatePlayerObject();
-
-
+	int idObjPleyer_;
 };
-
 
 /**********************************************************
 //StgStageScript
 **********************************************************/
-class StgStageScript : public StgControlScript
-{
-		friend StgStageScriptManager;
-	public:
-		enum
-		{
-			TYPE_SYSTEM,
-			TYPE_STAGE,
-			TYPE_PLAYER,
-			TYPE_ITEM,
+class StgStageScript : public StgControlScript {
+	friend StgStageScriptManager;
 
-			TYPE_ALL,
-			TYPE_SHOT,
-			TYPE_CHILD,
-			TYPE_IMMEDIATE,
-			TYPE_FADE,
+public:
+	enum {
+		TYPE_SYSTEM,
+		TYPE_STAGE,
+		TYPE_PLAYER,
+		TYPE_ITEM,
 
+		TYPE_ALL,
+		TYPE_SHOT,
+		TYPE_CHILD,
+		TYPE_IMMEDIATE,
+		TYPE_FADE,
 
-			OBJ_PLAYER = 100,
-			OBJ_SPELL_MANAGE,
-			OBJ_SPELL,
-			OBJ_ENEMY,
-			OBJ_ENEMY_BOSS,
-			OBJ_ENEMY_BOSS_SCENE,
-			OBJ_SHOT,
-			OBJ_LOOSE_LASER,//射出型レーザー
-			OBJ_STRAIGHT_LASER,//設置型レーザー
-			OBJ_CURVE_LASER,//曲がるレーザー
-			OBJ_ITEM,
+		OBJ_PLAYER = 100,
+		OBJ_SPELL_MANAGE,
+		OBJ_SPELL,
+		OBJ_ENEMY,
+		OBJ_ENEMY_BOSS,
+		OBJ_ENEMY_BOSS_SCENE,
+		OBJ_SHOT,
+		OBJ_LOOSE_LASER, //射出型レーザー
+		OBJ_STRAIGHT_LASER, //設置型レーザー
+		OBJ_CURVE_LASER, //曲がるレーザー
+		OBJ_ITEM,
 
-			INFO_LIFE,
-			INFO_DAMAGE_RATE_SHOT,
-			INFO_DAMAGE_RATE_SPELL,
-			INFO_SHOT_HIT_COUNT,
+		INFO_LIFE,
+		INFO_DAMAGE_RATE_SHOT,
+		INFO_DAMAGE_RATE_SPELL,
+		INFO_SHOT_HIT_COUNT,
 
-			INFO_TIMER,
-			INFO_TIMERF,
-			INFO_ORGTIMERF,
-			INFO_IS_SPELL,
-			INFO_IS_LAST_SPELL,
-			INFO_IS_DURABLE_SPELL,
-			INFO_SPELL_SCORE,
-			INFO_REMAIN_STEP_COUNT,
-			INFO_ACTIVE_STEP_LIFE_COUNT,
-			INFO_ACTIVE_STEP_TOTAL_MAX_LIFE,
-			INFO_ACTIVE_STEP_TOTAL_LIFE,
-			INFO_ACTIVE_STEP_LIFE_RATE_LIST,
-			INFO_IS_LAST_STEP,
-			INFO_PLAYER_SHOOTDOWN_COUNT,
-			INFO_PLAYER_SPELL_COUNT,
-			INFO_CURRENT_LIFE,
-			INFO_CURRENT_LIFE_MAX,
+		INFO_TIMER,
+		INFO_TIMERF,
+		INFO_ORGTIMERF,
+		INFO_IS_SPELL,
+		INFO_IS_LAST_SPELL,
+		INFO_IS_DURABLE_SPELL,
+		INFO_SPELL_SCORE,
+		INFO_REMAIN_STEP_COUNT,
+		INFO_ACTIVE_STEP_LIFE_COUNT,
+		INFO_ACTIVE_STEP_TOTAL_MAX_LIFE,
+		INFO_ACTIVE_STEP_TOTAL_LIFE,
+		INFO_ACTIVE_STEP_LIFE_RATE_LIST,
+		INFO_IS_LAST_STEP,
+		INFO_PLAYER_SHOOTDOWN_COUNT,
+		INFO_PLAYER_SPELL_COUNT,
+		INFO_CURRENT_LIFE,
+		INFO_CURRENT_LIFE_MAX,
 
-			INFO_ITEM_SCORE,
+		INFO_ITEM_SCORE,
 
-			INFO_RECT,
-			INFO_DELAY_COLOR,
-			INFO_BLEND,
-			INFO_COLLISION,
-			INFO_COLLISION_LIST,
+		INFO_RECT,
+		INFO_DELAY_COLOR,
+		INFO_BLEND,
+		INFO_COLLISION,
+		INFO_COLLISION_LIST,
 
-			//イベント
-			EV_REQUEST_LIFE = 1,//敵ライフ要求
-			EV_REQUEST_TIMER,//敵スペルタイマ要求
-			EV_REQUEST_IS_SPELL,//スペルカード宣言
-			EV_REQUEST_IS_LAST_SPELL,//ラストスペル
-			EV_REQUEST_IS_DURABLE_SPELL,//耐久スペル
-			EV_REQUEST_SPELL_SCORE,//スペルカードスコア
-			EV_REQUEST_REPLAY_TARGET_COMMON_AREA,//リプレイ対象
+		//イベント
+		EV_REQUEST_LIFE = 1, //敵ライフ要求
+		EV_REQUEST_TIMER, //敵スペルタイマ要求
+		EV_REQUEST_IS_SPELL, //スペルカード宣言
+		EV_REQUEST_IS_LAST_SPELL, //ラストスペル
+		EV_REQUEST_IS_DURABLE_SPELL, //耐久スペル
+		EV_REQUEST_SPELL_SCORE, //スペルカードスコア
+		EV_REQUEST_REPLAY_TARGET_COMMON_AREA, //リプレイ対象
 
-			EV_TIMEOUT,//スペルタイムアウト
-			EV_START_BOSS_SPELL,//ボススペルカード開始
-			EV_GAIN_SPELL,//スペルカード取得
-			EV_START_BOSS_STEP,//スペルカード開始
-			EV_END_BOSS_STEP,//スペルカード終了
+		EV_TIMEOUT, //スペルタイムアウト
+		EV_START_BOSS_SPELL, //ボススペルカード開始
+		EV_GAIN_SPELL, //スペルカード取得
+		EV_START_BOSS_STEP, //スペルカード開始
+		EV_END_BOSS_STEP, //スペルカード終了
 
-			EV_PLAYER_SHOOTDOWN,//自機ダウン
-			EV_PLAYER_SPELL,//自機スペル
-			EV_PLAYER_REBIRTH,//自機復帰
+		EV_PLAYER_SHOOTDOWN, //自機ダウン
+		EV_PLAYER_SPELL, //自機スペル
+		EV_PLAYER_REBIRTH, //自機復帰
 
-			EV_PAUSE_ENTER,//停止開始
-			EV_PAUSE_LEAVE,//停止解除
+		EV_PAUSE_ENTER, //停止開始
+		EV_PAUSE_LEAVE, //停止解除
 
-			EV_DELETE_SHOT_IMMEDIATE,
-			EV_DELETE_SHOT_TO_ITEM,
-			EV_DELETE_SHOT_FADE,
+		EV_DELETE_SHOT_IMMEDIATE,
+		EV_DELETE_SHOT_TO_ITEM,
+		EV_DELETE_SHOT_FADE,
 
-			TARGET_ALL,
-			TARGET_ENEMY,
-			TARGET_PLAYER,
-		};
-	protected:
+		TARGET_ALL,
+		TARGET_ENEMY,
+		TARGET_PLAYER,
+	};
 
-		StgStageController* stageController_;
-	public:
-		StgStageScript(StgStageController* stageController);
-		virtual ~StgStageScript();
+public:
+	StgStageScript(StgStageController* stageController);
+	virtual ~StgStageScript();
 
-		ref_count_ptr<StgStageScriptObjectManager> GetStgObjectManager();
+	ref_count_ptr<StgStageScriptObjectManager> GetStgObjectManager();
 
-		//STG共通関数：共通データ
-		static gstd::value Func_SaveCommonDataAreaToReplayFile(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_LoadCommonDataAreaFromReplayFile(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG共通関数：共通データ
+	static gstd::value Func_SaveCommonDataAreaToReplayFile(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_LoadCommonDataAreaFromReplayFile(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG共通関数：システム関連
-		static gstd::value Func_GetMainStgScriptPath(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetMainStgScriptDirectory(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetStgFrame(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetItemRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetShotRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetStgFrameRenderPriorityMinI(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetStgFrameRenderPriorityMaxI(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetItemRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetShotRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPlayerRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetCameraFocusPermitPriorityI(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CloseStgScene(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetReplayFps(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG共通関数：システム関連
+	static gstd::value Func_GetMainStgScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetMainStgScriptDirectory(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetStgFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetItemRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetShotRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetStgFrameRenderPriorityMinI(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetStgFrameRenderPriorityMaxI(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetItemRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetShotRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetCameraFocusPermitPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CloseStgScene(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetReplayFps(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG共通関数：自機
-		static gstd::value Func_GetPlayerObjectID(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPlayerScriptID(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetPlayerSpeed(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetPlayerClip(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetPlayerLife(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetPlayerPower(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetPlayerDownStateFrame(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetPlayerRebirthFrame(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetPlayerRebirthLossFrame(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetPlayerAutoItemCollectLine(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetForbidPlayerShot(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetForbidPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPlayerX(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPlayerY(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPlayerState(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPlayerSpeed(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPlayerClip(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPlayerLife(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPlayerPower(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPlayerDownStateFrame(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetPlayerRebirthFrame(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetAngleToPlayer(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_IsPermitPlayerShot(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_IsPermitPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_IsPlayerLastSpellWait(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_IsPlayerSpellActive(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG共通関数：自機
+	static gstd::value Func_GetPlayerObjectID(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerScriptID(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetPlayerSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetPlayerClip(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetPlayerLife(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetPlayerPower(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetPlayerDownStateFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetPlayerRebirthFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetPlayerRebirthLossFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetPlayerAutoItemCollectLine(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetForbidPlayerShot(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetForbidPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerX(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerY(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerState(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerClip(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerLife(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerPower(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerDownStateFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerRebirthFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetAngleToPlayer(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_IsPermitPlayerShot(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_IsPermitPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_IsPlayerLastSpellWait(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_IsPlayerSpellActive(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
+	//STG共通関数：敵
+	static gstd::value Func_GetEnemyBossSceneObjectID(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetEnemyBossObjectID(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetAllEnemyID(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetIntersectionRegistedEnemyID(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetAllEnemyIntersectionPosition(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetEnemyIntersectionPosition(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetEnemyIntersectionPositionByIdA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetEnemyIntersectionPositionByIdA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_LoadEnemyShotData(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ReloadEnemyShotData(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG共通関数：敵
-		static gstd::value Func_GetEnemyBossSceneObjectID(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetEnemyBossObjectID(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetAllEnemyID(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetIntersectionRegistedEnemyID(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetAllEnemyIntersectionPosition(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetEnemyIntersectionPosition(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetEnemyIntersectionPositionByIdA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetEnemyIntersectionPositionByIdA2(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_LoadEnemyShotData(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ReloadEnemyShotData(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG共通関数：弾
+	static gstd::value Func_DeleteShotAll(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_DeleteShotInCircle(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreateShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreateShotA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreateShotOA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreateShotB1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreateShotB2(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreateShotOB1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreateLooseLaserA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreateStraightLaserA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreateCurveLaserA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetShotIntersectionCircle(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetShotIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetShotIdInCircleA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetShotIdInCircleA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetShotCount(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetShotAutoDeleteClip(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetShotDataInfoA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_StartShotScript(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
+	//STG共通関数：アイテム
+	static gstd::value Func_CreateItemA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreateItemA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreateItemU1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreateItemU2(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreateItemScore(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CollectAllItems(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CollectItemsByType(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CollectItemsInCircle(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CancelCollectItems(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_StartItemScript(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetDefaultBonusItemEnable(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_LoadItemData(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ReloadItemData(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG共通関数：弾
-		static gstd::value Func_DeleteShotAll(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_DeleteShotInCircle(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CreateShotA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CreateShotA2(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CreateShotOA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CreateShotB1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CreateShotB2(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CreateShotOB1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CreateLooseLaserA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CreateStraightLaserA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CreateCurveLaserA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetShotIntersectionCircle(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetShotIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetShotIdInCircleA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetShotIdInCircleA2(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetShotCount(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetShotAutoDeleteClip(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetShotDataInfoA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_StartShotScript(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG共通関数：その他
+	static gstd::value Func_StartSlow(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_StopSlow(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_IsIntersected_Line_Circle(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_IsIntersected_Obj_Obj(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
+	//STG共通関数：移動オブジェクト操作
+	static gstd::value Func_ObjMove_SetX(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_SetY(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_SetPosition(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_SetSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_SetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_SetAcceleration(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_SetMaxSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_SetAngularVelocity(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_SetDestAtSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_SetDestAtFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_SetDestAtWeight(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_AddPatternA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_AddPatternA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_AddPatternA3(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_AddPatternA4(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_AddPatternB1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_AddPatternB2(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_AddPatternB3(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_GetX(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_GetY(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_GetSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_GetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG共通関数：アイテム
-		static gstd::value Func_CreateItemA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CreateItemA2(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CreateItemU1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CreateItemU2(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CreateItemScore(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CollectAllItems(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CollectItemsByType(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CollectItemsInCircle(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CancelCollectItems(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_StartItemScript(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_SetDefaultBonusItemEnable(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_LoadItemData(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ReloadItemData(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG共通関数：敵オブジェクト操作
+	static gstd::value Func_ObjEnemy_Create(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemy_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemy_GetInfo(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemy_SetLife(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemy_AddLife(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemy_SetDamageRate(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemy_AddIntersectionCircleA(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemy_SetIntersectionCircleToShot(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemy_SetIntersectionCircleToPlayer(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
+	//STG共通関数：敵ボスシーンオブジェクト操作
+	static gstd::value Func_ObjEnemyBossScene_Create(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemyBossScene_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemyBossScene_Add(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemyBossScene_LoadInThread(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemyBossScene_GetInfo(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemyBossScene_SetSpellTimer(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemyBossScene_StartSpell(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG共通関数：その他
-		static gstd::value Func_StartSlow(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_StopSlow(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_IsIntersected_Line_Circle(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_IsIntersected_Obj_Obj(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG共通関数：弾オブジェクト操作
+	static gstd::value Func_ObjShot_Create(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetAutoDelete(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetDeleteFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_FadeDelete(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetDelay(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetSpellResist(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetGraphic(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetSourceBlendType(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetDamage(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetPenetration(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetEraseShot(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetSpellFactor(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_ToItem(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_AddShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_AddShotA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetIntersectionCircleA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetIntersectionCircleA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetIntersectionEnable(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_SetItemChange(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_GetDelay(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_GetDamage(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_GetPenetration(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_IsSpellResist(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_GetImageID(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG共通関数：移動オブジェクト操作
-		static gstd::value Func_ObjMove_SetX(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_SetY(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_SetPosition(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_SetSpeed(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_SetAngle(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_SetAcceleration(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_SetMaxSpeed(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_SetAngularVelocity(gstd::script_machine* machine, int argc, gstd::value const * argv);	
-		static gstd::value Func_ObjMove_SetDestAtSpeed(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_SetDestAtFrame(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_SetDestAtWeight(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_AddPatternA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_AddPatternA2(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_AddPatternA3(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_AddPatternA4(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_AddPatternB1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_AddPatternB2(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_AddPatternB3(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_GetX(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_GetY(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_GetSpeed(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjMove_GetAngle(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	static gstd::value Func_ObjLaser_SetLength(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjLaser_SetRenderWidth(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjLaser_SetIntersectionWidth(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjLaser_SetInvalidLength(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjLaser_SetGrazeInvalidFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjLaser_SetItemDistance(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjLaser_GetLength(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjLaser_GetRenderWidth(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjLaser_GetIntersectionWidth(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjStLaser_SetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjStLaser_GetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjStLaser_SetSource(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjCrLaser_SetTipDecrement(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG共通関数：敵オブジェクト操作
-		static gstd::value Func_ObjEnemy_Create(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjEnemy_Regist(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjEnemy_GetInfo(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjEnemy_SetLife(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjEnemy_AddLife(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjEnemy_SetDamageRate(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjEnemy_AddIntersectionCircleA(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjEnemy_SetIntersectionCircleToShot(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjEnemy_SetIntersectionCircleToPlayer(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG共通関数：アイテムオブジェクト操作
+	static gstd::value Func_ObjItem_Create(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjItem_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjItem_SetItemID(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjItem_SetRenderScoreEnable(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjItem_SetAutoCollectEnable(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjItem_SetDefinedMovePatternA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjItem_GetInfo(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
+	//STG共通関数：自機オブジェクト操作
+	static gstd::value Func_ObjPlayer_AddIntersectionCircleA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjPlayer_AddIntersectionCircleA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjPlayer_ClearIntersection(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG共通関数：敵ボスシーンオブジェクト操作
-		static gstd::value Func_ObjEnemyBossScene_Create(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjEnemyBossScene_Regist(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjEnemyBossScene_Add(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjEnemyBossScene_LoadInThread(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjEnemyBossScene_GetInfo(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjEnemyBossScene_SetSpellTimer(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjEnemyBossScene_StartSpell(gstd::script_machine* machine, int argc, gstd::value const * argv);
+	//STG共通関数：当たり判定オブジェクト操作
+	static gstd::value Func_ObjCol_IsIntersected(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjCol_GetListOfIntersectedEnemyID(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjCol_GetIntersectedCount(gstd::script_machine* machine, int argc, gstd::value const* argv);
 
-		//STG共通関数：弾オブジェクト操作
-		static gstd::value Func_ObjShot_Create(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_Regist(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetAutoDelete(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetDeleteFrame(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_FadeDelete(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetDelay(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetSpellResist(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetGraphic(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetSourceBlendType(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetDamage(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetPenetration(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetEraseShot(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetSpellFactor(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_ToItem(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_AddShotA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_AddShotA2(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetIntersectionCircleA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetIntersectionCircleA2(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetIntersectionEnable(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_SetItemChange(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_GetDelay(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_GetDamage(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_GetPenetration(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_IsSpellResist(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjShot_GetImageID(gstd::script_machine* machine, int argc, gstd::value const * argv);
-
-		static gstd::value Func_ObjLaser_SetLength(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjLaser_SetRenderWidth(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjLaser_SetIntersectionWidth(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjLaser_SetInvalidLength(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjLaser_SetGrazeInvalidFrame(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjLaser_SetItemDistance(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjLaser_GetLength(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjLaser_GetRenderWidth(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjLaser_GetIntersectionWidth(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjStLaser_SetAngle(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjStLaser_GetAngle(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjStLaser_SetSource(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjCrLaser_SetTipDecrement(gstd::script_machine* machine, int argc, gstd::value const * argv);
-
-		//STG共通関数：アイテムオブジェクト操作
-		static gstd::value Func_ObjItem_Create(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjItem_Regist(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjItem_SetItemID(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjItem_SetRenderScoreEnable(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjItem_SetAutoCollectEnable(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjItem_SetDefinedMovePatternA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjItem_GetInfo(gstd::script_machine* machine, int argc, gstd::value const * argv);
-
-		//STG共通関数：自機オブジェクト操作
-		static gstd::value Func_ObjPlayer_AddIntersectionCircleA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjPlayer_AddIntersectionCircleA2(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjPlayer_ClearIntersection(gstd::script_machine* machine, int argc, gstd::value const * argv);
-
-
-		//STG共通関数：当たり判定オブジェクト操作
-		static gstd::value Func_ObjCol_IsIntersected(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjCol_GetListOfIntersectedEnemyID(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjCol_GetIntersectedCount(gstd::script_machine* machine, int argc, gstd::value const * argv);
+protected:
+	StgStageController* stageController_;
 };
-
 
 /**********************************************************
 //StgSystemScript
 **********************************************************/
-class StgStageSystemScript : public StgStageScript
-{
-	public:
-		StgStageSystemScript(StgStageController* stageController);
-		virtual ~StgStageSystemScript();
+class StgStageSystemScript : public StgStageScript {
+public:
+	StgStageSystemScript(StgStageController* stageController);
+	virtual ~StgStageSystemScript();
 
-		//システム専用関数：システム操作
-
+	//システム専用関数：システム操作
 };
 
 /**********************************************************
 //StgStageItemScript
 **********************************************************/
-class StgStageItemScript : public StgStageScript
-{
-	public:
-		enum
-		{
-			EV_GET_ITEM = 1100,
-		};
-	public:
-		StgStageItemScript(StgStageController* stageController);
-		virtual ~StgStageItemScript();
+class StgStageItemScript : public StgStageScript {
+public:
+	enum {
+		EV_GET_ITEM = 1100,
+	};
 
-		//システム専用関数：アイテム操作
+public:
+	StgStageItemScript(StgStageController* stageController);
+	virtual ~StgStageItemScript();
 
+	//システム専用関数：アイテム操作
 };
 
 /**********************************************************
 //StgStageShotScript
 **********************************************************/
-class StgStageShotScript : public StgStageScript
-{
-	public:
-		enum
-		{
+class StgStageShotScript : public StgStageScript {
+public:
+	enum {
 
-		};
-	public:
-		StgStageShotScript(StgStageController* stageController);
-		virtual ~StgStageShotScript();
+	};
 
-		//システム専用関数：アイテム操作
-		static gstd::value Func_SetShotDeleteEventEnable(gstd::script_machine* machine, int argc, gstd::value const * argv);
+public:
+	StgStageShotScript(StgStageController* stageController);
+	virtual ~StgStageShotScript();
 
+	//システム専用関数：アイテム操作
+	static gstd::value Func_SetShotDeleteEventEnable(gstd::script_machine* machine, int argc, gstd::value const* argv);
 };
-
 
 /**********************************************************
 //StgStagePlayerScript
 **********************************************************/
-class StgStagePlayerScript : public StgStageScript
-{
-	public:
-		enum
-		{
-			EV_REQUEST_SPELL = 1000,
-			EV_GRAZE,
-			EV_HIT,
-		};
-	public:
-		StgStagePlayerScript(StgStageController* stageController);
-		virtual ~StgStagePlayerScript();
+class StgStagePlayerScript : public StgStageScript {
+public:
+	enum {
+		EV_REQUEST_SPELL = 1000,
+		EV_GRAZE,
+		EV_HIT,
+	};
 
-		//自機専用関数
-		static gstd::value Func_CreatePlayerShotA1(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_CallSpell(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_LoadPlayerShotData(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ReloadPlayerShotData(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_GetSpellManageObject(gstd::script_machine* machine, int argc, gstd::value const * argv);
-	
-		//自機専用関数：スペルオブジェクト操作
-		static gstd::value Func_ObjSpell_Create(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjSpell_Regist(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjSpell_SetDamage(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjSpell_SetPenetration(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjSpell_SetEraseShot(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjSpell_SetIntersectionCircle(gstd::script_machine* machine, int argc, gstd::value const * argv);
-		static gstd::value Func_ObjSpell_SetIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const * argv);
+public:
+	StgStagePlayerScript(StgStageController* stageController);
+	virtual ~StgStagePlayerScript();
 
+	//自機専用関数
+	static gstd::value Func_CreatePlayerShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CallSpell(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_LoadPlayerShotData(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ReloadPlayerShotData(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetSpellManageObject(gstd::script_machine* machine, int argc, gstd::value const* argv);
+
+	//自機専用関数：スペルオブジェクト操作
+	static gstd::value Func_ObjSpell_Create(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjSpell_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjSpell_SetDamage(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjSpell_SetPenetration(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjSpell_SetEraseShot(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjSpell_SetIntersectionCircle(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjSpell_SetIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const* argv);
 };
-
 
 #endif

--- a/source/TouhouDanmakufu/Common/StgSystem.cpp
+++ b/source/TouhouDanmakufu/Common/StgSystem.cpp
@@ -1,8 +1,8 @@
-#include"StgSystem.hpp"
+#include "StgSystem.hpp"
 
-#include"StgPackageController.hpp"
-#include"StgStageScript.hpp"
-#include"StgPlayer.hpp"
+#include "StgPackageController.hpp"
+#include "StgPlayer.hpp"
+#include "StgStageScript.hpp"
 
 /**********************************************************
 //StgSystemController
@@ -12,7 +12,6 @@ StgSystemController::StgSystemController()
 }
 StgSystemController::~StgSystemController()
 {
-
 }
 void StgSystemController::Initialize(ref_count_ptr<StgSystemInformation> infoSystem)
 {
@@ -43,30 +42,23 @@ void StgSystemController::Start(ref_count_ptr<ScriptInformation> infoPlayer, ref
 	//アーカイブ
 	EFileManager* fileManager = EFileManager::GetInstance();
 	std::wstring archiveMain = infoMain->GetArchivePath();
-	if(archiveMain.size() > 0)
-	{
+	if (archiveMain.size() > 0)
 		fileManager->AddArchiveFile(archiveMain);
-	}
 
-	if(infoPlayer != NULL)
-	{
+	if (infoPlayer != NULL) {
 		std::wstring archivePlayer = infoPlayer->GetArchivePath();
-		if(archivePlayer.size() > 0)
-		{
+		if (archivePlayer.size() > 0) {
 			fileManager->AddArchiveFile(archivePlayer);
 		}
 	}
 
-	if(infoSystem_->IsPackageMode())
-	{
+	if (infoSystem_->IsPackageMode()) {
 		infoSystem_->SetScene(StgSystemInformation::SCENE_PACKAGE_CONTROL);
 		packageController_ = new StgPackageController(this);
 		packageController_->Initialize();
-	}
-	else
-	{
+	} else {
 		ref_count_ptr<ReplayInformation::StageData> replayStageData = NULL;
-		if(infoReplay != NULL)
+		if (infoReplay != NULL)
 			replayStageData = infoReplay->GetStageData(0);
 		ref_count_ptr<StgStageInformation> infoStage = new StgStageInformation();
 		infoStage->SetMainScriptInformation(infoMain);
@@ -76,22 +68,18 @@ void StgSystemController::Start(ref_count_ptr<ScriptInformation> infoPlayer, ref
 }
 void StgSystemController::Work()
 {
-	try
-	{
+	try {
 		_ControlScene();
 
 		ELogger* logger = ELogger::GetInstance();
 		logger->UpdateCommonDataInfoPanel(commonDataManager_);
-	}
-	catch(gstd::wexception e)
-	{
+	} catch (gstd::wexception e) {
 		Logger::WriteTop(e.what());
 		infoSystem_->SetError(e.what());
 	}
 
 	EDirectInput* input = EDirectInput::GetInstance();
-	if(infoSystem_->IsRetry())
-	{
+	if (infoSystem_->IsRetry()) {
 		infoSystem_->SetError(L"Retry");
 
 		DirectSoundManager* soundManager = DirectSoundManager::GetBase();
@@ -100,17 +88,13 @@ void StgSystemController::Work()
 		ShaderManager* shaderManager = ShaderManager::GetBase();
 		shaderManager->Clear();
 
-		if(infoSystem_->IsPackageMode())
-		{
+		if (infoSystem_->IsPackageMode()) {
 			ref_count_ptr<StgStageStartData> oldStageStartData;
 			ref_count_ptr<StgPackageInformation> infoPackage = packageController_->GetPackageInformation();
-			std::vector<ref_count_ptr<StgStageStartData> > listStageData = infoPackage->GetStageDataList();
-			if(listStageData.size() > 0)
-			{
+			std::vector<ref_count_ptr<StgStageStartData>> listStageData = infoPackage->GetStageDataList();
+			if (listStageData.size() > 0) {
 				oldStageStartData = *listStageData.begin();
-			}
-			else
-			{
+			} else {
 				oldStageStartData = infoPackage->GetNextStageData();
 			}
 			ref_count_ptr<StgStageInformation> oldStageInformation = oldStageStartData->GetStageInformation();
@@ -125,37 +109,29 @@ void StgSystemController::Work()
 			infoSystem_->ResetRetry();
 
 			StartStgScene(newStageStartData);
-		}
-		else
-		{
+		} else {
 			DoRetry();
 		}
 		return;
 	}
 
-	if(infoSystem_->IsError() || infoSystem_->IsStgEnd())
-	{
+	if (infoSystem_->IsError() || infoSystem_->IsStgEnd()) {
 		EFileManager* fileManager = EFileManager::GetInstance();
 		fileManager->ResetArchiveFile();
 
 		//終了
 		bool bRetry = false;
-		if(infoSystem_->IsError())
-		{
+		if (infoSystem_->IsError()) {
 			std::wstring error = infoSystem_->GetErrorMessage();
-			if(error.size() > 0)
-			{
+			if (error.size() > 0) {
 				ErrorDialog::ShowErrorDialog(error);
-			}
-			else
-			{
+			} else {
 				//リトライ
 				bRetry = true;
 			}
 		}
 
-		if(!bRetry)
-		{
+		if (!bRetry) {
 			DirectSoundManager* soundManager = DirectSoundManager::GetBase();
 			soundManager->Clear();
 		}
@@ -172,35 +148,29 @@ void StgSystemController::Work()
 }
 void StgSystemController::Render()
 {
-	if(infoSystem_->IsError())return;
+	if (infoSystem_->IsError())
+		return;
 
-	try
-	{
+	try {
 		int scene = infoSystem_->GetScene();
-		switch(scene)
-		{
-			case StgSystemInformation::SCENE_STG:
-			case StgSystemInformation::SCENE_PACKAGE_CONTROL:	
-			{
-				RenderScriptObject();
-				break;
-			}
-			case StgSystemInformation::SCENE_END:
-			{
-				if(endScene_ != NULL)
-					endScene_->Render();
-				break;
-			}
-			case StgSystemInformation::SCENE_REPLAY_SAVE:
-			{
-				if(replaySaveScene_ != NULL)
-					replaySaveScene_->Render();
-				break;
-			}
+		switch (scene) {
+		case StgSystemInformation::SCENE_STG:
+		case StgSystemInformation::SCENE_PACKAGE_CONTROL: {
+			RenderScriptObject();
+			break;
 		}
-	}
-	catch(gstd::wexception e)
-	{
+		case StgSystemInformation::SCENE_END: {
+			if (endScene_ != NULL)
+				endScene_->Render();
+			break;
+		}
+		case StgSystemInformation::SCENE_REPLAY_SAVE: {
+			if (replaySaveScene_ != NULL)
+				replaySaveScene_->Render();
+			break;
+		}
+		}
+	} catch (gstd::wexception e) {
 		DirectGraphics* graphics = DirectGraphics::GetBase();
 		gstd::ref_count_ptr<DxCamera2D> camera2D = graphics->GetCamera2D();
 		camera2D->SetEnable(false);
@@ -214,23 +184,18 @@ void StgSystemController::RenderScriptObject()
 	int scene = infoSystem_->GetScene();
 	bool bPackageMode = infoSystem_->IsPackageMode();
 	bool bPause = false;
-	if(scene == StgSystemInformation::SCENE_STG)
-	{
+	if (scene == StgSystemInformation::SCENE_STG) {
 		ref_count_ptr<StgStageInformation> infoStage = stageController_->GetStageInformation();
 		bPause = infoStage->IsPause();
 	}
 
-	if(bPause && !bPackageMode)
-	{
+	if (bPause && !bPackageMode) {
 		//停止
 		stageController_->GetPauseManager()->Render();
-	}
-	else
-	{
+	} else {
 		bool bReplay = false;
 		int countRender = 0;
-		if(scene == StgSystemInformation::SCENE_STG && stageController_ != NULL)
-		{
+		if (scene == StgSystemInformation::SCENE_STG && stageController_ != NULL) {
 			ref_count_ptr<StgStageScriptObjectManager> objectManagerStage = stageController_->GetMainObjectManager();
 			countRender = max(objectManagerStage->GetRenderBucketCapacity() - 1, countRender);
 
@@ -238,27 +203,21 @@ void StgSystemController::RenderScriptObject()
 			bReplay = infoStage->IsReplay();
 		}
 
-		if(infoSystem_->IsPackageMode())
-		{
+		if (infoSystem_->IsPackageMode()) {
 			ref_count_ptr<DxScriptObjectManager> objectManagerPackage = packageController_->GetMainObjectManager();
 			countRender = max(objectManagerPackage->GetRenderBucketCapacity() - 1, countRender);
 		}
 
 		int invalidPriMin = infoSystem_->GetInvaridRenderPriorityMin();
 		int invalidPriMax = infoSystem_->GetInvaridRenderPriorityMax();
-		if(invalidPriMin < 0 && invalidPriMax < 0) 
-		{
+		if (invalidPriMin < 0 && invalidPriMax < 0) {
 			RenderScriptObject(0, countRender);
-		}
-		else
-		{
+		} else {
 			RenderScriptObject(0, invalidPriMin - 1);
 			RenderScriptObject(invalidPriMax + 1, countRender);
 		}
 
-
-		if(bReplay)
-		{
+		if (bReplay) {
 			//リプレイ中
 /*
 			ref_count_ptr<StgStageInformation> infoStage = stageController_->GetStageInformation();
@@ -277,7 +236,7 @@ void StgSystemController::RenderScriptObject()
 			dxText.SetFontColorTop(D3DCOLOR_ARGB(255,128,128,255));
 			dxText.SetFontColorBottom(D3DCOLOR_ARGB(255,64,64,255));
 			dxText.SetFontBorderType(directx::DxFont::BORDER_FULL);
-			dxText.SetFontBorderColor(D3DCOLOR_ARGB(255,255,255,255));
+			dxText.SetFontBorderColor(D3DCOLOR_ARGB(255, 255, 255, 255));
 			dxText.SetFontBorderWidth(1);
 			dxText.SetFontSize(12);
 			dxText.SetFontBold(true);
@@ -287,20 +246,17 @@ void StgSystemController::RenderScriptObject()
 */
 		}
 	}
-
 }
 void StgSystemController::RenderScriptObject(int priMin, int priMax)
 {
 	ref_count_ptr<StgStageScriptObjectManager> objectManagerStage = NULL;
 	ref_count_ptr<DxScriptObjectManager> objectManagerPackage = NULL;
-	std::vector<std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync > > *pRenderListStage = NULL;
-	std::vector<std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync > > *pRenderListPackage = NULL;
-
+	std::vector<std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>>* pRenderListStage = NULL;
+	std::vector<std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>>* pRenderListPackage = NULL;
 
 	int scene = infoSystem_->GetScene();
 	bool bPause = false;
-	if(scene == StgSystemInformation::SCENE_STG)
-	{
+	if (scene == StgSystemInformation::SCENE_STG) {
 		ref_count_ptr<StgStageInformation> infoStage = stageController_->GetStageInformation();
 		bPause = infoStage->IsPause();
 	}
@@ -309,23 +265,18 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 	//・パッケージモードでない(一時停止もステージ処理側で処理するため)
 	//・パッケージスクリプトの場合は、一時停止をパッケージスクリプトで処理するため
 	//　一時停止中はSTGシーンは描画対象外とする
-	bool bValidStage = (scene == StgSystemInformation::SCENE_STG || !infoSystem_->IsPackageMode()) && 
-						stageController_ != NULL && !bPause;
-	if(bValidStage)
-	{
+	bool bValidStage = (scene == StgSystemInformation::SCENE_STG || !infoSystem_->IsPackageMode()) && stageController_ != NULL && !bPause;
+	if (bValidStage) {
 		objectManagerStage = stageController_->GetMainObjectManager();
 		objectManagerStage->PrepareRenderObject();
 		pRenderListStage = objectManagerStage->GetRenderObjectListPointer();
 	}
 
-	if(infoSystem_->IsPackageMode())
-	{
+	if (infoSystem_->IsPackageMode()) {
 		objectManagerPackage = packageController_->GetMainObjectManager();
 		objectManagerPackage->PrepareRenderObject();
 		pRenderListPackage = objectManagerPackage->GetRenderObjectListPointer();
 	}
-
-
 
 	//--------------------------------
 
@@ -339,8 +290,7 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 	D3DXVECTOR2 focusPos = orgFocusPos;
 
 	ref_count_ptr<StgStageInformation> stageInfo = NULL;
-	if(bValidStage)
-	{
+	if (bValidStage) {
 		stageInfo = stageController_->GetStageInformation();
 		RECT rcStgFrame = stageInfo->GetStgFrameRect();
 
@@ -353,9 +303,7 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 
 		orgFocusPos = camera2D->GetFocusPosition();
 		focusPos = orgFocusPos;
-	}
-	else
-	{
+	} else {
 		stageInfo = new StgStageInformation();
 
 		RECT rect;
@@ -364,8 +312,7 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 		rect.bottom = graphics->GetScreenHeight();
 
 		stageInfo->SetStgFrameRect(rect);
-		if(scene != StgSystemInformation::SCENE_STG)
-		{
+		if (scene != StgSystemInformation::SCENE_STG) {
 			//STGシーンでないならカメラ座標をリセットしておく
 			orgFocusPos = camera2D->GetFocusPosition();
 			focusPos = orgFocusPos;
@@ -375,7 +322,7 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 	RECT rcStgFrame = stageInfo->GetStgFrameRect();
 	int stgWidth = rcStgFrame.right - rcStgFrame.left;
 	int stgHeight = rcStgFrame.bottom - rcStgFrame.top;
-	POINT stgCenter = {rcStgFrame.left + stgWidth / 2, rcStgFrame.top + stgHeight / 2};
+	POINT stgCenter = { rcStgFrame.left + stgWidth / 2, rcStgFrame.top + stgHeight / 2 };
 	int priMinStgFrame = stageInfo->GetStgFrameMinPriority();
 	int priMaxStgFrame = stageInfo->GetStgFrameMaxPriority();
 	int priShot = stageInfo->GetShotObjectPriority();
@@ -386,8 +333,7 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 
 	std::vector<bool> listShotValidPriority;
 	std::vector<bool> listItemValidPriority;
-	if(bValidStage)
-	{
+	if (bValidStage) {
 		listShotValidPriority = stageController_->GetShotManager()->GetValidRenderPriorityList();
 		listItemValidPriority = stageController_->GetItemManager()->GetValidRenderPriorityList();
 	}
@@ -400,15 +346,12 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 	D3DCOLOR fogColor = D3DCOLOR_ARGB(255, 255, 255, 255);
 	float fogStart = 0;
 	float fogEnd = 0;
-	if(objectManagerStage != NULL)
-	{
+	if (objectManagerStage != NULL) {
 		bFogEnable = objectManagerStage->IsFogEneble();
 		fogColor = objectManagerStage->GetFogColor();
 		fogStart = objectManagerStage->GetFogStart();
 		fogEnd = objectManagerStage->GetFogEnd();
-	}
-	else if(objectManagerPackage != NULL)
-	{
+	} else if (objectManagerPackage != NULL) {
 		bFogEnable = objectManagerPackage->IsFogEneble();
 		fogColor = objectManagerPackage->GetFogColor();
 		fogStart = objectManagerPackage->GetFogStart();
@@ -420,17 +363,15 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 	//描画開始前リセット
 	camera2D->SetEnable(false);
 	camera2D->Reset();
-	graphics->ResetViewPort();	
+	graphics->ResetViewPort();
 
 	bool bClearZBufferFor2DCoordinate = false;
 	bool bRunMinStgFrame = false;
 	bool bRunMaxStgFrame = false;
-	for(int iPri = priMin ; iPri <= priMax ; iPri++)
-	{
-		if(iPri >= priMinStgFrame && !bRunMinStgFrame)
-		{
+	for (int iPri = priMin; iPri <= priMax; iPri++) {
+		if (iPri >= priMinStgFrame && !bRunMinStgFrame) {
 			//STGフレーム開始
-			if(bValidStage && iPri < invalidPriMin)
+			if (bValidStage && iPri < invalidPriMin)
 				graphics->ClearRenderTarget(rcStgFrame);
 
 			double clipNear = camera3D->GetNearClip();
@@ -451,41 +392,32 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 			bClearZBufferFor2DCoordinate = false;
 		}
 
-		if(objectManagerStage != NULL && !bPause)
-		{
+		if (objectManagerStage != NULL && !bPause) {
 			//シェーダ設定
 			ref_count_ptr<Shader> shader = objectManagerStage->GetShader(iPri);
-			if(shader != NULL)
-			{
+			if (shader != NULL) {
 				shader->Begin();
 			}
 
 			//ステージ描画
-			if(listShotValidPriority[iPri])
-			{
+			if (listShotValidPriority[iPri]) {
 				//弾描画
 				stageController_->GetShotManager()->Render(iPri);
 			}
-			if(listItemValidPriority[iPri])
-			{
+			if (listItemValidPriority[iPri]) {
 				//アイテム描画
 				stageController_->GetItemManager()->Render(iPri);
 			}
 
-			if(pRenderListStage != NULL && iPri < (*pRenderListStage).size())
-			{
-				std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync >::iterator itr;
-				for(itr = (*pRenderListStage)[iPri].begin() ; itr != (*pRenderListStage)[iPri].end() ; itr++)
-				{
-					if(!bClearZBufferFor2DCoordinate)
-					{
+			if (pRenderListStage != NULL && iPri < (*pRenderListStage).size()) {
+				std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>::iterator itr;
+				for (itr = (*pRenderListStage)[iPri].begin(); itr != (*pRenderListStage)[iPri].end(); itr++) {
+					if (!bClearZBufferFor2DCoordinate) {
 						DxScriptMeshObject* objMesh = dynamic_cast<DxScriptMeshObject*>((*itr).GetPointer());
-						if(objMesh != NULL)
-						{
+						if (objMesh != NULL) {
 							gstd::ref_count_ptr<DxMesh>& mesh = objMesh->GetMesh();
-							if(mesh != NULL && mesh->IsCoordinate2D())
-							{
-								graphics->GetDevice()->Clear(0, NULL, D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0,0,0), 1.0,0);
+							if (mesh != NULL && mesh->IsCoordinate2D()) {
+								graphics->GetDevice()->Clear(0, NULL, D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0, 0, 0), 1.0, 0);
 								bClearZBufferFor2DCoordinate = true;
 							}
 						}
@@ -493,39 +425,30 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 					(*itr)->Render();
 				}
 				(*pRenderListStage)[iPri].clear();
-
 			}
 
-			if(shader != NULL)
-			{
+			if (shader != NULL) {
 				shader->End();
 			}
 		}
 
 		//パッケージ
-		if(objectManagerPackage != NULL)
-		{
+		if (objectManagerPackage != NULL) {
 			//シェーダ設定
 			ref_count_ptr<Shader> shader = objectManagerPackage->GetShader(iPri);
-			if(shader != NULL)
-			{
+			if (shader != NULL) {
 				shader->Begin();
 			}
 
-			if(pRenderListPackage != NULL && iPri < (*pRenderListPackage).size())
-			{
-				std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync >::iterator itr;
-				for(itr = (*pRenderListPackage)[iPri].begin() ; itr != (*pRenderListPackage)[iPri].end() ; itr++)
-				{
-					if(!bClearZBufferFor2DCoordinate)
-					{
+			if (pRenderListPackage != NULL && iPri < (*pRenderListPackage).size()) {
+				std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>::iterator itr;
+				for (itr = (*pRenderListPackage)[iPri].begin(); itr != (*pRenderListPackage)[iPri].end(); itr++) {
+					if (!bClearZBufferFor2DCoordinate) {
 						DxScriptMeshObject* objMesh = dynamic_cast<DxScriptMeshObject*>((*itr).GetPointer());
-						if(objMesh != NULL)
-						{
+						if (objMesh != NULL) {
 							gstd::ref_count_ptr<DxMesh>& mesh = objMesh->GetMesh();
-							if(mesh != NULL && mesh->IsCoordinate2D())
-							{
-								graphics->GetDevice()->Clear(0, NULL, D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0,0,0), 1.0,0);
+							if (mesh != NULL && mesh->IsCoordinate2D()) {
+								graphics->GetDevice()->Clear(0, NULL, D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0, 0, 0), 1.0, 0);
 								bClearZBufferFor2DCoordinate = true;
 							}
 						}
@@ -534,20 +457,17 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 				}
 				(*pRenderListPackage)[iPri].clear();
 			}
-			if(shader != NULL)
-			{
+			if (shader != NULL) {
 				shader->End();
 			}
 		}
 
-		if(iPri == priCamera)
-		{
+		if (iPri == priCamera) {
 			camera2D->SetFocus(stgCenter.x, stgCenter.y);
 			camera2D->SetRatio(1);
 			camera2D->SetAngleZ(0);
 		}
-		if(iPri >= priMaxStgFrame && !bRunMaxStgFrame)
-		{
+		if (iPri >= priMaxStgFrame && !bRunMaxStgFrame) {
 			//STGフレーム終了
 			camera2D->SetEnable(false);
 			camera2D->Reset();
@@ -563,48 +483,40 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 	camera2D->SetAngleZ(focusAngleZ);
 
 	//--------------------------------
-	if(objectManagerStage != NULL)
+	if (objectManagerStage != NULL)
 		objectManagerStage->ClearRenderObject();
-	if(objectManagerPackage != NULL)
+	if (objectManagerPackage != NULL)
 		objectManagerPackage->ClearRenderObject();
 }
 void StgSystemController::_ControlScene()
 {
-	if(infoSystem_->IsPackageMode())
-	{
+	if (infoSystem_->IsPackageMode()) {
 		packageController_->Work();
 
 		ref_count_ptr<StgPackageInformation> infoPackage = packageController_->GetPackageInformation();
-		if(infoPackage->IsEnd())
-		{
+		if (infoPackage->IsEnd()) {
 			infoSystem_->SetStgEnd();
 		}
 	}
 
 	int scene = infoSystem_->GetScene();
-	switch(scene)
-	{
-	case StgSystemInformation::SCENE_STG:
-	{
+	switch (scene) {
+	case StgSystemInformation::SCENE_STG: {
 		ref_count_ptr<StgStageInformation> infoStage = stageController_->GetStageInformation();
-		if(!infoStage->IsEnd())
+		if (!infoStage->IsEnd())
 			stageController_->Work();
 
-		if(infoStage->IsEnd())
-		{
+		if (infoStage->IsEnd()) {
 			//次ステージへ
 			stageController_->CloseScene();
-			if(infoSystem_->IsPackageMode())
-			{
+			if (infoSystem_->IsPackageMode()) {
 				stageController_->RenderToTransitionTexture();
-				if(infoStage->GetResult() == StgStageInformation::RESULT_UNKNOWN)
-				{
+				if (infoStage->GetResult() == StgStageInformation::RESULT_UNKNOWN) {
 					int sceneResult = StgStageInformation::RESULT_CLEARED;
 					ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController_->GetPlayerObject();
-					if(objPlayer != NULL)
-					{
+					if (objPlayer != NULL) {
 						int statePlayer = objPlayer->GetState();
-						if(statePlayer == StgPlayerObject::STATE_END)
+						if (statePlayer == StgPlayerObject::STATE_END)
 							sceneResult = StgStageInformation::RESULT_PLAYER_DOWN;
 					}
 					infoStage->SetResult(sceneResult);
@@ -613,9 +525,9 @@ void StgSystemController::_ControlScene()
 
 				ref_count_ptr<StgPackageInformation> infoPackage = packageController_->GetPackageInformation();
 				infoPackage->FinishCurrentStage();
-			}
-			else 
+			} else {
 				TransStgEndScene();
+			}
 		}
 		break;
 	}
@@ -627,43 +539,37 @@ void StgSystemController::_ControlScene()
 		break;
 	}
 
-	if(infoSystem_->IsPackageMode())
-	{
+	if (infoSystem_->IsPackageMode()) {
 		//シーン変化時には即座にパッケージ管理機能を実行する
 		//パッケージスクリプト内で起動するシーン遷移の描画などが追いつかなくなるため
-		if(scene != infoSystem_->GetScene())
-		{
+		if (scene != infoSystem_->GetScene()) {
 			packageController_->Work();
 		}
 	}
 
 	ELogger* logger = ELogger::GetInstance();
-	if(logger->IsWindowVisible())
-	{
+	if (logger->IsWindowVisible()) {
 		//ログ関連
 		int taskCount = 0;
 		int objectCount = 0;
-		if(packageController_ != NULL)
-		{
+		if (packageController_ != NULL) {
 			ref_count_ptr<StgControlScriptManager> scriptManager = packageController_->GetScriptManager();
-			if(scriptManager != NULL) 
+			if (scriptManager != NULL)
 				taskCount = scriptManager->GetAllScriptThreadCount();
 
-			ref_count_ptr<DxScriptObjectManager> objectManager =  packageController_->GetMainObjectManager();
-			if(objectManager != NULL)
+			ref_count_ptr<DxScriptObjectManager> objectManager = packageController_->GetMainObjectManager();
+			if (objectManager != NULL)
 				objectCount += objectManager->GetAliveObjectCount();
 		}
-		if(stageController_ != NULL)
-		{
+		if (stageController_ != NULL) {
 			ref_count_ptr<StgStageInformation> infoStage = stageController_->GetStageInformation();
-			if(!infoStage->IsEnd())
-			{
+			if (!infoStage->IsEnd()) {
 				StgControlScriptManager* scriptManager = stageController_->GetScriptManagerP();
-				if(scriptManager != NULL)
+				if (scriptManager != NULL)
 					taskCount = scriptManager->GetAllScriptThreadCount();
 
-				ref_count_ptr<DxScriptObjectManager> objectManager =  stageController_->GetMainObjectManager();
-				if(objectManager != NULL)
+				ref_count_ptr<DxScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
+				if (objectManager != NULL)
 					objectCount += objectManager->GetAliveObjectCount();
 			}
 		}
@@ -691,22 +597,18 @@ void StgSystemController::StartStgScene(ref_count_ptr<StgStageStartData> startDa
 void StgSystemController::TransStgEndScene()
 {
 	bool bReplay = false;
-	if(stageController_ != NULL)
-	{
+	if (stageController_ != NULL) {
 		ref_count_ptr<StgStageInformation> infoStage = stageController_->GetStageInformation();
 		bReplay = infoStage->IsReplay();
 	}
 
-	if(!bReplay)
-	{
+	if (!bReplay) {
 		ref_count_ptr<ReplayInformation> infoReplay = CreateReplayInformation();
 		infoSystem_->SetActiveReplayInformation(infoReplay);
 		endScene_ = new StgEndScene(this);
 		endScene_->Start();
 		infoSystem_->SetScene(StgSystemInformation::SCENE_END);
-	}
-	else
-	{
+	} else {
 		infoSystem_->SetStgEnd();
 	}
 }
@@ -741,12 +643,10 @@ ref_count_ptr<ReplayInformation> StgSystemController::CreateReplayInformation()
 	double fpsAvarage = 0;
 
 	//ステージ
-	if(infoSystem_->IsPackageMode())
-	{
+	if (infoSystem_->IsPackageMode()) {
 		ref_count_ptr<StgPackageInformation> infoPackage = packageController_->GetPackageInformation();
-		std::vector<ref_count_ptr<StgStageStartData> > listStageData = infoPackage->GetStageDataList();
-		for(int iStage = 0 ; iStage < listStageData.size() ; iStage++)
-		{
+		std::vector<ref_count_ptr<StgStageStartData>> listStageData = infoPackage->GetStageDataList();
+		for (int iStage = 0; iStage < listStageData.size(); iStage++) {
 			ref_count_ptr<StgStageStartData> stageData = listStageData[iStage];
 			ref_count_ptr<StgStageInformation> infoStage = stageData->GetStageInformation();
 			ref_count_ptr<ReplayInformation::StageData> replayStageData = infoStage->GetReplayData();
@@ -754,11 +654,9 @@ ref_count_ptr<ReplayInformation> StgSystemController::CreateReplayInformation()
 
 			fpsAvarage += replayStageData->GetFramePerSecondAvarage();
 		}
-		if(listStageData.size() > 0)
+		if (listStageData.size() > 0)
 			fpsAvarage = fpsAvarage / listStageData.size();
-	}
-	else
-	{
+	} else {
 		ref_count_ptr<StgStageController> stageController = stageController_;
 		ref_count_ptr<ReplayInformation::StageData> replayStageData = infoLastStage->GetReplayData();
 		res->SetStageData(0, replayStageData);
@@ -777,42 +675,36 @@ ref_count_ptr<ReplayInformation> StgSystemController::CreateReplayInformation()
 void StgSystemController::TerminateScriptAll()
 {
 	std::wstring error = L"force terminate";
-	if(packageController_ != NULL)
-	{
+	if (packageController_ != NULL) {
 		ref_count_ptr<ScriptManager> scriptManager = packageController_->GetScriptManager();
-		if(scriptManager != NULL)
+		if (scriptManager != NULL)
 			scriptManager->TerminateScriptAll(error);
 	}
 
-	if(stageController_ != NULL)
-	{
+	if (stageController_ != NULL) {
 		ScriptManager* scriptManager = stageController_->GetScriptManagerP();
-		if(scriptManager != NULL)
+		if (scriptManager != NULL)
 			scriptManager->TerminateScriptAll(error);
 
 		ref_count_ptr<StgPauseScene> pauseScene = stageController_->GetPauseManager();
-		if(pauseScene != NULL)
-		{
+		if (pauseScene != NULL) {
 			ref_count_ptr<ScriptManager> pauseScriptManager = pauseScene->GetScriptManager();
-			if(pauseScriptManager != NULL)
+			if (pauseScriptManager != NULL)
 				pauseScriptManager->TerminateScriptAll(error);
 		}
 	}
 
-	if(endScene_ != NULL)
-	{
+	if (endScene_ != NULL) {
 		ref_count_ptr<ScriptManager> scriptManager = endScene_->GetScriptManager();
-		if(scriptManager != NULL)
+		if (scriptManager != NULL)
 			scriptManager->TerminateScriptAll(error);
 	}
 
-	if(replaySaveScene_ != NULL)
-	{
+	if (replaySaveScene_ != NULL) {
 		ref_count_ptr<ScriptManager> scriptManager = replaySaveScene_->GetScriptManager();
-		if(scriptManager != NULL)
+		if (scriptManager != NULL)
 			scriptManager->TerminateScriptAll(error);
 	}
-
 }
 
 /**********************************************************
@@ -838,10 +730,10 @@ std::wstring StgSystemInformation::GetErrorMessage()
 {
 	std::wstring res = L"";
 	std::list<std::wstring>::iterator itr = listError_.begin();
-	for(; itr != listError_.end() ; itr++)
-	{
+	for (; itr != listError_.end(); itr++) {
 		std::wstring str = (*itr);
-		if(str == L"Retry")continue;
+		if (str == L"Retry")
+			continue;
 		res += str + L"\r\n" + L"\r\n";
 	}
 	return res;

--- a/source/TouhouDanmakufu/Common/StgSystem.hpp
+++ b/source/TouhouDanmakufu/Common/StgSystem.hpp
@@ -1,147 +1,138 @@
 #ifndef __TOUHOUDANMAKUFU_DNHSTG_SYSTEM__
 #define __TOUHOUDANMAKUFU_DNHSTG_SYSTEM__
 
-#include"StgCommon.hpp"
-#include"StgStageScript.hpp"
-#include"StgStageController.hpp"
-#include"StgPlayer.hpp"
-#include"StgEnemy.hpp"
-#include"StgShot.hpp"
-#include"StgItem.hpp"
-#include"StgIntersection.hpp"
-#include"StgUserExtendScene.hpp"
-#include"StgPackageController.hpp"
-
+#include "StgCommon.hpp"
+#include "StgEnemy.hpp"
+#include "StgIntersection.hpp"
+#include "StgItem.hpp"
+#include "StgPackageController.hpp"
+#include "StgPlayer.hpp"
+#include "StgShot.hpp"
+#include "StgStageController.hpp"
+#include "StgStageScript.hpp"
+#include "StgUserExtendScene.hpp"
 
 class StgSystemInformation;
 /**********************************************************
 //StgSystemController
 **********************************************************/
-class StgSystemController : public TaskBase
-{
-	public:
-		enum
-		{
-			TASK_PRI_WORK = 4,
-			TASK_PRI_RENDER = 4,
-		};
+class StgSystemController : public TaskBase {
+public:
+	enum {
+		TASK_PRI_WORK = 4,
+		TASK_PRI_RENDER = 4,
+	};
 
-	protected:
-		ref_count_ptr<StgSystemInformation> infoSystem_;
-		ref_count_ptr<ScriptEngineCache> scriptEngineCache_;
-		gstd::ref_count_ptr<ScriptCommonDataManager> commonDataManager_;
+public:
+	StgSystemController();
+	~StgSystemController();
+	void Initialize(ref_count_ptr<StgSystemInformation> infoSystem);
+	void Start(ref_count_ptr<ScriptInformation> infoPlayer, ref_count_ptr<ReplayInformation> infoReplay);
+	void Work();
+	void Render();
+	void RenderScriptObject();
+	void RenderScriptObject(int priMin, int priMax);
 
-		ref_count_ptr<StgEndScene> endScene_;
-		ref_count_ptr<StgReplaySaveScene> replaySaveScene_;
+	ref_count_ptr<StgSystemInformation>& GetSystemInformation() { return infoSystem_; }
+	StgStageController* GetStageController() { return stageController_.GetPointer(); }
+	StgPackageController* GetPackageController() { return packageController_.GetPointer(); }
+	ref_count_ptr<StgControlScriptInformation>& GetControlScriptInformation() { return infoControlScript_; }
 
-		ref_count_ptr<StgStageController> stageController_;
+	gstd::ref_count_ptr<ScriptEngineCache> GetScriptEngineCache() { return scriptEngineCache_; }
+	gstd::ref_count_ptr<ScriptCommonDataManager> GetCommonDataManager() { return commonDataManager_; }
 
-		ref_count_ptr<StgPackageController> packageController_;
-		ref_count_ptr<StgControlScriptInformation> infoControlScript_;
+	void StartStgScene(ref_count_ptr<StgStageInformation> infoStage, ref_count_ptr<ReplayInformation::StageData> replayStageData);
+	void StartStgScene(ref_count_ptr<StgStageStartData> startData);
 
-		virtual void DoEnd() = 0;
-		virtual void DoRetry() = 0;
-		void _ControlScene();
+	void TransStgEndScene();
+	void TransReplaySaveScene();
 
-	public:
-		StgSystemController();
-		~StgSystemController();
-		void Initialize(ref_count_ptr<StgSystemInformation> infoSystem);
-		void Start(ref_count_ptr<ScriptInformation> infoPlayer, ref_count_ptr<ReplayInformation> infoReplay);
-		void Work();
-		void Render();
-		void RenderScriptObject();
-		void RenderScriptObject(int priMin, int priMax);
+	ref_count_ptr<ReplayInformation> CreateReplayInformation();
+	void TerminateScriptAll();
 
-		ref_count_ptr<StgSystemInformation>& GetSystemInformation(){return infoSystem_;}
-		StgStageController* GetStageController(){return stageController_.GetPointer();}
-		StgPackageController* GetPackageController(){return packageController_.GetPointer();}
-		ref_count_ptr<StgControlScriptInformation>& GetControlScriptInformation(){return infoControlScript_;}
+protected:
+	virtual void DoEnd() = 0;
+	virtual void DoRetry() = 0;
+	void _ControlScene();
 
+	ref_count_ptr<StgSystemInformation> infoSystem_;
+	ref_count_ptr<ScriptEngineCache> scriptEngineCache_;
+	gstd::ref_count_ptr<ScriptCommonDataManager> commonDataManager_;
 
-		gstd::ref_count_ptr<ScriptEngineCache> GetScriptEngineCache(){return scriptEngineCache_;}
-		gstd::ref_count_ptr<ScriptCommonDataManager> GetCommonDataManager(){return commonDataManager_;}
+	ref_count_ptr<StgEndScene> endScene_;
+	ref_count_ptr<StgReplaySaveScene> replaySaveScene_;
 
-		void StartStgScene(ref_count_ptr<StgStageInformation> infoStage, ref_count_ptr<ReplayInformation::StageData> replayStageData);
-		void StartStgScene(ref_count_ptr<StgStageStartData> startData);
+	ref_count_ptr<StgStageController> stageController_;
 
-		void TransStgEndScene();
-		void TransReplaySaveScene();
-
-		ref_count_ptr<ReplayInformation> CreateReplayInformation();
-		void TerminateScriptAll();
+	ref_count_ptr<StgPackageController> packageController_;
+	ref_count_ptr<StgControlScriptInformation> infoControlScript_;
 };
 
 /**********************************************************
 //StgSystemInformation
 **********************************************************/
-class StgSystemInformation
-{
-	public:
-		enum
-		{
-			SCENE_NULL,
-			SCENE_PACKAGE_CONTROL,
-			SCENE_STG,
-			SCENE_REPLAY_SAVE,
-			SCENE_END,
-		};
+class StgSystemInformation {
+public:
+	enum {
+		SCENE_NULL,
+		SCENE_PACKAGE_CONTROL,
+		SCENE_STG,
+		SCENE_REPLAY_SAVE,
+		SCENE_END,
+	};
 
-	private:
-		int scene_;
-		bool bEndStg_;
-		bool bRetry_;
+public:
+	StgSystemInformation();
+	virtual ~StgSystemInformation();
 
-		std::wstring pathPauseScript_;
-		std::wstring pathEndSceneScript_;
-		std::wstring pathReplaySaveSceneScript_;
+	bool IsPackageMode();
+	void ResetRetry();
+	int GetScene() { return scene_; }
+	void SetScene(int scene) { scene_ = scene; }
+	bool IsStgEnd() { return bEndStg_; }
+	void SetStgEnd() { bEndStg_ = true; }
+	bool IsRetry() { return bRetry_; }
+	void SetRetry() { bRetry_ = true; }
+	bool IsError() { return listError_.size() > 0; }
+	void SetError(std::wstring error) { listError_.push_back(error); }
+	std::wstring GetErrorMessage();
 
-		std::list<std::wstring> listError_;
-		ref_count_ptr<ScriptInformation> infoMain_;
-		ref_count_ptr<ReplayInformation> infoReplayActive_; //アクティブリプレイ情報
+	std::wstring GetPauseScriptPath() { return pathPauseScript_; }
+	void SetPauseScriptPath(std::wstring path) { pathPauseScript_ = path; }
+	std::wstring GetEndSceneScriptPath() { return pathEndSceneScript_; }
+	void SetEndSceneScriptPath(std::wstring path) { pathEndSceneScript_ = path; }
+	std::wstring GetReplaySaveSceneScriptPath() { return pathReplaySaveSceneScript_; }
+	void SetReplaySaveSceneScriptPath(std::wstring path) { pathReplaySaveSceneScript_ = path; }
 
-		int invalidPriMin_;
-		int invalidPriMax_;
-		std::set<int> listReplayTargetKey_;
+	ref_count_ptr<ScriptInformation> GetMainScriptInformation() { return infoMain_; }
+	void SetMainScriptInformation(ref_count_ptr<ScriptInformation> info) { infoMain_ = info; }
 
-	public:
-		StgSystemInformation();
-		virtual ~StgSystemInformation();
+	ref_count_ptr<ReplayInformation> GetActiveReplayInformation() { return infoReplayActive_; }
+	void SetActiveReplayInformation(ref_count_ptr<ReplayInformation> info) { infoReplayActive_ = info; }
 
-		bool IsPackageMode();
-		void ResetRetry();
-		int GetScene(){return scene_;}
-		void SetScene(int scene){scene_ = scene;}
-		bool IsStgEnd(){return bEndStg_;}
-		void SetStgEnd(){bEndStg_ = true;}
-		bool IsRetry(){return bRetry_;}
-		void SetRetry(){bRetry_ = true;}
-		bool IsError(){return listError_.size() > 0;}
-		void SetError(std::wstring error){listError_.push_back(error);}
-		std::wstring GetErrorMessage();
+	void SetInvaridRenderPriority(int priMin, int priMax);
+	int GetInvaridRenderPriorityMin() { return invalidPriMin_; }
+	int GetInvaridRenderPriorityMax() { return invalidPriMax_; }
 
-		std::wstring GetPauseScriptPath(){return pathPauseScript_;}
-		void SetPauseScriptPath(std::wstring path){pathPauseScript_ = path;}
-		std::wstring GetEndSceneScriptPath(){return pathEndSceneScript_;}
-		void SetEndSceneScriptPath(std::wstring path){pathEndSceneScript_ = path;}
-		std::wstring GetReplaySaveSceneScriptPath(){return pathReplaySaveSceneScript_;}
-		void SetReplaySaveSceneScriptPath(std::wstring path){pathReplaySaveSceneScript_ = path;}
+	void AddReplayTargetKey(int id) { listReplayTargetKey_.insert(id); }
+	std::set<int> GetReplayTargetKeyList() { return listReplayTargetKey_; }
 
-		ref_count_ptr<ScriptInformation> GetMainScriptInformation(){return infoMain_;}
-		void SetMainScriptInformation(ref_count_ptr<ScriptInformation> info){infoMain_ = info;}
+private:
+	int scene_;
+	bool bEndStg_;
+	bool bRetry_;
 
-		ref_count_ptr<ReplayInformation> GetActiveReplayInformation(){return infoReplayActive_;}
-		void SetActiveReplayInformation(ref_count_ptr<ReplayInformation> info){infoReplayActive_ = info;}
+	std::wstring pathPauseScript_;
+	std::wstring pathEndSceneScript_;
+	std::wstring pathReplaySaveSceneScript_;
 
-		void SetInvaridRenderPriority(int priMin, int priMax);
-		int GetInvaridRenderPriorityMin(){return invalidPriMin_;}
-		int GetInvaridRenderPriorityMax(){return invalidPriMax_;}
+	std::list<std::wstring> listError_;
+	ref_count_ptr<ScriptInformation> infoMain_;
+	ref_count_ptr<ReplayInformation> infoReplayActive_; //アクティブリプレイ情報
 
-		void AddReplayTargetKey(int id){listReplayTargetKey_.insert(id);}
-		std::set<int> GetReplayTargetKeyList(){return listReplayTargetKey_;}
-
+	int invalidPriMin_;
+	int invalidPriMax_;
+	std::set<int> listReplayTargetKey_;
 };
-
-
 
 #endif

--- a/source/TouhouDanmakufu/Common/StgUserExtendScene.cpp
+++ b/source/TouhouDanmakufu/Common/StgUserExtendScene.cpp
@@ -1,7 +1,7 @@
-#include"StgUserExtendScene.hpp"
+#include "StgUserExtendScene.hpp"
 
-#include"StgSystem.hpp"
-#include"StgStageScript.hpp"
+#include "StgStageScript.hpp"
+#include "StgSystem.hpp"
 
 /**********************************************************
 //StgUserExtendScene
@@ -17,46 +17,45 @@ void StgUserExtendScene::_InitializeTransitionTexture()
 {
 	//画面キャプチャ
 	StgStageController* stageController = systemController_->GetStageController();
-	if(stageController != NULL)
-	{
+	if (stageController != NULL)
 		stageController->RenderToTransitionTexture();
-	}
-
 }
 void StgUserExtendScene::_InitializeScript(std::wstring path, int type)
 {
-	if(scriptManager_ == NULL)return;
+	if (scriptManager_ == NULL)
+		return;
 	_int64 idScript = scriptManager_->LoadScript(path, type);
 	scriptManager_->StartScript(idScript);
 }
 void StgUserExtendScene::_CallScriptMainLoop()
 {
-	if(scriptManager_ == NULL)return;
+	if (scriptManager_ == NULL)
+		return;
 	scriptManager_->Work();
 }
 void StgUserExtendScene::_CallScriptFinalize()
 {
-	if(scriptManager_ == NULL)return;
+	if (scriptManager_ == NULL)
+		return;
 	scriptManager_->CallScriptFinalizeAll();
 }
 void StgUserExtendScene::_AddRelativeManager()
 {
-	if(scriptManager_ == NULL)return;
+	if (scriptManager_ == NULL)
+		return;
 	ref_count_ptr<ScriptManager> scriptManager = scriptManager_;
 
 	StgStageController* stageController = systemController_->GetStageController();
-	if(stageController != NULL)
-	{
+	if (stageController != NULL) {
 		ref_count_ptr<ScriptManager> stageScriptManager = stageController->GetScriptManagerR();
-		if(stageScriptManager != NULL)
+		if (stageScriptManager != NULL)
 			ScriptManager::AddRelativeScriptManagerMutual(scriptManager, stageScriptManager);
 	}
 
 	StgPackageController* packageController = systemController_->GetPackageController();
-	if(packageController != NULL)
-	{
+	if (packageController != NULL) {
 		ref_count_ptr<ScriptManager> packageScriptManager = packageController->GetScriptManager();
-		if(packageScriptManager != NULL)
+		if (packageScriptManager != NULL)
 			ScriptManager::AddRelativeScriptManagerMutual(scriptManager, packageScriptManager);
 	}
 }
@@ -66,7 +65,8 @@ void StgUserExtendScene::Work()
 }
 void StgUserExtendScene::Render()
 {
-	if(scriptManager_ == NULL)return;
+	if (scriptManager_ == NULL)
+		return;
 	scriptManager_->Render();
 }
 
@@ -90,16 +90,12 @@ StgUserExtendSceneScriptManager::~StgUserExtendSceneScriptManager()
 }
 void StgUserExtendSceneScriptManager::Work()
 {
-	if(!IsError())
-	{
+	if (!IsError()) {
 		StgControlScriptManager::Work();
 		objectManager_->WorkObject();
-	}
-	else
-	{
+	} else {
 		systemController_->GetSystemInformation()->SetError(error_);
 	}
-
 }
 void StgUserExtendSceneScriptManager::Render()
 {
@@ -108,21 +104,19 @@ void StgUserExtendSceneScriptManager::Render()
 ref_count_ptr<ManagedScript> StgUserExtendSceneScriptManager::Create(int type)
 {
 	ref_count_ptr<ManagedScript> res;
-	switch(type)
-	{
-		case StgUserExtendSceneScript::TYPE_PAUSE_SCENE:
-			res = new StgPauseSceneScript(systemController_);
-			break;
-		case StgUserExtendSceneScript::TYPE_END_SCENE:
-			res = new StgEndSceneScript(systemController_);
-			break;
-		case StgUserExtendSceneScript::TYPE_REPLAY_SCENE:
-			res = new StgReplaySaveScript(systemController_);
-			break;
+	switch (type) {
+	case StgUserExtendSceneScript::TYPE_PAUSE_SCENE:
+		res = new StgPauseSceneScript(systemController_);
+		break;
+	case StgUserExtendSceneScript::TYPE_END_SCENE:
+		res = new StgEndSceneScript(systemController_);
+		break;
+	case StgUserExtendSceneScript::TYPE_REPLAY_SCENE:
+		res = new StgReplaySaveScript(systemController_);
+		break;
 	}
 
-	if(res != NULL)
-	{
+	if (res != NULL) {
 		res->SetObjectManager(objectManager_);
 		res->SetScriptManager(this);
 	}
@@ -131,24 +125,21 @@ ref_count_ptr<ManagedScript> StgUserExtendSceneScriptManager::Create(int type)
 }
 void StgUserExtendSceneScriptManager::CallScriptFinalizeAll()
 {
-	std::list<ref_count_ptr<ManagedScript> >::iterator itr = listScriptRun_.begin();
-	for(; itr != listScriptRun_.end(); itr++)
-	{
+	std::list<ref_count_ptr<ManagedScript>>::iterator itr = listScriptRun_.begin();
+	for (; itr != listScriptRun_.end(); itr++) {
 		ref_count_ptr<ManagedScript> script = (*itr);
-		if(script->IsEventExists("Finalize"))
+		if (script->IsEventExists("Finalize"))
 			script->Run("Finalize");
 	}
 }
 gstd::value StgUserExtendSceneScriptManager::GetResultValue()
 {
 	gstd::value res;
-	std::list<ref_count_ptr<ManagedScript> >::iterator itr = listScriptRun_.begin();
-	for(; itr != listScriptRun_.end(); itr++)
-	{
+	std::list<ref_count_ptr<ManagedScript>>::iterator itr = listScriptRun_.begin();
+	for (; itr != listScriptRun_.end(); itr++) {
 		ref_count_ptr<ManagedScript> script = (*itr);
 		gstd::value v = script->GetResultValue();
-		if(v.has_data())
-		{
+		if (v.has_data()) {
 			res = v;
 			break;
 		}
@@ -157,7 +148,8 @@ gstd::value StgUserExtendSceneScriptManager::GetResultValue()
 }
 bool StgUserExtendSceneScriptManager::IsRealValue(gstd::value val)
 {
-	if(listScriptRun_.size() == 0)return false;
+	if (listScriptRun_.size() == 0)
+		return false;
 	ref_count_ptr<ManagedScript> script = *listScriptRun_.begin();
 
 	bool res = script->IsRealValue(val);
@@ -167,7 +159,8 @@ bool StgUserExtendSceneScriptManager::IsRealValue(gstd::value val)
 /**********************************************************
 //StgUserExtendSceneScript
 **********************************************************/
-StgUserExtendSceneScript::StgUserExtendSceneScript(StgSystemController* systemController) : StgControlScript(systemController)
+StgUserExtendSceneScript::StgUserExtendSceneScript(StgSystemController* systemController)
+	: StgControlScript(systemController)
 {
 	StgStageController* stageController = systemController_->GetStageController();
 
@@ -179,11 +172,11 @@ StgUserExtendSceneScript::~StgUserExtendSceneScript()
 {
 }
 
-
 /**********************************************************
 //StgPauseScene
 **********************************************************/
-StgPauseScene::StgPauseScene(StgSystemController* controller) : StgUserExtendScene(controller)
+StgPauseScene::StgPauseScene(StgSystemController* controller)
+	: StgUserExtendScene(controller)
 {
 }
 StgPauseScene::~StgPauseScene()
@@ -191,34 +184,26 @@ StgPauseScene::~StgPauseScene()
 }
 void StgPauseScene::Work()
 {
-	if(scriptManager_ == NULL)return;
+	if (scriptManager_ == NULL)
+		return;
 	_CallScriptMainLoop();
 
 	ref_count_ptr<StgSystemInformation> infoSystem = systemController_->GetSystemInformation();
 	ref_count_ptr<StgStageInformation> infoStage = systemController_->GetStageController()->GetStageInformation();
 	gstd::value resValue = scriptManager_->GetResultValue();
-	if(scriptManager_->IsRealValue(resValue))
-	{
+	if (scriptManager_->IsRealValue(resValue)) {
 		int result = (int)resValue.as_real();
-		if(result == StgControlScript::RESULT_CANCEL)
-		{
-		}
-		else if(result == StgControlScript::RESULT_END)
-		{
-			if(infoSystem->IsPackageMode())
-			{
+		if (result == StgControlScript::RESULT_CANCEL) {
+		} else if (result == StgControlScript::RESULT_END) {
+			if (infoSystem->IsPackageMode()) {
 				infoStage->SetResult(StgStageInformation::RESULT_BREAK_OFF);
 				infoStage->SetEnd();
-				//infoSystem->SetScene(StgSystemInformation::SCENE_PACKAGE_CONTROL);
-			}
-			else
-			{
+				// infoSystem->SetScene(StgSystemInformation::SCENE_PACKAGE_CONTROL);
+			} else {
 				infoSystem->SetStgEnd();
 			}
-		}
-		else if(result == StgControlScript::RESULT_RETRY)
-		{
-			if(!infoStage->IsReplay())
+		} else if (result == StgControlScript::RESULT_RETRY) {
+			if (!infoStage->IsReplay())
 				infoSystem->SetRetry();
 		}
 		EDirectInput::GetInstance()->ResetInputState();
@@ -245,16 +230,17 @@ void StgPauseScene::Start()
 	std::wstring path = sysInfo->GetPauseScriptPath();
 	_InitializeScript(path, StgUserExtendSceneScript::TYPE_PAUSE_SCENE);
 
-	if(stageController != NULL)
+	if (stageController != NULL)
 		stageController->GetStageInformation()->SetPause(true);
 }
 void StgPauseScene::Finish()
 {
 	StgStageController* stageController = systemController_->GetStageController();
-	if(stageController != NULL)
+	if (stageController != NULL)
 		stageController->GetStageInformation()->SetPause(false);
 
-	if(scriptManager_ == NULL)return;
+	if (scriptManager_ == NULL)
+		return;
 	_CallScriptFinalize();
 	scriptManager_ = NULL;
 
@@ -266,15 +252,15 @@ void StgPauseScene::Finish()
 /**********************************************************
 //StgPauseSceneScript
 **********************************************************/
-const function stgPauseFunction[] =  
-{
+const function stgPauseFunction[] = {
 	//関数：
 
 	//定数：
-	{"__stgPauseFunction__", constant<0>::func, 0},
+	{ "__stgPauseFunction__", constant<0>::func, 0 },
 
 };
-StgPauseSceneScript::StgPauseSceneScript(StgSystemController* controller) : StgUserExtendSceneScript(controller)
+StgPauseSceneScript::StgPauseSceneScript(StgSystemController* controller)
+	: StgUserExtendSceneScript(controller)
 {
 	typeScript_ = TYPE_PAUSE_SCENE;
 	_AddFunction(stgPauseFunction, sizeof(stgPauseFunction) / sizeof(function));
@@ -285,44 +271,37 @@ StgPauseSceneScript::~StgPauseSceneScript()
 
 //一時停止専用関数：一時停止操作
 
-
 /**********************************************************
 //StgEndScene
 **********************************************************/
-StgEndScene::StgEndScene(StgSystemController* controller) : StgUserExtendScene(controller)
+StgEndScene::StgEndScene(StgSystemController* controller)
+	: StgUserExtendScene(controller)
 {
-
 }
 StgEndScene::~StgEndScene()
 {
 }
 void StgEndScene::Work()
 {
-	if(scriptManager_ == NULL)return;
+	if (scriptManager_ == NULL)
+		return;
 	_CallScriptMainLoop();
 
 	ref_count_ptr<StgSystemInformation> infoSystem = systemController_->GetSystemInformation();
 	gstd::value resValue = scriptManager_->GetResultValue();
-	if(scriptManager_->IsRealValue(resValue))
-	{
+	if (scriptManager_->IsRealValue(resValue)) {
 		int result = (int)resValue.as_real();
-		if(result == StgControlScript::RESULT_SAVE_REPLAY)
-		{
-			//info->SetStgEnd();
+		if (result == StgControlScript::RESULT_SAVE_REPLAY) {
+			// info->SetStgEnd();
 			systemController_->TransReplaySaveScene();
-		}
-		else if(result == StgControlScript::RESULT_END)
-		{
+		} else if (result == StgControlScript::RESULT_END) {
 			infoSystem->SetStgEnd();
-		}
-		else if(result == StgControlScript::RESULT_RETRY)
-		{
+		} else if (result == StgControlScript::RESULT_RETRY) {
 			infoSystem->SetRetry();
 		}
 		EDirectInput::GetInstance()->ResetInputState();
 		Finish();
 	}
-
 }
 
 void StgEndScene::Start()
@@ -343,7 +322,8 @@ void StgEndScene::Finish()
 {
 	ref_count_ptr<StgSystemInformation> info = systemController_->GetSystemInformation();
 
-	if(scriptManager_ == NULL)return;
+	if (scriptManager_ == NULL)
+		return;
 	_CallScriptFinalize();
 	scriptManager_ = NULL;
 }
@@ -351,15 +331,15 @@ void StgEndScene::Finish()
 /**********************************************************
 //StgEndSceneScript
 **********************************************************/
-const function stgEndFunction[] =  
-{
+const function stgEndFunction[] = {
 	//関数：
 
 	//定数：
-	{"__stgEndFunction__", constant<0>::func, 0},
+	{ "__stgEndFunction__", constant<0>::func, 0 },
 
 };
-StgEndSceneScript::StgEndSceneScript(StgSystemController* controller) : StgUserExtendSceneScript(controller)
+StgEndSceneScript::StgEndSceneScript(StgSystemController* controller)
+	: StgUserExtendSceneScript(controller)
 {
 	typeScript_ = TYPE_END_SCENE;
 	_AddFunction(stgEndFunction, sizeof(stgEndFunction) / sizeof(function));
@@ -371,29 +351,26 @@ StgEndSceneScript::~StgEndSceneScript()
 /**********************************************************
 //StgReplaySaveScene
 **********************************************************/
-StgReplaySaveScene::StgReplaySaveScene(StgSystemController* controller) : StgUserExtendScene(controller)
+StgReplaySaveScene::StgReplaySaveScene(StgSystemController* controller)
+	: StgUserExtendScene(controller)
 {
-
 }
 StgReplaySaveScene::~StgReplaySaveScene()
 {
 }
 void StgReplaySaveScene::Work()
 {
-	if(scriptManager_ == NULL)return;
+	if (scriptManager_ == NULL)
+		return;
 	_CallScriptMainLoop();
 
 	ref_count_ptr<StgSystemInformation> infoSystem = systemController_->GetSystemInformation();
 	gstd::value resValue = scriptManager_->GetResultValue();
-	if(scriptManager_->IsRealValue(resValue))
-	{
+	if (scriptManager_->IsRealValue(resValue)) {
 		int result = (int)resValue.as_real();
-		if(result == StgControlScript::RESULT_END)
-		{
+		if (result == StgControlScript::RESULT_END) {
 			infoSystem->SetStgEnd();
-		}
-		else if(result == StgControlScript::RESULT_CANCEL)
-		{
+		} else if (result == StgControlScript::RESULT_CANCEL) {
 			systemController_->TransStgEndScene();
 		}
 
@@ -410,7 +387,7 @@ void StgReplaySaveScene::Start()
 
 	ref_count_ptr<StgSystemInformation> info = systemController_->GetSystemInformation();
 
-	//_InitializeTransitionTexture();
+	// _InitializeTransitionTexture();
 
 	//スクリプト初期化
 	std::wstring path = info->GetReplaySaveSceneScriptPath();
@@ -420,7 +397,8 @@ void StgReplaySaveScene::Finish()
 {
 	ref_count_ptr<StgSystemInformation> info = systemController_->GetSystemInformation();
 
-	if(scriptManager_ == NULL)return;
+	if (scriptManager_ == NULL)
+		return;
 	_CallScriptFinalize();
 	scriptManager_ = NULL;
 }
@@ -428,15 +406,15 @@ void StgReplaySaveScene::Finish()
 /**********************************************************
 //StgReplaySaveScript
 **********************************************************/
-const function stgReplaySaveFunction[] =  
-{
+const function stgReplaySaveFunction[] = {
 	//関数：
 
 	//定数：
-	{"__stgReplaySaveFunction__", constant<0>::func, 0},
+	{ "__stgReplaySaveFunction__", constant<0>::func, 0 },
 
 };
-StgReplaySaveScript::StgReplaySaveScript(StgSystemController* controller) : StgUserExtendSceneScript(controller)
+StgReplaySaveScript::StgReplaySaveScript(StgSystemController* controller)
+	: StgUserExtendSceneScript(controller)
 {
 	typeScript_ = TYPE_REPLAY_SCENE;
 	_AddFunction(stgReplaySaveFunction, sizeof(stgReplaySaveFunction) / sizeof(function));

--- a/source/TouhouDanmakufu/Common/StgUserExtendScene.hpp
+++ b/source/TouhouDanmakufu/Common/StgUserExtendScene.hpp
@@ -1,194 +1,155 @@
 #ifndef __TOUHOUDANMAKUFU_DNHSTG_USER_EXTEND_SCENE__
 #define __TOUHOUDANMAKUFU_DNHSTG_USER_EXTEND_SCENE__
 
-#include"StgCommon.hpp"
-#include"StgControlScript.hpp"
+#include "StgCommon.hpp"
+#include "StgControlScript.hpp"
 
 /**********************************************************
 //StgUserExtendScene
 **********************************************************/
 class StgUserExtendSceneScriptManager;
-class StgUserExtendScene
-{
-	protected:
-		StgSystemController* systemController_;
-		ref_count_ptr<StgUserExtendSceneScriptManager> scriptManager_;
+class StgUserExtendScene {
+public:
+	StgUserExtendScene(StgSystemController* controller);
+	virtual ~StgUserExtendScene();
+	ref_count_ptr<StgUserExtendSceneScriptManager> GetScriptManager() { return scriptManager_; }
 
-		void _InitializeTransitionTexture();
-		void _InitializeScript(std::wstring path, int type);
-		void _CallScriptMainLoop();
-		void _CallScriptFinalize();
-		void _AddRelativeManager();
-	public:
-		StgUserExtendScene(StgSystemController* controller);
-		virtual ~StgUserExtendScene();
-		ref_count_ptr<StgUserExtendSceneScriptManager> GetScriptManager(){return scriptManager_;}
+	virtual void Work();
+	virtual void Render();
 
-		virtual void Work();
-		virtual void Render();
+	virtual void Start();
+	virtual void Finish();
 
-		virtual void Start();
-		virtual void Finish();
+protected:
+	void _InitializeTransitionTexture();
+	void _InitializeScript(std::wstring path, int type);
+	void _CallScriptMainLoop();
+	void _CallScriptFinalize();
+	void _AddRelativeManager();
 
+	StgSystemController* systemController_;
+	ref_count_ptr<StgUserExtendSceneScriptManager> scriptManager_;
 };
 
 /**********************************************************
 //StgUserExtendSceneScriptManager
 **********************************************************/
 class StgUserExtendSceneScript;
-class StgUserExtendSceneScriptManager : public StgControlScriptManager
-{
-	protected:
-		StgSystemController* systemController_;
-		ref_count_ptr<DxScriptObjectManager> objectManager_;
+class StgUserExtendSceneScriptManager : public StgControlScriptManager {
+public:
+	StgUserExtendSceneScriptManager(StgSystemController* controller);
+	virtual ~StgUserExtendSceneScriptManager();
+	virtual void Work();
+	virtual void Render();
+	virtual ref_count_ptr<ManagedScript> Create(int type);
 
-	public:
-		StgUserExtendSceneScriptManager(StgSystemController* controller);
-		virtual ~StgUserExtendSceneScriptManager();
-		virtual void Work();
-		virtual void Render();
-		virtual ref_count_ptr<ManagedScript> Create(int type);
+	void CallScriptFinalizeAll();
+	gstd::value GetResultValue();
+	bool IsRealValue(gstd::value val);
 
-		void CallScriptFinalizeAll();
-		gstd::value GetResultValue();
-		bool IsRealValue(gstd::value val);
+protected:
+	StgSystemController* systemController_;
+	ref_count_ptr<DxScriptObjectManager> objectManager_;
 };
 
 /**********************************************************
 //StgUserExtendSceneScript
 **********************************************************/
-class StgUserExtendSceneScript : public StgControlScript
-{
-	public:
-		enum
-		{
-			TYPE_PAUSE_SCENE,
-			TYPE_END_SCENE,
-			TYPE_REPLAY_SCENE,
-		};
+class StgUserExtendSceneScript : public StgControlScript {
+public:
+	enum {
+		TYPE_PAUSE_SCENE,
+		TYPE_END_SCENE,
+		TYPE_REPLAY_SCENE,
+	};
 
-	protected:
-
-
-	public:
-		StgUserExtendSceneScript(StgSystemController* controller);
-		virtual ~StgUserExtendSceneScript();
+public:
+	StgUserExtendSceneScript(StgSystemController* controller);
+	virtual ~StgUserExtendSceneScript();
 };
 
 /**********************************************************
 //StgPauseScene
 **********************************************************/
 class StgPauseSceneScript;
-class StgPauseScene : public StgUserExtendScene
-{
-	public:
+class StgPauseScene : public StgUserExtendScene {
+public:
+	StgPauseScene(StgSystemController* controller);
+	virtual ~StgPauseScene();
 
-	private:
+	virtual void Work();
 
-	public:
-		StgPauseScene(StgSystemController* controller);
-		virtual ~StgPauseScene();
-
-		virtual void Work();
-
-		virtual void Start();
-		virtual void Finish();
+	virtual void Start();
+	virtual void Finish();
 };
 
-class StgPauseSceneScript : public StgUserExtendSceneScript
-{
-	public:
-		enum
-		{
+class StgPauseSceneScript : public StgUserExtendSceneScript {
+public:
+	enum {
 
-		};
+	};
 
-	protected:
-
-
-	public:
-		StgPauseSceneScript(StgSystemController* controller);
-		virtual ~StgPauseSceneScript();
+public:
+	StgPauseSceneScript(StgSystemController* controller);
+	virtual ~StgPauseSceneScript();
 };
-
 
 /**********************************************************
 //StgEndScene
 **********************************************************/
 class StgEndScript;
-class StgEndScene : public StgUserExtendScene
-{
-	public:
+class StgEndScene : public StgUserExtendScene {
+public:
+	StgEndScene(StgSystemController* controller);
+	virtual ~StgEndScene();
 
-	private:
+	void Work();
 
-	public:
-		StgEndScene(StgSystemController* controller);
-		virtual ~StgEndScene();
-
-		void Work();
-
-		void Start();
-		void Finish();
+	void Start();
+	void Finish();
 };
 
 /**********************************************************
 //StgEndSceneScript
 **********************************************************/
-class StgEndSceneScript : public StgUserExtendSceneScript
-{
-	public:
-		enum
-		{
+class StgEndSceneScript : public StgUserExtendSceneScript {
+public:
+	enum {
 
-		};
+	};
 
-	protected:
-
-	public:
-		StgEndSceneScript(StgSystemController* controller);
-		virtual ~StgEndSceneScript();
+public:
+	StgEndSceneScript(StgSystemController* controller);
+	virtual ~StgEndSceneScript();
 };
 
 /**********************************************************
 //StgReplaySaveScene
 **********************************************************/
 class StgReplaySaveScript;
-class StgReplaySaveScene : public StgUserExtendScene
-{
-	public:
+class StgReplaySaveScene : public StgUserExtendScene {
+public:
+	StgReplaySaveScene(StgSystemController* controller);
+	virtual ~StgReplaySaveScene();
 
-	private:
+	void Work();
 
-	public:
-		StgReplaySaveScene(StgSystemController* controller);
-		virtual ~StgReplaySaveScene();
-
-		void Work();
-
-		void Start();
-		void Finish();
+	void Start();
+	void Finish();
 };
 
 /**********************************************************
 //StgReplaySaveScript
 **********************************************************/
-class StgReplaySaveScript : public StgUserExtendSceneScript
-{
-	public:
-		enum
-		{
+class StgReplaySaveScript : public StgUserExtendSceneScript {
+public:
+	enum {
 
-		};
+	};
 
-	protected:
-
-	public:
-		StgReplaySaveScript(StgSystemController* controller);
-		virtual ~StgReplaySaveScript();
-
+public:
+	StgReplaySaveScript(StgSystemController* controller);
+	virtual ~StgReplaySaveScript();
 };
 
-
 #endif
-

--- a/source/TouhouDanmakufu/DnhConfig/Common.cpp
+++ b/source/TouhouDanmakufu/DnhConfig/Common.cpp
@@ -1,4 +1,4 @@
-#include"Common.hpp"
+#include "Common.hpp"
 
 /**********************************************************
 //KeyCodeList
@@ -49,7 +49,7 @@ KeyCodeList::KeyCodeList()
 	mapText_[DIK_APOSTROPHE] = L"'";
 	mapText_[DIK_GRAVE] = L"`";
 	mapText_[DIK_LSHIFT] = L"Shift (Left)";
- 	mapText_[DIK_BACKSLASH] = L"\\";
+	mapText_[DIK_BACKSLASH] = L"\\";
 
 	mapText_[DIK_Z] = L"Z";
 	mapText_[DIK_X] = L"X";
@@ -97,28 +97,28 @@ KeyCodeList::KeyCodeList()
 
 	mapText_[DIK_F11] = L"F11";
 	mapText_[DIK_F12] = L"F12";
-	mapText_[DIK_F13] = L"F13";//NEC PC-98
-	mapText_[DIK_F14] = L"F14";//NEC PC-98
-	mapText_[DIK_F15] = L"F15";//NEC PC-98
+	mapText_[DIK_F13] = L"F13"; //NEC PC-98
+	mapText_[DIK_F14] = L"F14"; //NEC PC-98
+	mapText_[DIK_F15] = L"F15"; //NEC PC-98
 
-	mapText_[DIK_KANA] = L"カナ";//日本語キーボード
-	mapText_[DIK_CONVERT] = L"変換";//日本語キーボード
-	mapText_[DIK_NOCONVERT] = L"無変換";//日本語キーボード
-	mapText_[DIK_YEN] = L"\\";//日本語キーボード
-	mapText_[DIK_NUMPADEQUALS] = L"(Numpad)";//NEC PC-98
-	mapText_[DIK_CIRCUMFLEX] = L"^";//日本語キーボード
+	mapText_[DIK_KANA] = L"カナ"; //日本語キーボード
+	mapText_[DIK_CONVERT] = L"変換"; //日本語キーボード
+	mapText_[DIK_NOCONVERT] = L"無変換"; //日本語キーボード
+	mapText_[DIK_YEN] = L"\\"; //日本語キーボード
+	mapText_[DIK_NUMPADEQUALS] = L"(Numpad)"; //NEC PC-98
+	mapText_[DIK_CIRCUMFLEX] = L"^"; //日本語キーボード
 
-	mapText_[DIK_AT] = L"@";//NEC PC-98
-	mapText_[DIK_COLON] = L":";//NEC PC-98
-	mapText_[DIK_UNDERLINE] = L"_";//NEC PC-98
-	mapText_[DIK_KANJI] = L"漢字";//日本語キーボード
-	mapText_[DIK_STOP] = L"Stop";//NEC PC-98
+	mapText_[DIK_AT] = L"@"; //NEC PC-98
+	mapText_[DIK_COLON] = L":"; //NEC PC-98
+	mapText_[DIK_UNDERLINE] = L"_"; //NEC PC-98
+	mapText_[DIK_KANJI] = L"漢字"; //日本語キーボード
+	mapText_[DIK_STOP] = L"Stop"; //NEC PC-98
 	mapText_[DIK_AX] = L"(Japan AX)";
 	mapText_[DIK_UNLABELED] = L"(J3100)";
 
 	mapText_[DIK_NUMPADENTER] = L"Enter (Numpad)";
 	mapText_[DIK_RCONTROL] = L"Ctrl (Right)";
-	mapText_[DIK_NUMPADCOMMA] = L", (Numpad)";//NEC PC-98
+	mapText_[DIK_NUMPADCOMMA] = L", (Numpad)"; //NEC PC-98
 	mapText_[DIK_DIVIDE] = L"/ (Numpad)";
 	mapText_[DIK_SYSRQ] = L"Sys Rq";
 	mapText_[DIK_RMENU] = L"Alt (Right)";
@@ -141,8 +141,7 @@ KeyCodeList::KeyCodeList()
 	mapText_[DIK_SLEEP] = L"Sleep";
 
 	std::map<int, std::wstring>::iterator itr = mapText_.begin();
-	for(; itr != mapText_.end() ; itr++)
-	{
+	for (; itr != mapText_.end(); itr++) {
 		int code = itr->first;
 		listValidCode_.push_back(code);
 	}
@@ -157,7 +156,8 @@ bool KeyCodeList::IsValidCode(int code)
 }
 std::wstring KeyCodeList::GetCodeText(int code)
 {
-	if(!IsValidCode(code))return L"";
+	if (!IsValidCode(code))
+		return L"";
 
 	std::wstring res = mapText_[code];
 	return res;

--- a/source/TouhouDanmakufu/DnhConfig/Common.hpp
+++ b/source/TouhouDanmakufu/DnhConfig/Common.hpp
@@ -1,26 +1,24 @@
 #ifndef __TOUHOUDANMAKUFU_CONFIG_COMMON__
 #define __TOUHOUDANMAKUFU_CONFIG_COMMON__
 
-#include"../Common/DnhCommon.hpp"
-#include"GcLibImpl.hpp"
+#include "../Common/DnhCommon.hpp"
+#include "GcLibImpl.hpp"
 
 /**********************************************************
 //KeyCodeList
 **********************************************************/
-class KeyCodeList
-{
-	private:
-		std::map<int, std::wstring> mapText_;
-		std::vector<int> listValidCode_;
-	public:
-		KeyCodeList();
-		virtual ~KeyCodeList();
+class KeyCodeList {
+public:
+	KeyCodeList();
+	virtual ~KeyCodeList();
 
-		bool IsValidCode(int code);
-		std::wstring GetCodeText(int code);
-		std::vector<int>& GetValidCodeList(){return listValidCode_;}
+	bool IsValidCode(int code);
+	std::wstring GetCodeText(int code);
+	std::vector<int>& GetValidCodeList() { return listValidCode_; }
+
+private:
+	std::map<int, std::wstring> mapText_;
+	std::vector<int> listValidCode_;
 };
 
-
 #endif
-

--- a/source/TouhouDanmakufu/DnhConfig/Constant.hpp
+++ b/source/TouhouDanmakufu/DnhConfig/Constant.hpp
@@ -1,16 +1,13 @@
 #ifndef __TOUHOUDANMAKUFU_CONFIG_CONSTANT__
 #define __TOUHOUDANMAKUFU_CONFIG_CONSTANT__
 
-#pragma comment(lib,"source/GcLib/ext/ogg_static.lib")
-#pragma comment(lib,"source/GcLib/ext/vorbis_static.lib")
-#pragma comment(lib,"source/GcLib/ext/vorbisfile_static.lib")
+#pragma comment(lib, "source/GcLib/ext/ogg_static.lib")
+#pragma comment(lib, "source/GcLib/ext/vorbis_static.lib")
+#pragma comment(lib, "source/GcLib/ext/vorbisfile_static.lib")
 
-#include"../Common/DnhConstant.hpp"
-#include"../Common/DnhCommon.hpp"
+#include "../Common/DnhCommon.hpp"
+#include "../Common/DnhConstant.hpp"
 
-#include"resource.h"
-
+#include "resource.h"
 
 #endif
-
-

--- a/source/TouhouDanmakufu/DnhConfig/GcLibImpl.cpp
+++ b/source/TouhouDanmakufu/DnhConfig/GcLibImpl.cpp
@@ -1,16 +1,14 @@
-#include"GcLibImpl.hpp"
-#include"MainWindow.hpp"
+#include "GcLibImpl.hpp"
+#include "MainWindow.hpp"
 
 /**********************************************************
 //EApplication
 **********************************************************/
 EApplication::EApplication()
 {
-
 }
 EApplication::~EApplication()
 {
-
 }
 bool EApplication::_Initialize()
 {
@@ -22,8 +20,8 @@ bool EApplication::_Initialize()
 
 	HWND hWndMain = MainWindow::GetInstance()->GetWindowHandle();
 	WindowLogger::InsertOpenCommandInSystemMenu(hWndMain);
-//	::SetWindowText(hWndMain, "DnhViewer");
-//	::SetClassLong(hWndMain, GCL_HICON, (LONG)LoadIcon(GetApplicationHandle(), MAKEINTRESOURCE(IDI_ICON)));
+	// ::SetWindowText(hWndMain, "DnhViewer");
+	// ::SetClassLong(hWndMain, GCL_HICON, (LONG)LoadIcon(GetApplicationHandle(), MAKEINTRESOURCE(IDI_ICON)));
 
 	EDirectInput* input = EDirectInput::CreateInstance();
 	input->Initialize(hWndMain);
@@ -44,8 +42,7 @@ bool EApplication::_Loop()
 	HWND hWndFocused = ::GetForegroundWindow();
 	HWND hWndMain = mainWindow->GetWindowHandle();
 	HWND hWndLogger = ELogger::GetInstance()->GetWindowHandle();
-	if(hWndFocused != hWndMain && hWndFocused != hWndLogger)
-	{
+	if (hWndFocused != hWndMain && hWndFocused != hWndLogger) {
 		//非アクティブ時は動作しない
 		::Sleep(10);
 		return true;
@@ -68,5 +65,3 @@ bool EApplication::_Finalize()
 	Logger::WriteTop(L"アプリケーション終了処理完了");
 	return true;
 }
-
-

--- a/source/TouhouDanmakufu/DnhConfig/GcLibImpl.hpp
+++ b/source/TouhouDanmakufu/DnhConfig/GcLibImpl.hpp
@@ -1,24 +1,25 @@
 #ifndef __TOUHOUDANMAKUFU_CONFIG_GCLIBIMPL__
 #define __TOUHOUDANMAKUFU_CONFIG_GCLIBIMPL__
 
-#include"Constant.hpp"
-#include"../Common/DnhGcLibImpl.hpp"
+#include "../Common/DnhGcLibImpl.hpp"
+#include "Constant.hpp"
 
 /**********************************************************
 //EApplication
 **********************************************************/
-class EApplication : public Singleton<EApplication>, public Application
-{
-		friend Singleton<EApplication>;
-		EApplication();
-	protected:
-		bool _Initialize();
-		bool _Loop();
-		bool _Finalize();
-	public:
-		~EApplication();
+class EApplication : public Singleton<EApplication>, public Application {
+	friend Singleton<EApplication>;
+
+private:
+	EApplication();
+
+protected:
+	bool _Initialize();
+	bool _Loop();
+	bool _Finalize();
+
+public:
+	~EApplication();
 };
-
-
 
 #endif

--- a/source/TouhouDanmakufu/DnhConfig/MainWindow.cpp
+++ b/source/TouhouDanmakufu/DnhConfig/MainWindow.cpp
@@ -1,25 +1,23 @@
-#include"MainWindow.hpp"
-#include"GcLibImpl.hpp"
+#include "MainWindow.hpp"
+#include "GcLibImpl.hpp"
 
 /**********************************************************
 //MainWindow
 **********************************************************/
 MainWindow::MainWindow()
 {
-
 }
 MainWindow::~MainWindow()
 {
-
 }
 bool MainWindow::Initialize()
 {
-	hWnd_ = ::CreateDialog((HINSTANCE)GetWindowLong(NULL,GWL_HINSTANCE),
-							MAKEINTRESOURCE(IDD_DIALOG_MAIN),
-							NULL,(DLGPROC)_StaticWindowProcedure);
+	hWnd_ = ::CreateDialog((HINSTANCE)GetWindowLong(NULL, GWL_HINSTANCE),
+		MAKEINTRESOURCE(IDD_DIALOG_MAIN),
+		NULL, (DLGPROC)_StaticWindowProcedure);
 
-//	::SetClassLong(hWnd_, GCL_HICON, 
-//		( LONG )(HICON)LoadImage(Application::GetApplicationHandle(), MAKEINTRESOURCE(IDI_ICON), IMAGE_ICON, 32, 32, 0));
+	// ::SetClassLong(hWnd_, GCL_HICON,
+	// 		( LONG )(HICON)LoadImage(Application::GetApplicationHandle(), MAKEINTRESOURCE(IDI_ICON), IMAGE_ICON, 32, 32, 0));
 
 	Attach(hWnd_);
 	::ShowWindow(hWnd_, SW_HIDE);
@@ -61,66 +59,55 @@ bool MainWindow::StartUp()
 	panelKey_->StartUp();
 	return true;
 }
-LRESULT MainWindow::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
+LRESULT MainWindow::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	switch (uMsg)
-	{
-		case WM_CLOSE:
-		{
-			::DestroyWindow(hWnd);
+	switch (uMsg) {
+	case WM_CLOSE: {
+		::DestroyWindow(hWnd);
+		break;
+	}
+	case WM_DESTROY: {
+		::PostQuitMessage(0);
+		break;
+	}
+	case WM_COMMAND: {
+		switch (wParam & 0xffff) {
+		case ID_MENUITEM_MAIN_EXIT:
+		case IDCANCEL:
+			::DestroyWindow(hWnd_);
+			break;
+
+		case IDOK:
+			Save();
+			::DestroyWindow(hWnd_);
+			break;
+
+		case ID_BUTTON_EXECUTE: {
+			Save();
+			_RunExecutor();
+			::DestroyWindow(hWnd_);
 			break;
 		}
-		case WM_DESTROY:
-		{
-			::PostQuitMessage(0);
+		}
+		break;
+	}
+
+	case WM_SYSCOMMAND: {
+		int nId = wParam & 0xffff;
+		if (nId == WindowLogger::MENU_ID_OPEN) {
+			ELogger::GetInstance()->ShowLogWindow();
+		}
+		break;
+	}
+
+	case WM_NOTIFY: {
+		switch (((NMHDR*)lParam)->code) {
+		case TCN_SELCHANGE:
+			wndTab_->ShowPage();
 			break;
 		}
-		case WM_COMMAND:
-		{
-			switch(wParam & 0xffff)
-			{
-				case ID_MENUITEM_MAIN_EXIT:
-				case IDCANCEL:
-					::DestroyWindow(hWnd_);
-					break;
-
-				case IDOK:
-					Save();
-					::DestroyWindow(hWnd_);
-					break;
-
-				case ID_BUTTON_EXECUTE:
-				{
-					Save();
-					_RunExecutor();
-					::DestroyWindow(hWnd_);
-					break;
-				}
-			}
-			break;
-		}
-
-		case WM_SYSCOMMAND:
-		{
-			int nId = wParam & 0xffff;
-			if (nId == WindowLogger::MENU_ID_OPEN)
-			{
-				ELogger::GetInstance()->ShowLogWindow();
-			}
-			break;
-		}
-
-		case WM_NOTIFY:
-		{
-			switch (((NMHDR *)lParam)->code)
-			{
-				case TCN_SELCHANGE:
-					wndTab_->ShowPage();
-					break;
-			}
-			break;
-		}
-
+		break;
+	}
 	}
 	return _CallPreviousWindowProcedure(hWnd, uMsg, wParam, lParam);
 }
@@ -140,10 +127,8 @@ void MainWindow::_RunExecutor()
 		NULL, NULL,
 		TRUE, 0,
 		NULL, NULL,
-		&si, &infoProcess
-	);
-	if(res == 0)
-	{
+		&si, &infoProcess);
+	if (res == 0) {
 		std::wstring log = StringUtility::Format(L"実行失敗\r\n%s", ErrorUtility::GetLastErrorMessage().c_str());
 		Logger::WriteTop(log);
 		return;
@@ -155,7 +140,6 @@ void MainWindow::_RunExecutor()
 
 void MainWindow::ClearData()
 {
-
 }
 bool MainWindow::Load()
 {
@@ -163,8 +147,7 @@ bool MainWindow::Load()
 	std::string path;
 /*
 	bool res = record.ReadFromFile(path);
-	if(!res)
-	{
+	if (!res) {
 		//::MessageBox(hWnd_, "読み込み失敗", "設定を開く", MB_OK);
 		return false;
 	}
@@ -182,9 +165,9 @@ bool MainWindow::Save()
 }
 void MainWindow::UpdateKeyAssign()
 {
-	if(!panelKey_->IsWindowVisible())return;
+	if (!panelKey_->IsWindowVisible())
+		return;
 	panelKey_->UpdateKeyAssign();
-
 }
 void MainWindow::ReadConfiguration()
 {
@@ -207,13 +190,12 @@ DevicePanel::DevicePanel()
 }
 DevicePanel::~DevicePanel()
 {
-
 }
 bool DevicePanel::Initialize(HWND hParent)
 {
-	hWnd_ = ::CreateDialog((HINSTANCE)GetWindowLong(NULL,GWL_HINSTANCE),
-							MAKEINTRESOURCE(IDD_PANEL_DEVICE),
-							hParent,(DLGPROC)_StaticWindowProcedure);
+	hWnd_ = ::CreateDialog((HINSTANCE)GetWindowLong(NULL, GWL_HINSTANCE),
+		MAKEINTRESOURCE(IDD_PANEL_DEVICE),
+		hParent, (DLGPROC)_StaticWindowProcedure);
 	Attach(hWnd_);
 
 	comboWindowSize_.Attach(::GetDlgItem(hWnd_, IDC_COMBO_WINDOWSIZE));
@@ -221,12 +203,12 @@ bool DevicePanel::Initialize(HWND hParent)
 	comboWindowSize_.AddString(L"800x600");
 	comboWindowSize_.AddString(L"960x720");
 	comboWindowSize_.AddString(L"1280x960");
-	SetWindowPos(comboWindowSize_.GetWindowHandle(), NULL, 0, 0, 
+	SetWindowPos(comboWindowSize_.GetWindowHandle(), NULL, 0, 0,
 		comboWindowSize_.GetClientWidth(), 200, SWP_NOMOVE);
 
 	return true;
 }
-LRESULT DevicePanel::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
+LRESULT DevicePanel::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
 	return WPanel::_WindowProcedure(hWnd, uMsg, wParam, lParam);
 }
@@ -234,13 +216,12 @@ void DevicePanel::ReadConfiguration()
 {
 	DnhConfiguration* config = DnhConfiguration::GetInstance();
 	int screenMode = config->GetScreenMode();
-	switch(screenMode)
-	{
+	switch (screenMode) {
 	case DirectGraphics::SCREENMODE_FULLSCREEN:
-		SendDlgItemMessage(hWnd_, IDC_RADIO_FULLSCREEN ,BM_SETCHECK, 1, 0);
+		SendDlgItemMessage(hWnd_, IDC_RADIO_FULLSCREEN, BM_SETCHECK, 1, 0);
 		break;
 	default:
-		SendDlgItemMessage(hWnd_, IDC_RADIO_WINDOW ,BM_SETCHECK, 1, 0);
+		SendDlgItemMessage(hWnd_, IDC_RADIO_WINDOW, BM_SETCHECK, 1, 0);
 		break;
 	}
 
@@ -248,28 +229,26 @@ void DevicePanel::ReadConfiguration()
 	comboWindowSize_.SetSelectedIndex(windowSize);
 
 	int fpsType = config->GetFpsType();
-	switch(fpsType)
-	{
+	switch (fpsType) {
 	case DnhConfiguration::FPS_NORMAL:
-		SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_1 ,BM_SETCHECK, 1, 0);
+		SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_1, BM_SETCHECK, 1, 0);
 		break;
 	case DnhConfiguration::FPS_1_2:
-		SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_2 ,BM_SETCHECK, 1, 0);
+		SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_2, BM_SETCHECK, 1, 0);
 		break;
 	case DnhConfiguration::FPS_1_3:
-		SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_3 ,BM_SETCHECK, 1, 0);
+		SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_3, BM_SETCHECK, 1, 0);
 		break;
 	case DnhConfiguration::FPS_AUTO:
-		SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_AUTO ,BM_SETCHECK, 1, 0);
+		SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_AUTO, BM_SETCHECK, 1, 0);
 		break;
 	}
-
 }
 void DevicePanel::WriteConfiguration()
 {
 	DnhConfiguration* config = DnhConfiguration::GetInstance();
 	int screenMode = DirectGraphics::SCREENMODE_WINDOW;
-	if(SendDlgItemMessage(hWnd_, IDC_RADIO_FULLSCREEN, BM_GETCHECK, 0, 0))
+	if (SendDlgItemMessage(hWnd_, IDC_RADIO_FULLSCREEN, BM_GETCHECK, 0, 0))
 		screenMode = DirectGraphics::SCREENMODE_FULLSCREEN;
 	config->SetScreenMode(screenMode);
 
@@ -277,13 +256,13 @@ void DevicePanel::WriteConfiguration()
 	config->SetWindowSize(windowSize);
 
 	int fpsType = DnhConfiguration::FPS_NORMAL;
-	if(SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_1, BM_GETCHECK, 0, 0))
+	if (SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_1, BM_GETCHECK, 0, 0))
 		fpsType = DnhConfiguration::FPS_NORMAL;
-	else if(SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_2, BM_GETCHECK, 0, 0))
+	else if (SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_2, BM_GETCHECK, 0, 0))
 		fpsType = DnhConfiguration::FPS_1_2;
-	else if(SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_3, BM_GETCHECK, 0, 0))
+	else if (SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_3, BM_GETCHECK, 0, 0))
 		fpsType = DnhConfiguration::FPS_1_3;
-	else if(SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_AUTO, BM_GETCHECK, 0, 0))
+	else if (SendDlgItemMessage(hWnd_, IDC_RADIO_FPS_AUTO, BM_GETCHECK, 0, 0))
 		fpsType = DnhConfiguration::FPS_AUTO;
 	config->SetFpsType(fpsType);
 }
@@ -296,23 +275,22 @@ KeyPanel::KeyPanel()
 }
 KeyPanel::~KeyPanel()
 {
-
 }
 bool KeyPanel::Initialize(HWND hParent)
 {
-	hWnd_ = ::CreateDialog((HINSTANCE)GetWindowLong(NULL,GWL_HINSTANCE),
-							MAKEINTRESOURCE(IDD_PANEL_KEY),
-							hParent,(DLGPROC)_StaticWindowProcedure);
+	hWnd_ = ::CreateDialog((HINSTANCE)GetWindowLong(NULL, GWL_HINSTANCE),
+		MAKEINTRESOURCE(IDD_PANEL_KEY),
+		hParent, (DLGPROC)_StaticWindowProcedure);
 	Attach(hWnd_);
 
 	comboPadIndex_.Attach(::GetDlgItem(hWnd_, IDC_COMBO_PADINDEX));
 
 	HWND hListKey = ::GetDlgItem(hWnd_, IDC_LIST_KEY);
 	DWORD dwStyle = ListView_GetExtendedListViewStyle(hListKey);
-	dwStyle |= LVS_EX_FULLROWSELECT|LVS_EX_GRIDLINES;
+	dwStyle |= LVS_EX_FULLROWSELECT | LVS_EX_GRIDLINES;
 	ListView_SetExtendedListViewStyle(hListKey, dwStyle);
-//	HIMAGELIST hImageList = ImageList_Create(32 , 22 , ILC_COLOR4 |ILC_MASK , 2 , 1);
-//	ListView_SetImageList(hList, hImageList, LVSIL_SMALL) ;
+	// HIMAGELIST hImageList = ImageList_Create(32, 22, ILC_COLOR4 | ILC_MASK, 2, 1);
+	// ListView_SetImageList(hList, hImageList, LVSIL_SMALL);
 
 	viewKey_ = new KeyListView();
 	viewKey_->Attach(hListKey);
@@ -333,8 +311,7 @@ bool KeyPanel::Initialize(HWND hParent)
 	mapViewText[EDirectInput::KEY_USER1] = L"User1(ユーザ定義1)";
 	mapViewText[EDirectInput::KEY_USER2] = L"User2(ユーザ定義2)";
 	mapViewText[EDirectInput::KEY_PAUSE] = L"Pause(ポーズ)";
-	for(int iView = 0 ; iView < mapViewText.size() ; iView++)
-	{
+	for (int iView = 0; iView < mapViewText.size(); iView++) {
 		std::wstring text = mapViewText[iView];
 		viewKey_->SetText(iView, COL_ACTION, text);
 		_UpdateText(iView);
@@ -347,33 +324,31 @@ bool KeyPanel::StartUp()
 	int padDeviceTextWidth = comboPadIndex_.GetClientWidth();
 	EDirectInput* input = EDirectInput::GetInstance();
 	int padCount = input->GetPadDeviceCount();
-	for(int iPad = 0; iPad < padCount ; iPad++)
-	{
+	for (int iPad = 0; iPad < padCount; iPad++) {
 		DIDEVICEINSTANCE info = input->GetPadDeviceInformation(iPad);
-		std::wstring strPad = StringUtility::Format(L"%d : %s [%s]", iPad+1, info.tszInstanceName, info.tszProductName);
+		std::wstring strPad = StringUtility::Format(L"%d : %s [%s]", iPad + 1, info.tszInstanceName, info.tszProductName);
 		comboPadIndex_.AddString(strPad);
 
 		int textCount = StringUtility::CountAsciiSizeCharacter(strPad);
-		//padDeviceTextWidth = max(padDeviceTextWidth, textCount * 10);
+		// padDeviceTextWidth = max(padDeviceTextWidth, textCount * 10);
 	}
-	if(padCount == 0)
-	{
+	if (padCount == 0) {
 		comboPadIndex_.AddString(L"(none)");
 		comboPadIndex_.SetWindowEnable(false);
 	}
-	SetWindowPos(comboPadIndex_.GetWindowHandle(), NULL, 0, 0, 
+	SetWindowPos(comboPadIndex_.GetWindowHandle(), NULL, 0, 0,
 		padDeviceTextWidth, 200, SWP_NOMOVE);
 
 	DnhConfiguration* config = DnhConfiguration::GetInstance();
 	int padIndex = config->GetPadIndex();
-	padIndex = min(padIndex, padCount-1);
+	padIndex = min(padIndex, padCount - 1);
 	padIndex = max(padIndex, 0);
 	comboPadIndex_.SetSelectedIndex(padIndex);
 
 	return true;
 }
 
-LRESULT KeyPanel::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
+LRESULT KeyPanel::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
 	return WPanel::_WindowProcedure(hWnd, uMsg, wParam, lParam);
 }
@@ -381,7 +356,8 @@ void KeyPanel::_UpdateText(int row)
 {
 	DnhConfiguration* config = DnhConfiguration::GetInstance();
 	ref_count_ptr<VirtualKey> vk = config->GetVirtualKey(row);
-	if(vk == NULL)return;
+	if (vk == NULL)
+		return;
 
 	int keyCode = vk->GetKeyCode();
 	std::wstring strKey = listKeyCode_.GetCodeText(keyCode);
@@ -390,12 +366,12 @@ void KeyPanel::_UpdateText(int row)
 	int padButton = vk->GetPadButton();
 	std::wstring strPad = StringUtility::Format(L"PAD %02d", padButton);
 	viewKey_->SetText(row, COL_PAD_ASSIGN, strPad);
-	
 }
 void KeyPanel::UpdateKeyAssign()
 {
 	int row = viewKey_->GetSelectedRow();
-	if(row < 0)return;
+	if (row < 0)
+		return;
 
 	DnhConfiguration* config = DnhConfiguration::GetInstance();
 	ref_count_ptr<VirtualKey> vk = config->GetVirtualKey(row);
@@ -404,49 +380,46 @@ void KeyPanel::UpdateKeyAssign()
 	bool bChange = false;
 	int pushKeyCode = -1;
 	std::vector<int>& listValidCode = listKeyCode_.GetValidCodeList();
-	for(int iCode = 0 ; iCode < listValidCode.size() ; iCode++)
-	{
+	for (int iCode = 0; iCode < listValidCode.size(); iCode++) {
 		int code = listValidCode[iCode];
 		int state = input->GetKeyState(code);
-		if(state != KEY_PUSH)continue;
+		if (state != KEY_PUSH)
+			continue;
 
 		pushKeyCode = code;
 		bChange = true;
 		break;
 	}
-	if(pushKeyCode >= 0)
+	if (pushKeyCode >= 0)
 		vk->SetKeyCode(pushKeyCode);
 
 	int pushPadIndex = comboPadIndex_.GetSelectedIndex();
 	int pushPadButton = -1;
-	for(int iButton = 0 ; iButton < DirectInput::MAX_PAD_BUTTON ; iButton++)
-	{
+	for (int iButton = 0; iButton < DirectInput::MAX_PAD_BUTTON; iButton++) {
 		int state = input->GetPadState(pushPadIndex, iButton);
-		if(state != KEY_PUSH)continue;
+		if (state != KEY_PUSH)
+			continue;
 
 		pushPadButton = iButton;
 		bChange = true;
 		break;
 	}
-	if(pushPadButton >= 0)
-	{
+	if (pushPadButton >= 0) {
 		vk->SetPadIndex(pushPadIndex);
 		vk->SetPadButton(pushPadButton);
 	}
 
-	if(bChange)
-	{
+	if (bChange) {
 		_UpdateText(row);
 
 		int nextRow = row + 1;
-		if(pushKeyCode >= 0 && false)
-		{
-			if(pushKeyCode == DIK_UP)
+		if (pushKeyCode >= 0 && false) {
+			if (pushKeyCode == DIK_UP)
 				nextRow++;
-			if(pushKeyCode == DIK_DOWN)
+			if (pushKeyCode == DIK_DOWN)
 				nextRow--;
 		}
-		if(nextRow >= viewKey_->GetRowCount())
+		if (nextRow >= viewKey_->GetRowCount())
 			nextRow = 0;
 		viewKey_->SetSelectedRow(nextRow);
 	}
@@ -463,12 +436,11 @@ void KeyPanel::WriteConfiguration()
 }
 
 //KeyPanel::KeyListView
-LRESULT KeyPanel::KeyListView::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
+LRESULT KeyPanel::KeyListView::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	switch (uMsg)
-	{
-		case WM_KEYDOWN://キー入力を無視
-			return FALSE;
+	switch (uMsg) {
+	case WM_KEYDOWN: //キー入力を無視
+		return FALSE;
 	}
 	return _CallPreviousWindowProcedure(hWnd, uMsg, wParam, lParam);
 }
@@ -481,13 +453,12 @@ OptionPanel::OptionPanel()
 }
 OptionPanel::~OptionPanel()
 {
-
 }
 bool OptionPanel::Initialize(HWND hParent)
 {
-	hWnd_ = ::CreateDialog((HINSTANCE)GetWindowLong(NULL,GWL_HINSTANCE),
-							MAKEINTRESOURCE(IDD_PANEL_OPTION),
-							hParent,(DLGPROC)_StaticWindowProcedure);
+	hWnd_ = ::CreateDialog((HINSTANCE)GetWindowLong(NULL, GWL_HINSTANCE),
+		MAKEINTRESOURCE(IDD_PANEL_OPTION),
+		hParent, (DLGPROC)_StaticWindowProcedure);
 	Attach(hWnd_);
 
 	HWND hListOption = ::GetDlgItem(hWnd_, IDC_LIST_OPTION);
@@ -504,7 +475,7 @@ bool OptionPanel::Initialize(HWND hParent)
 
 	return true;
 }
-LRESULT OptionPanel::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
+LRESULT OptionPanel::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
 	return WPanel::_WindowProcedure(hWnd, uMsg, wParam, lParam);
 }
@@ -512,12 +483,12 @@ void OptionPanel::ReadConfiguration()
 {
 	DnhConfiguration* config = DnhConfiguration::GetInstance();
 	HWND hListOption = viewOption_->GetWindowHandle();
-	if(config->IsLogWindow())
-		ListView_SetItemState(hListOption, ROW_LOG_WINDOW, INDEXTOSTATEIMAGEMASK(2),LVIS_STATEIMAGEMASK);
-	if(config->IsLogFile())
-		ListView_SetItemState(hListOption, ROW_LOG_FILE, INDEXTOSTATEIMAGEMASK(2),LVIS_STATEIMAGEMASK);
-	if(!config->IsMouseVisible())
-		ListView_SetItemState(hListOption, ROW_MOUSE_UNVISIBLE, INDEXTOSTATEIMAGEMASK(2),LVIS_STATEIMAGEMASK);
+	if (config->IsLogWindow())
+		ListView_SetItemState(hListOption, ROW_LOG_WINDOW, INDEXTOSTATEIMAGEMASK(2), LVIS_STATEIMAGEMASK);
+	if (config->IsLogFile())
+		ListView_SetItemState(hListOption, ROW_LOG_FILE, INDEXTOSTATEIMAGEMASK(2), LVIS_STATEIMAGEMASK);
+	if (!config->IsMouseVisible())
+		ListView_SetItemState(hListOption, ROW_MOUSE_UNVISIBLE, INDEXTOSTATEIMAGEMASK(2), LVIS_STATEIMAGEMASK);
 }
 void OptionPanel::WriteConfiguration()
 {
@@ -527,4 +498,3 @@ void OptionPanel::WriteConfiguration()
 	config->SetLogFile(ListView_GetCheckState(hListOption, ROW_LOG_FILE) ? true : false);
 	config->SetMouseVisible(ListView_GetCheckState(hListOption, ROW_MOUSE_UNVISIBLE) ? false : true);
 }
-

--- a/source/TouhouDanmakufu/DnhConfig/MainWindow.hpp
+++ b/source/TouhouDanmakufu/DnhConfig/MainWindow.hpp
@@ -1,8 +1,8 @@
 #ifndef __TOUHOUDANMAKUFU_CONFIG_MAINWINDOW__
 #define __TOUHOUDANMAKUFU_CONFIG_MAINWINDOW__
 
-#include"Constant.hpp"
-#include"Common.hpp"
+#include "Common.hpp"
+#include "Constant.hpp"
 
 class DevicePanel;
 class KeyPanel;
@@ -10,110 +10,108 @@ class OptionPanel;
 /**********************************************************
 //MainWindow
 **********************************************************/
-class MainWindow : public WindowBase , public gstd::Singleton<MainWindow>
-{
-	protected:
-		ref_count_ptr<WTabControll> wndTab_;
-		ref_count_ptr<DevicePanel> panelDevice_;
-		ref_count_ptr<KeyPanel> panelKey_;
-		ref_count_ptr<OptionPanel> panelOption_;
+class MainWindow : public WindowBase, public gstd::Singleton<MainWindow> {
+public:
+	MainWindow();
+	~MainWindow();
+	bool Initialize();
+	bool StartUp();
 
-		void _RunExecutor();
-		virtual LRESULT _WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
-	public:
-		MainWindow();
-		~MainWindow();
-		bool Initialize();
-		bool StartUp();
+	void ClearData();
+	bool Load();
+	bool Save();
 
-		void ClearData();
-		bool Load();
-		bool Save();
+	void UpdateKeyAssign();
 
-		void UpdateKeyAssign();
+	void ReadConfiguration();
+	void WriteConfiguration();
 
-		void ReadConfiguration();
-		void WriteConfiguration();
+protected:
+	void _RunExecutor();
+	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+	ref_count_ptr<WTabControll> wndTab_;
+	ref_count_ptr<DevicePanel> panelDevice_;
+	ref_count_ptr<KeyPanel> panelKey_;
+	ref_count_ptr<OptionPanel> panelOption_;
 };
 
 /**********************************************************
 //DevicePanel
 **********************************************************/
-class DevicePanel : public WPanel
-{
-	protected:
-		WComboBox comboWindowSize_;
-		virtual LRESULT _WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
+class DevicePanel : public WPanel {
+public:
+	DevicePanel();
+	~DevicePanel();
+	bool Initialize(HWND hParent);
 
-	public:
-		DevicePanel();
-		~DevicePanel();
-		bool Initialize(HWND hParent);
+	void ReadConfiguration();
+	void WriteConfiguration();
 
-		void ReadConfiguration();
-		void WriteConfiguration();
+protected:
+	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	WComboBox comboWindowSize_;
 };
 
 /**********************************************************
 //KeyPanel
 **********************************************************/
-class KeyPanel : public WPanel
-{
+class KeyPanel : public WPanel {
 	class KeyListView;
-	protected:
-		enum
-		{
-			COL_ACTION,
-			COL_KEY_ASSIGN,
-			COL_PAD_ASSIGN,
-		};
 
-		WComboBox comboPadIndex_;
-		ref_count_ptr<KeyListView> viewKey_;
-		KeyCodeList listKeyCode_;
-		virtual LRESULT _WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
-		void _UpdateText(int row);
+protected:
+	enum {
+		COL_ACTION,
+		COL_KEY_ASSIGN,
+		COL_PAD_ASSIGN,
+	};
 
-	public:
-		KeyPanel();
-		~KeyPanel();
-		bool Initialize(HWND hParent);
-		bool StartUp();
-		void UpdateKeyAssign();
+public:
+	KeyPanel();
+	~KeyPanel();
+	bool Initialize(HWND hParent);
+	bool StartUp();
+	void UpdateKeyAssign();
 
-		void ReadConfiguration();
-		void WriteConfiguration();
+	void ReadConfiguration();
+	void WriteConfiguration();
+
+protected:
+	WComboBox comboPadIndex_;
+	ref_count_ptr<KeyListView> viewKey_;
+	KeyCodeList listKeyCode_;
+	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	void _UpdateText(int row);
 };
 
-class KeyPanel::KeyListView : public WListView
-{
-	protected:
-		virtual LRESULT _WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
+class KeyPanel::KeyListView : public WListView {
+protected:
+	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 };
 
 /**********************************************************
 //OptionPanel
 **********************************************************/
-class OptionPanel : public WPanel
-{
-	protected:
-		enum
-		{
-			ROW_LOG_WINDOW,
-			ROW_LOG_FILE,
-			ROW_MOUSE_UNVISIBLE,
-		};
-		ref_count_ptr<WListView> viewOption_;
+class OptionPanel : public WPanel {
+protected:
+	enum {
+		ROW_LOG_WINDOW,
+		ROW_LOG_FILE,
+		ROW_MOUSE_UNVISIBLE,
+	};
 
-		virtual LRESULT _WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
+public:
+	OptionPanel();
+	~OptionPanel();
+	bool Initialize(HWND hParent);
 
-	public:
-		OptionPanel();
-		~OptionPanel();
-		bool Initialize(HWND hParent);
+	void ReadConfiguration();
+	void WriteConfiguration();
 
-		void ReadConfiguration();
-		void WriteConfiguration();
+protected:
+	ref_count_ptr<WListView> viewOption_;
+
+	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 };
 
 #endif

--- a/source/TouhouDanmakufu/DnhConfig/WinMain.cpp
+++ b/source/TouhouDanmakufu/DnhConfig/WinMain.cpp
@@ -1,19 +1,17 @@
-#include"GcLibImpl.hpp"
-#include"MainWindow.hpp"
-
+#include "GcLibImpl.hpp"
+#include "MainWindow.hpp"
 
 /**********************************************************
 WinMain
 **********************************************************/
 int WINAPI wWinMain(HINSTANCE hInstance,
-                        HINSTANCE hPrevInstance,
-                        LPWSTR lpCmdLine,
-                        int nCmdShow )
+	HINSTANCE hPrevInstance,
+	LPWSTR lpCmdLine,
+	int nCmdShow)
 {
 	gstd::DebugUtility::DumpMemoryLeaksOnExit();
 
-	try
-	{
+	try {
 		DnhConfiguration::CreateInstance();
 		ELogger* logger = ELogger::CreateInstance();
 		logger->Initialize(false, false);
@@ -24,20 +22,15 @@ int WINAPI wWinMain(HINSTANCE hInstance,
 		EApplication* app = EApplication::CreateInstance();
 		app->Initialize();
 		app->Run();
-	}
-	catch(std::exception& e)
-	{
+	} catch (std::exception& e) {
 		std::wstring log = StringUtility::ConvertMultiToWide(e.what());
 		Logger::WriteTop(log);
-	}
-	catch(gstd::wexception& e)
-	{
+	} catch (gstd::wexception& e) {
 		Logger::WriteTop(e.what());
 	}
-//	catch(...)
-//	{
-//		Logger::WriteTop("不明なエラー");
-//	}
+	// catch (...) {
+	// 	Logger::WriteTop("不明なエラー");
+	// }
 
 	EApplication::DeleteInstance();
 	MainWindow::DeleteInstance();
@@ -47,4 +40,3 @@ int WINAPI wWinMain(HINSTANCE hInstance,
 
 	return 0;
 }
-

--- a/source/TouhouDanmakufu/DnhExecutor/Common.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/Common.cpp
@@ -1,4 +1,4 @@
-#include"Common.hpp"
+#include "Common.hpp"
 
 /**********************************************************
 //MenuTask
@@ -29,21 +29,17 @@ int MenuTask::_GetCursorKeyState()
 {
 	EDirectInput* input = EDirectInput::GetInstance();
 	int res = CURSOR_NONE;
-	int vkeys[] = {EDirectInput::KEY_LEFT, EDirectInput::KEY_RIGHT, EDirectInput::KEY_UP, EDirectInput::KEY_DOWN};
-	for(int iKey = 0 ; iKey < CURSOR_COUNT && res == CURSOR_NONE; iKey++)
-	{
+	int vkeys[] = { EDirectInput::KEY_LEFT, EDirectInput::KEY_RIGHT, EDirectInput::KEY_UP, EDirectInput::KEY_DOWN };
+	for (int iKey = 0; iKey < CURSOR_COUNT && res == CURSOR_NONE; iKey++) {
 		int state = input->GetVirtualKeyState(vkeys[iKey]);
-		if(state == KEY_PUSH)
-		{
+		if (state == KEY_PUSH) {
 			cursorFrame_[iKey] = 0;
 			res = iKey;
-		}
-		else if(state == KEY_HOLD)
-		{
+		} else if (state == KEY_HOLD) {
 			cursorFrame_[iKey]++;
-			if(cursorFrame_[iKey] % 5 == 4 && cursorFrame_[iKey] > 15)
+			if (cursorFrame_[iKey] % 5 == 4 && cursorFrame_[iKey] > 15)
 				res = iKey;
-		}			
+		}
 	}
 	return res;
 }
@@ -51,75 +47,58 @@ void MenuTask::_MoveCursor()
 {
 	int stateCursor = _GetCursorKeyState();
 
-	if(stateCursor != CURSOR_NONE)
-	{
+	if (stateCursor != CURSOR_NONE) {
 		Lock lock(cs_);
 		int pageLast = pageCurrent_;
 		int countItem = item_.size();
 		int countCurrentPageItem = GetCurrentPageItemCount();
 		int countCurrentPageMaxX = GetCurrentPageMaxX();
 		int countCurrentPageMaxY = GetCurrentPageMaxY();
-		if(stateCursor == CURSOR_LEFT)
-		{
+		if (stateCursor == CURSOR_LEFT) {
 			cursorX_--;
-			if(cursorX_ < 0)
-			{
-				if(bPageChangeX_)
-				{
+			if (cursorX_ < 0) {
+				if (bPageChangeX_) {
 					pageCurrent_--;
-					if(pageCurrent_ <= 0)
+					if (pageCurrent_ <= 0)
 						pageCurrent_ = GetPageCount();
 				}
 				cursorX_ = countCurrentPageMaxX;
 			}
 			cursorY_ = min(cursorY_, GetCurrentPageMaxY());
-		}
-		else if(stateCursor == CURSOR_RIGHT)
-		{
+		} else if (stateCursor == CURSOR_RIGHT) {
 			cursorX_++;
-			if(cursorX_ > countCurrentPageMaxX)
-			{
-				if(bPageChangeX_)
-				{
+			if (cursorX_ > countCurrentPageMaxX) {
+				if (bPageChangeX_) {
 					pageCurrent_++;
-					if(pageCurrent_ > GetPageCount())
+					if (pageCurrent_ > GetPageCount())
 						pageCurrent_ = 1;
 				}
-				cursorX_ = 0;		
+				cursorX_ = 0;
 			}
 			cursorY_ = min(cursorY_, GetCurrentPageMaxY());
-		}
-		else if(stateCursor == CURSOR_UP)
-		{
+		} else if (stateCursor == CURSOR_UP) {
 			cursorY_--;
-			if(cursorY_ < 0)
-			{
-				if(bPageChangeY_)	
-				{
+			if (cursorY_ < 0) {
+				if (bPageChangeY_) {
 					pageCurrent_--;
-					if(pageCurrent_ <= 0)
+					if (pageCurrent_ <= 0)
 						pageCurrent_ = GetPageCount();
 				}
 				cursorY_ = countCurrentPageMaxY;
 			}
-		}
-		else if(stateCursor == CURSOR_DOWN)
-		{
+		} else if (stateCursor == CURSOR_DOWN) {
 			cursorY_++;
-			if(cursorY_ > countCurrentPageMaxY)
-			{
-				if(bPageChangeY_)
-				{
+			if (cursorY_ > countCurrentPageMaxY) {
+				if (bPageChangeY_) {
 					pageCurrent_++;
-					if(pageCurrent_ >= GetPageCount())
+					if (pageCurrent_ >= GetPageCount())
 						pageCurrent_ = 1;
 				}
-				cursorY_ = 0;		
+				cursorY_ = 0;
 			}
 		}
 
-		if(pageLast != pageCurrent_)
-		{
+		if (pageLast != pageCurrent_) {
 			//ページ変更
 			_ChangePage();
 		}
@@ -127,16 +106,13 @@ void MenuTask::_MoveCursor()
 }
 void MenuTask::Work()
 {
-	if(!bActive_)
-	{
+	if (!bActive_) {
 		bWaitedKeyFree_ = false;
 		return;
 	}
 
 	EDirectInput* input = EDirectInput::GetInstance();
-	if(input->GetVirtualKeyState(EDirectInput::KEY_OK) == KEY_FREE &&
-		input->GetVirtualKeyState(EDirectInput::KEY_CANCEL) == KEY_FREE) 
-	{
+	if (input->GetVirtualKeyState(EDirectInput::KEY_OK) == KEY_FREE && input->GetVirtualKeyState(EDirectInput::KEY_CANCEL) == KEY_FREE) {
 		bWaitedKeyFree_ = true;
 	}
 
@@ -146,11 +122,11 @@ void MenuTask::Work()
 		Lock lock(cs_);
 		int indexTop = ((pageMaxX_ + 1) * (pageMaxY_ + 1)) * (pageCurrent_ - 1);
 		int countCurrentPageItem = GetCurrentPageItemCount();
-		for(int iItem = 0 ; iItem < countCurrentPageItem ; iItem++)
-		{
+		for (int iItem = 0; iItem < countCurrentPageItem; iItem++) {
 			int index = indexTop + iItem;
 			ref_count_ptr<MenuItem> item = item_[index];
-			if(item == NULL)continue;
+			if (item == NULL)
+				continue;
 			item->Work();
 		}
 	}
@@ -161,11 +137,11 @@ void MenuTask::Render()
 		Lock lock(cs_);
 		int indexTop = ((pageMaxX_ + 1) * (pageMaxY_ + 1)) * (pageCurrent_ - 1);
 		int countCurrentPageItem = GetCurrentPageItemCount();
-		for(int iItem = 0 ; iItem < countCurrentPageItem ; iItem++)
-		{
+		for (int iItem = 0; iItem < countCurrentPageItem; iItem++) {
 			int index = indexTop + iItem;
 			ref_count_ptr<MenuItem> item = item_[index];
-			if(item == NULL)continue;
+			if (item == NULL)
+				continue;
 			item->Render();
 		}
 	}
@@ -205,8 +181,7 @@ ref_count_ptr<MenuItem> MenuTask::GetSelectedMenuItem()
 	{
 		Lock lock(cs_);
 		int index = GetSelectedItemIndex();
-		if(index >= 0 && index < item_.size())
-		{
+		if (index >= 0 && index < item_.size()) {
 			res = item_[index];
 		}
 	}
@@ -240,18 +215,21 @@ TextLightUpMenuItem::TextLightUpMenuItem()
 }
 void TextLightUpMenuItem::_WorkSelectedItem()
 {
-	if(menu_->GetSelectedMenuItem() == this)frameSelected_++;
-	else frameSelected_ = 0;
+	if (menu_->GetSelectedMenuItem() == this)
+		frameSelected_++;
+	else
+		frameSelected_ = 0;
 }
 int TextLightUpMenuItem::_GetSelectedItemAlpha()
 {
 	int res = 0;
-	if(menu_->GetSelectedMenuItem() == this)
-	{
+	if (menu_->GetSelectedMenuItem() == this) {
 		int cycle = 60;
 		int alpha = frameSelected_ % cycle;
-		if(alpha < cycle / 2)alpha = 255 * (float)((float)(cycle / 2 - alpha) / (float)(cycle / 2));
-		else alpha = 255 * (float)((float)(alpha - cycle / 2) / (float)(cycle / 2));
+		if (alpha < cycle / 2)
+			alpha = 255 * (float)((float)(cycle / 2 - alpha) / (float)(cycle / 2));
+		else
+			alpha = 255 * (float)((float)(alpha - cycle / 2) / (float)(cycle / 2));
 		res = alpha;
 	}
 	return res;

--- a/source/TouhouDanmakufu/DnhExecutor/Common.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/Common.hpp
@@ -1,92 +1,86 @@
 #ifndef __TOUHOUDANMAKUFU_EXE_COMMON__
 #define __TOUHOUDANMAKUFU_EXE_COMMON__
 
-#include"../Common/DnhCommon.hpp"
-#include"../Common/DnhReplay.hpp"
+#include "../Common/DnhCommon.hpp"
+#include "../Common/DnhReplay.hpp"
 
-#include"GcLibImpl.hpp"
-
-
-
+#include "GcLibImpl.hpp"
 
 /**********************************************************
 //MenuTask
 **********************************************************/
 class MenuItem;
-class MenuTask
-{
-	protected:
-		enum
-		{
-			CURSOR_NONE = -1,
-			CURSOR_LEFT = 0,
-			CURSOR_RIGHT,
-			CURSOR_UP,
-			CURSOR_DOWN,
-			CURSOR_COUNT = 4,
-		};
-		CriticalSection cs_;
-		bool bActive_;
-		std::vector<ref_count_ptr<MenuItem> > item_;
-		
-		std::vector<int> cursorFrame_;
-		int cursorX_;
-		int cursorY_;
-		int pageCurrent_;
-		int pageMaxX_;
-		int pageMaxY_;
-		bool bPageChangeX_;
-		bool bPageChangeY_;
-		bool bWaitedKeyFree_;
+class MenuTask {
+protected:
+	enum {
+		CURSOR_NONE = -1,
+		CURSOR_LEFT = 0,
+		CURSOR_RIGHT,
+		CURSOR_UP,
+		CURSOR_DOWN,
+		CURSOR_COUNT = 4,
+	};
 
-		int _GetCursorKeyState();
-		virtual void _MoveCursor();
-		virtual void _ChangePage(){};
+public:
+	MenuTask();
+	virtual ~MenuTask();
+	virtual void Clear();
+	virtual void Work();
+	virtual void Render();
+	void SetActive(bool bActive) { bActive_ = bActive; }
 
-		bool _IsWaitedKeyFree(){return bWaitedKeyFree_;}
+	virtual void AddMenuItem(ref_count_ptr<MenuItem> item);
 
-	public:
-		MenuTask();
-		virtual ~MenuTask();
-		virtual void Clear();
-		virtual void Work();
-		virtual void Render();
-		void SetActive(bool bActive){bActive_ = bActive;}
-		
-		virtual void AddMenuItem(ref_count_ptr<MenuItem> item);
+	int GetPageCount();
+	int GetSelectedItemIndex();
+	ref_count_ptr<MenuItem> GetSelectedMenuItem();
 
-		int GetPageCount();
-		int GetSelectedItemIndex();
-		ref_count_ptr<MenuItem> GetSelectedMenuItem();
+	int GetCurrentPageItemCount();
+	int GetCurrentPageMaxX();
+	int GetCurrentPageMaxY();
 
-		int GetCurrentPageItemCount();
-		int GetCurrentPageMaxX();
-		int GetCurrentPageMaxY();
+protected:
+	int _GetCursorKeyState();
+	virtual void _MoveCursor();
+	virtual void _ChangePage(){};
+
+	bool _IsWaitedKeyFree() { return bWaitedKeyFree_; }
+
+	CriticalSection cs_;
+	bool bActive_;
+	std::vector<ref_count_ptr<MenuItem>> item_;
+
+	std::vector<int> cursorFrame_;
+	int cursorX_;
+	int cursorY_;
+	int pageCurrent_;
+	int pageMaxX_;
+	int pageMaxY_;
+	bool bPageChangeX_;
+	bool bPageChangeY_;
+	bool bWaitedKeyFree_;
 };
-class MenuItem
-{
+class MenuItem {
 	friend MenuTask;
-	protected:
-		MenuTask* menu_;
-	public:
-		MenuItem(){}
-		virtual ~MenuItem(){}
-		virtual void Work(){}
-		virtual void Render(){}
+
+public:
+	MenuItem() {}
+	virtual ~MenuItem() {}
+	virtual void Work() {}
+	virtual void Render() {}
+
+protected:
+	MenuTask* menu_;
 };
-class TextLightUpMenuItem : public MenuItem
-{
-	protected:
-		int frameSelected_;
+class TextLightUpMenuItem : public MenuItem {
+public:
+	TextLightUpMenuItem();
 
-		void _WorkSelectedItem();
-		int _GetSelectedItemAlpha();
-	public:
-		TextLightUpMenuItem();
+protected:
+	void _WorkSelectedItem();
+	int _GetSelectedItemAlpha();
 
+	int frameSelected_;
 };
-
-
 
 #endif
-

--- a/source/TouhouDanmakufu/DnhExecutor/Constant.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/Constant.hpp
@@ -1,17 +1,13 @@
 #ifndef __TOUHOUDANMAKUFU_EXE_CONSTANT__
 #define __TOUHOUDANMAKUFU_EXE_CONSTANT__
 
-#pragma comment(lib,"source/GcLib/ext/ogg_static.lib")
-#pragma comment(lib,"source/GcLib/ext/vorbis_static.lib")
-#pragma comment(lib,"source/GcLib/ext/vorbisfile_static.lib")
+#pragma comment(lib, "source/GcLib/ext/ogg_static.lib")
+#pragma comment(lib, "source/GcLib/ext/vorbis_static.lib")
+#pragma comment(lib, "source/GcLib/ext/vorbisfile_static.lib")
 
-#include"../Common/DnhConstant.hpp"
-#include"../Common/DnhCommon.hpp"
+#include "../Common/DnhCommon.hpp"
+#include "../Common/DnhConstant.hpp"
 
-
-#include"resource.h"
-
+#include "resource.h"
 
 #endif
-
-

--- a/source/TouhouDanmakufu/DnhExecutor/GcLibImpl.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/GcLibImpl.cpp
@@ -1,17 +1,15 @@
-#include"GcLibImpl.hpp"
-#include"System.hpp"
-#include"StgScene.hpp"
+#include "GcLibImpl.hpp"
+#include "StgScene.hpp"
+#include "System.hpp"
 
 /**********************************************************
 //EApplication
 **********************************************************/
 EApplication::EApplication()
 {
-
 }
 EApplication::~EApplication()
 {
-
 }
 bool EApplication::_Initialize()
 {
@@ -28,11 +26,11 @@ bool EApplication::_Initialize()
 
 	DnhConfiguration* config = DnhConfiguration::CreateInstance();
 	std::wstring configWindowTitle = config->GetWindowTitle();
-	if(configWindowTitle.size() > 0)
+	if (configWindowTitle.size() > 0)
 		appName = configWindowTitle;
 
 	//マウス表示
-	if(!config->IsMouseVisible())
+	if (!config->IsMouseVisible())
 		WindowUtility::SetMouseVisible(false);
 
 	//DirectX初期化
@@ -68,19 +66,23 @@ bool EApplication::_Initialize()
 
 	gstd::ref_count_ptr<gstd::TaskInfoPanel> panelTask = new gstd::TaskInfoPanel();
 	bool bAddTaskPanel = logger->AddPanel(panelTask, L"Task");
-	if(bAddTaskPanel)taskManager->SetInfoPanel(panelTask);
+	if (bAddTaskPanel)
+		taskManager->SetInfoPanel(panelTask);
 
 	gstd::ref_count_ptr<directx::TextureInfoPanel> panelTexture = new directx::TextureInfoPanel();
 	bool bTexturePanel = logger->AddPanel(panelTexture, L"Texture");
-	if(bTexturePanel)textureManager->SetInfoPanel(panelTexture);
+	if (bTexturePanel)
+		textureManager->SetInfoPanel(panelTexture);
 
 	gstd::ref_count_ptr<directx::DxMeshInfoPanel> panelMesh = new directx::DxMeshInfoPanel();
 	bool bMeshPanel = logger->AddPanel(panelMesh, L"Mesh");
-	if(bMeshPanel)meshManager->SetInfoPanel(panelMesh);
+	if (bMeshPanel)
+		meshManager->SetInfoPanel(panelMesh);
 
 	gstd::ref_count_ptr<directx::SoundInfoPanel> panelSound = new directx::SoundInfoPanel();
 	bool bSoundPanel = logger->AddPanel(panelSound, L"Sound");
-	if(bSoundPanel)soundManager->SetInfoPanel(panelSound);
+	if (bSoundPanel)
+		soundManager->SetInfoPanel(panelSound);
 
 	gstd::ref_count_ptr<gstd::ScriptCommonDataInfoPanel> panelCommonData = logger->GetScriptCommonDataInfoPanel();
 	logger->AddPanel(panelCommonData, L"Common Data");
@@ -88,8 +90,7 @@ bool EApplication::_Initialize()
 	gstd::ref_count_ptr<ScriptInfoPanel> panelScript = new ScriptInfoPanel();
 	logger->AddPanel(panelScript, L"Script");
 
-	if(config->IsLogWindow())
-	{
+	if (config->IsLogWindow()) {
 		logger->LoadState();
 		logger->SetWindowVisible(true);
 	}
@@ -111,8 +112,7 @@ bool EApplication::_Loop()
 	HWND hWndFocused = ::GetForegroundWindow();
 	HWND hWndGraphics = graphics->GetWindowHandle();
 	HWND hWndLogger = ELogger::GetInstance()->GetWindowHandle();
-	if(hWndFocused != hWndGraphics && hWndFocused != hWndLogger)
-	{
+	if (hWndFocused != hWndGraphics && hWndFocused != hWndLogger) {
 		//非アクティブ時は動作しない
 		::Sleep(10);
 		return true;
@@ -120,19 +120,15 @@ bool EApplication::_Loop()
 
 	EDirectInput* input = EDirectInput::GetInstance();
 	input->Update();
-	if(input->GetKeyState(DIK_LCONTROL) == KEY_HOLD &&
-		input->GetKeyState(DIK_LSHIFT) == KEY_HOLD &&
-		input->GetKeyState(DIK_R) == KEY_PUSH)
-	{
+	if (input->GetKeyState(DIK_LCONTROL) == KEY_HOLD && input->GetKeyState(DIK_LSHIFT) == KEY_HOLD && input->GetKeyState(DIK_R) == KEY_PUSH) {
 		//リセット
 		SystemController* systemController = SystemController::CreateInstance();
 		systemController->Reset();
 	}
-	
+
 	taskManager->CallWorkFunction();
 
-	if(!fpsController->IsSkip())
-	{
+	if (!fpsController->IsSkip()) {
 		graphics->BeginScene();
 		taskManager->CallRenderFunction();
 		graphics->EndScene();
@@ -144,7 +140,7 @@ bool EApplication::_Loop()
 	SYSTEMTIME time;
 	GetLocalTime(&time);
 	std::wstring fps = StringUtility::Format(L"Work：%.2ffps、Draw：%.2ffps",
-		fpsController->GetCurrentWorkFps(), 
+		fpsController->GetCurrentWorkFps(),
 		fpsController->GetCurrentRenderFps());
 	logger->SetInfo(0, L"fps", fps);
 
@@ -154,23 +150,20 @@ bool EApplication::_Loop()
 	int heightScreen = heightConfig * graphics->GetScreenHeightRatio();
 
 	std::wstring screen = StringUtility::Format(L"width：%d/%d、height：%d/%d",
-		widthScreen, widthConfig, 
+		widthScreen, widthConfig,
 		heightScreen, heightConfig);
 	logger->SetInfo(1, L"screen", screen);
 
-	logger->SetInfo(2, L"font cache", 
-		StringUtility::Format(L"%d", EDxTextRenderer::GetInstance()->GetCacheCount() ));
-	
+	logger->SetInfo(2, L"font cache",
+		StringUtility::Format(L"%d", EDxTextRenderer::GetInstance()->GetCacheCount()));
+
 	//高速動作
 	int fastModeKey = fpsController->GetFastModeKey();
-	if(input->GetKeyState(fastModeKey) == KEY_HOLD)
-	{
-		if(!fpsController->IsFastMode())
+	if (input->GetKeyState(fastModeKey) == KEY_HOLD) {
+		if (!fpsController->IsFastMode())
 			fpsController->SetFastMode(true);
-	}
-	else if(input->GetKeyState(fastModeKey) == KEY_PULL || input->GetKeyState(fastModeKey) == KEY_FREE)
-	{
-		if(fpsController->IsFastMode())
+	} else if (input->GetKeyState(fastModeKey) == KEY_PULL || input->GetKeyState(fastModeKey) == KEY_FREE) {
+		if (fpsController->IsFastMode())
 			fpsController->SetFastMode(false);
 	}
 	return true;
@@ -198,15 +191,11 @@ bool EApplication::_Finalize()
 	return true;
 }
 
-
-
-
 /**********************************************************
 //EDirectGraphics
 **********************************************************/
 EDirectGraphics::EDirectGraphics()
 {
-
 }
 EDirectGraphics::~EDirectGraphics()
 {
@@ -220,23 +209,20 @@ bool EDirectGraphics::Initialize()
 	int windowSize = dnhConfig->GetWindowSize();
 
 	bool bUserSize = screenWidth != 640 || screenHeight != 480;
-	if(!bUserSize)
-	{
-		if(windowSize == DnhConfiguration::WINDOW_SIZE_640x480 && screenWidth > 640)
+	if (!bUserSize) {
+		if (windowSize == DnhConfiguration::WINDOW_SIZE_640x480 && screenWidth > 640)
 			windowSize = DnhConfiguration::WINDOW_SIZE_800x600;
-		if(windowSize == DnhConfiguration::WINDOW_SIZE_800x600 && screenWidth > 800)
+		if (windowSize == DnhConfiguration::WINDOW_SIZE_800x600 && screenWidth > 800)
 			windowSize = DnhConfiguration::WINDOW_SIZE_960x720;
-		if(windowSize == DnhConfiguration::WINDOW_SIZE_960x720 && screenWidth > 960)
+		if (windowSize == DnhConfiguration::WINDOW_SIZE_960x720 && screenWidth > 960)
 			windowSize = DnhConfiguration::WINDOW_SIZE_1280x960;
-		if(windowSize == DnhConfiguration::WINDOW_SIZE_1280x960 && screenWidth > 1280)
+		if (windowSize == DnhConfiguration::WINDOW_SIZE_1280x960 && screenWidth > 1280)
 			windowSize = DnhConfiguration::WINDOW_SIZE_1600x1200;
-		if(windowSize == DnhConfiguration::WINDOW_SIZE_1600x1200 && screenWidth > 1600)
+		if (windowSize == DnhConfiguration::WINDOW_SIZE_1600x1200 && screenWidth > 1600)
 			windowSize = DnhConfiguration::WINDOW_SIZE_1920x1200;
 	}
 
-
-	bool bShowWindow = screenMode == DirectGraphics::SCREENMODE_FULLSCREEN ||
-						windowSize == DnhConfiguration::WINDOW_SIZE_640x480;
+	bool bShowWindow = screenMode == DirectGraphics::SCREENMODE_FULLSCREEN || windowSize == DnhConfiguration::WINDOW_SIZE_640x480;
 
 	DirectGraphicsConfig dxConfig;
 	dxConfig.SetScreenWidth(screenWidth);
@@ -247,50 +233,51 @@ bool EDirectGraphics::Initialize()
 	int wWidth = ::GetSystemMetrics(SM_CXFULLSCREEN);
 	int wHeight = ::GetSystemMetrics(SM_CYFULLSCREEN);
 	bool bFullScreenEnable = screenWidth <= wWidth && screenHeight <= wHeight;
-	
+
 	//コンフィグ反映
-	if(screenMode == DirectGraphics::SCREENMODE_FULLSCREEN && bFullScreenEnable)
-	{
+	if (screenMode == DirectGraphics::SCREENMODE_FULLSCREEN && bFullScreenEnable) {
 		ChangeScreenMode();
-	}
-	else
-	{	
-		if(windowSize != DnhConfiguration::WINDOW_SIZE_640x480 || bUserSize)
-		{
+	} else {
+		if (windowSize != DnhConfiguration::WINDOW_SIZE_640x480 || bUserSize) {
 			int width = screenWidth;
 			int height = screenHeight;
-			if(!bUserSize)
-			{
-				switch(windowSize)
-				{
+			if (!bUserSize) {
+				switch (windowSize) {
 				case DnhConfiguration::WINDOW_SIZE_800x600:
-					width = 800; height = 600; // + ::GetSystemMetrics(SM_CXEDGE) + 10 ; + ::GetSystemMetrics(SM_CXEDGE) + 10 ;
+					width = 800;
+					height = 600; // + ::GetSystemMetrics(SM_CXEDGE) + 10 ; + ::GetSystemMetrics(SM_CXEDGE) + 10 ;
 					break;
 				case DnhConfiguration::WINDOW_SIZE_960x720:
-					width = 960; height = 720; // + ::GetSystemMetrics(SM_CXEDGE) + 10 ; + ::GetSystemMetrics(SM_CXEDGE) + 10 ;
+					width = 960;
+					height = 720; // + ::GetSystemMetrics(SM_CXEDGE) + 10 ; + ::GetSystemMetrics(SM_CXEDGE) + 10 ;
 					break;
 				case DnhConfiguration::WINDOW_SIZE_1280x960:
-					width = 1280; height = 960; // + ::GetSystemMetrics(SM_CXEDGE) + 10 ; + ::GetSystemMetrics(SM_CXEDGE) + 10 ;
+					width = 1280;
+					height = 960; // + ::GetSystemMetrics(SM_CXEDGE) + 10 ; + ::GetSystemMetrics(SM_CXEDGE) + 10 ;
 					break;
 				case DnhConfiguration::WINDOW_SIZE_1600x1200:
-					width = 1600; height = 1200;  // + ::GetSystemMetrics(SM_CXEDGE) + 10 ; + ::GetSystemMetrics(SM_CXEDGE) + 10 ;
+					width = 1600;
+					height = 1200; // + ::GetSystemMetrics(SM_CXEDGE) + 10 ; + ::GetSystemMetrics(SM_CXEDGE) + 10 ;
 					break;
 				case DnhConfiguration::WINDOW_SIZE_1920x1200:
-					width = 1920; height = 1200; // + ::GetSystemMetrics(SM_CXEDGE) + 10 ; + ::GetSystemMetrics(SM_CXEDGE) + 10 ;
+					width = 1920;
+					height = 1200; // + ::GetSystemMetrics(SM_CXEDGE) + 10 ; + ::GetSystemMetrics(SM_CXEDGE) + 10 ;
 					break;
 				}
 			}
 
 			double ratioWH = (double)screenWidth / (double)screenHeight;
-			if(width > wWidth)width = wWidth;
+			if (width > wWidth)
+				width = wWidth;
 			height = (double)width / ratioWH;
 
 			double ratioHW = (double)screenHeight / (double)screenWidth;
-			if(height > wHeight) height = wHeight;
+			if (height > wHeight)
+				height = wHeight;
 			width = (double)height / ratioHW;
 
-			int tw=::GetSystemMetrics(SM_CXEDGE) + 10+GetSystemMetrics(SM_CXBORDER)+GetSystemMetrics(SM_CXDLGFRAME);
-			int th=::GetSystemMetrics(SM_CYEDGE) + 10+GetSystemMetrics(SM_CYBORDER)+GetSystemMetrics(SM_CYDLGFRAME)+GetSystemMetrics(SM_CYCAPTION);
+			int tw = ::GetSystemMetrics(SM_CXEDGE) + 10 + GetSystemMetrics(SM_CXBORDER) + GetSystemMetrics(SM_CXDLGFRAME);
+			int th = ::GetSystemMetrics(SM_CYEDGE) + 10 + GetSystemMetrics(SM_CYBORDER) + GetSystemMetrics(SM_CYDLGFRAME) + GetSystemMetrics(SM_CYCAPTION);
 			width += tw;
 			height += th;
 
@@ -309,19 +296,14 @@ void EDirectGraphics::SetRenderStateFor2D(int blend)
 	graphics->SetZBufferEnable(false);
 	graphics->SetZWriteEnalbe(false);
 }
-LRESULT EDirectGraphics::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
+LRESULT EDirectGraphics::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	switch (uMsg)
-	{
-		case WM_SYSCOMMAND:
-		{
-			int nId = wParam & 0xffff;
-			if (nId == WindowLogger::MENU_ID_OPEN)
-			{
-				ELogger::GetInstance()->ShowLogWindow();
-			}
-			break;
-		}
+	switch (uMsg) {
+	case WM_SYSCOMMAND:
+		int nId = wParam & 0xffff;
+		if (nId == WindowLogger::MENU_ID_OPEN)
+			ELogger::GetInstance()->ShowLogWindow();
+		break;
 	}
 	return DirectGraphicsPrimaryWindow::_WindowProcedure(hWnd, uMsg, wParam, lParam);
 }

--- a/source/TouhouDanmakufu/DnhExecutor/GcLibImpl.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/GcLibImpl.hpp
@@ -1,37 +1,43 @@
 #ifndef __TOUHOUDANMAKUFU_EXE_GCLIBIMPL__
 #define __TOUHOUDANMAKUFU_EXE_GCLIBIMPL__
 
-#include"Constant.hpp"
-#include"../Common/DnhGcLibImpl.hpp"
+#include "../Common/DnhGcLibImpl.hpp"
+#include "Constant.hpp"
 
 /**********************************************************
 //EApplication
 **********************************************************/
-class EApplication : public Singleton<EApplication>, public Application
-{
-		friend Singleton<EApplication>;
-		EApplication();
-	protected:
-		bool _Initialize();
-		bool _Loop();
-		bool _Finalize();
-	public:
-		~EApplication();
+class EApplication : public Singleton<EApplication>, public Application {
+	friend Singleton<EApplication>;
+
+private:
+	EApplication();
+
+protected:
+	bool _Initialize();
+	bool _Loop();
+	bool _Finalize();
+
+public:
+	~EApplication();
 };
 
 /**********************************************************
 //EDirectGraphics
 **********************************************************/
-class EDirectGraphics : public Singleton<EDirectGraphics>, public DirectGraphicsPrimaryWindow
-{
-		friend Singleton<EDirectGraphics>;
-		EDirectGraphics();
-	protected:
-		virtual LRESULT _WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
-	public:
-		~EDirectGraphics();
-		virtual bool Initialize();
-		void SetRenderStateFor2D(int blend);
+class EDirectGraphics : public Singleton<EDirectGraphics>, public DirectGraphicsPrimaryWindow {
+	friend Singleton<EDirectGraphics>;
+
+private:
+	EDirectGraphics();
+
+protected:
+	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+public:
+	~EDirectGraphics();
+	virtual bool Initialize();
+	void SetRenderStateFor2D(int blend);
 };
 
 #endif

--- a/source/TouhouDanmakufu/DnhExecutor/ScriptSelectScene.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/ScriptSelectScene.cpp
@@ -112,7 +112,7 @@ void ScriptSelectScene::Work()
 				int index = GetSelectedItemIndex();
 				ScriptSelectSceneMenuItem* pItem = (ScriptSelectSceneMenuItem*)item_[index].GetPointer();
 				std::wstring dir = pItem->GetPath();
-				
+
 				//ページリセット
 				cursorX_ = 0;
 				cursorY_ = 0;
@@ -142,7 +142,7 @@ void ScriptSelectScene::Work()
 				taskManager->AddWorkFunction(TTaskFunction<PlayTypeSelectScene>::Create(
 					task, &PlayTypeSelectScene::Work), PlayTypeSelectScene::TASK_PRI_WORK);
 				taskManager->AddRenderFunction(TTaskFunction<PlayTypeSelectScene>::Create(
-					task, &PlayTypeSelectScene::Render), PlayTypeSelectScene::TASK_PRI_RENDER);				
+					task, &PlayTypeSelectScene::Render), PlayTypeSelectScene::TASK_PRI_RENDER);
 
 				return;
 			}
@@ -179,7 +179,7 @@ void ScriptSelectScene::Work()
 				return;
 			}
 		}
-		
+
 		if(bTitle)
 		{
 			SceneManager* sceneManager = SystemController::GetInstance()->GetSceneManager();
@@ -274,7 +274,7 @@ void ScriptSelectScene::Render()
 			}
 		}
 
-		ref_count_ptr<ScriptSelectSceneMenuItem> item = 
+		ref_count_ptr<ScriptSelectSceneMenuItem> item =
 			ref_count_ptr<ScriptSelectSceneMenuItem>::DownCast(GetSelectedMenuItem());
 		if(bActive_ && item != NULL && item->GetType() != ScriptSelectSceneMenuItem::TYPE_DIR)
 		{
@@ -303,7 +303,7 @@ void ScriptSelectScene::Render()
 				}
 				else
 					spriteImage_->SetTexture(NULL);
-					
+
 			}
 
 			texture = spriteImage_->GetTexture();
@@ -322,7 +322,7 @@ void ScriptSelectScene::Render()
 			root = PathProperty::ReplaceYenToSlash(root);
 			path = PathProperty::ReplaceYenToSlash(path);
 			path = StringUtility::ReplaceAll(path, root, L"");
-			
+
 			std::wstring archive = info->GetArchivePath();
 			if(archive.size() > 0)
 			{
@@ -461,7 +461,7 @@ void ScriptSelectScene::AddMenuItem(std::list<ref_count_ptr<ScriptSelectSceneMen
 				if(path.size() > 0)
 					bWait = true;
 			}
-			
+
 			if(path.size() == 0 && (pageCurrent_ > 1 || cursorY_ > 0))
 			{
 				ScriptSelectSceneMenuItem* pItem = (ScriptSelectSceneMenuItem*)item.GetPointer();
@@ -540,7 +540,7 @@ void ScriptSelectFileModel::_SearchScript(std::wstring dir)
 	HANDLE hFind;
 	std::wstring findDir = dir + L"*.*";
 	hFind = FindFirstFile(findDir.c_str(), &data);
-	do 
+	do
 	{
 		if(GetStatus() != RUN)return;
 
@@ -554,7 +554,7 @@ void ScriptSelectFileModel::_SearchScript(std::wstring dir)
 		}
 
 		std::wstring name = data.cFileName;
-		if((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) && 
+		if((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
 			(name != L".." && name != L"."))
 		{
 			//ディレクトリ
@@ -587,7 +587,7 @@ void ScriptSelectFileModel::_SearchScript(std::wstring dir)
 }
 void ScriptSelectFileModel::_CreateMenuItem(std::wstring path)
 {
-	std::vector<ref_count_ptr<ScriptInformation> >listInfo = 
+	std::vector<ref_count_ptr<ScriptInformation> >listInfo =
 		ScriptInformation::CreateScriptInformationList(path, true);
 	for(int iInfo = 0 ; iInfo < listInfo.size() ; iInfo++)
 	{
@@ -688,7 +688,7 @@ PlayTypeSelectScene::PlayTypeSelectScene(ref_count_ptr<ScriptInformation> info)
 			int itemY = 256 + (itemCount % pageMaxY_) * 20;
 
 			std::wstring text = StringUtility::Format(L"No.%02d %-8s %012I64d %-8s (%2.2ffps) <%s>",
-				index, 	
+				index,
 				replay->GetUserName().c_str(),
 				replay->GetTotalScore(),
 				replay->GetPlayerScriptReplayName().c_str(),
@@ -719,7 +719,7 @@ void PlayTypeSelectScene::Work()
 		{
 			//パッケージ以外
 			int indexSelect = GetSelectedItemIndex();
-			if(indexSelect == 0) 
+			if(indexSelect == 0)
 			{
 				//自機選択
 				TransitionManager* transitionManager = SystemController::GetInstance()->GetTransitionManager();
@@ -735,7 +735,7 @@ void PlayTypeSelectScene::Work()
 				taskManager->AddWorkFunction(TTaskFunction<PlayerSelectScene>::Create(
 					task, &PlayerSelectScene::Work), PlayerSelectScene::TASK_PRI_WORK);
 				taskManager->AddRenderFunction(TTaskFunction<PlayerSelectScene>::Create(
-					task, &PlayerSelectScene::Render), PlayerSelectScene::TASK_PRI_RENDER);	
+					task, &PlayerSelectScene::Render), PlayerSelectScene::TASK_PRI_RENDER);
 			}
 			else
 			{
@@ -754,7 +754,7 @@ void PlayTypeSelectScene::Work()
 	else if(input->GetVirtualKeyState(EDirectInput::KEY_CANCEL) == KEY_PUSH)
 	{
 		ETaskManager* taskManager = ETaskManager::GetInstance();
-		ref_count_ptr<ScriptSelectScene> scriptSelectScene = 
+		ref_count_ptr<ScriptSelectScene> scriptSelectScene =
 			ref_count_ptr<ScriptSelectScene>::DownCast(taskManager->GetTask(typeid(ScriptSelectScene)));
 		scriptSelectScene->SetActive(true);
 
@@ -830,7 +830,7 @@ PlayerSelectScene::PlayerSelectScene(ref_count_ptr<ScriptInformation> info)
 	int screenHeight = graphics->GetScreenHeight();
 	RECT_D srcBack = {0., 0., 640., 480.};
 	RECT_D destBack = {0., 0., (double)screenWidth, (double)screenHeight};
-	
+
 	spriteBack_ = new Sprite2D();
 	spriteBack_->SetTexture(textureBack);
 	spriteBack_->SetVertex(srcBack, destBack);
@@ -858,7 +858,7 @@ PlayerSelectScene::PlayerSelectScene(ref_count_ptr<ScriptInformation> info)
 
 	std::vector<ref_count_ptr<ScriptInformation> > listLastPlayerSelect = systemInfo->GetLastPlayerSelectedList();
 	bool bSameList = false;
-	if(listPlayer_.size() == listLastPlayerSelect.size()) 
+	if(listPlayer_.size() == listLastPlayerSelect.size())
 	{
 		bSameList = true;
 		for(int iList = 0 ; iList < listPlayer_.size() ; iList++)
@@ -955,7 +955,7 @@ void PlayerSelectScene::Render()
 			}
 			else
 				spriteImage_->SetTexture(NULL);
-				
+
 		}
 
 		texture = spriteImage_->GetTexture();
@@ -974,7 +974,7 @@ void PlayerSelectScene::Render()
 		root = PathProperty::ReplaceYenToSlash(root);
 		path = PathProperty::ReplaceYenToSlash(path);
 		path = StringUtility::ReplaceAll(path, root, L"");
-		
+
 		std::wstring archive = infoSelected->GetArchivePath();
 		if(archive.size() > 0)
 		{

--- a/source/TouhouDanmakufu/DnhExecutor/ScriptSelectScene.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/ScriptSelectScene.hpp
@@ -4,7 +4,6 @@
 #include"GcLibImpl.hpp"
 #include"Common.hpp"
 
-
 class ScriptSelectSceneMenuItem;
 class ScriptSelectModel;
 /**********************************************************
@@ -120,7 +119,7 @@ class ScriptSelectModel
 	public:
 		ScriptSelectModel();
 		virtual ~ScriptSelectModel();
-		
+
 		virtual void CreateMenuItem() = 0;
 		bool IsCreated(){return bCreated_;}
 };
@@ -137,7 +136,7 @@ class ScriptSelectFileModel : public ScriptSelectModel , public Thread
 			TYPE_DIR = ScriptSelectScene::TYPE_DIR,
 			TYPE_ALL = ScriptSelectScene::TYPE_ALL,
 		};
-		
+
 	protected:
 		int type_;
 		std::wstring dir_;
@@ -223,7 +222,7 @@ class PlayerSelectScene : public TaskBase , public MenuTask
 };
 class PlayerSelectMenuItem : public TextLightUpMenuItem
 {
-		ref_count_ptr<ScriptInformation> info_;//é©ã@èÓïÒ
+		ref_count_ptr<ScriptInformation> info_;
 
 		PlayerSelectScene* _GetTitleScene(){return (PlayerSelectScene*)menu_;}
 	public:

--- a/source/TouhouDanmakufu/DnhExecutor/StgScene.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/StgScene.cpp
@@ -1,5 +1,5 @@
-#include"StgScene.hpp"
-#include"System.hpp"
+#include "StgScene.hpp"
+#include "System.hpp"
 
 /**********************************************************
 //EStgSystemController
@@ -14,7 +14,6 @@ void EStgSystemController::DoRetry()
 	ref_count_ptr<StgStageInformation> infoStage = stageController_->GetStageInformation();
 	sceneManager->TransStgScene(infoStage->GetMainScriptInformation(), infoStage->GetPlayerScriptInformation(), NULL);
 }
-
 
 /**********************************************************
 //PStgSystemController

--- a/source/TouhouDanmakufu/DnhExecutor/StgScene.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/StgScene.hpp
@@ -1,29 +1,24 @@
 #ifndef __TOUHOUDANMAKUFU_EXE_STG_SCENE__
 #define __TOUHOUDANMAKUFU_EXE_STG_SCENE__
 
-#include"../Common/StgSystem.hpp"
+#include "../Common/StgSystem.hpp"
 
 /**********************************************************
 //EStgSystemController
 **********************************************************/
-class EStgSystemController : public StgSystemController
-{
-	protected:
-		virtual void DoEnd();
-		virtual void DoRetry();
+class EStgSystemController : public StgSystemController {
+protected:
+	virtual void DoEnd();
+	virtual void DoRetry();
 };
-
 
 /**********************************************************
 //PStgSystemController
 **********************************************************/
-class PStgSystemController : public StgSystemController
-{
-	protected:
-		virtual void DoEnd();
-		virtual void DoRetry();
+class PStgSystemController : public StgSystemController {
+protected:
+	virtual void DoEnd();
+	virtual void DoRetry();
 };
-
-
 
 #endif

--- a/source/TouhouDanmakufu/DnhExecutor/System.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/System.cpp
@@ -1,7 +1,7 @@
-#include"System.hpp"
-#include"TitleScene.hpp"
-#include"ScriptSelectScene.hpp"
-#include"StgScene.hpp"
+#include "System.hpp"
+#include "ScriptSelectScene.hpp"
+#include "StgScene.hpp"
+#include "TitleScene.hpp"
 
 /**********************************************************
 //SystemController
@@ -16,8 +16,8 @@ SystemController::SystemController()
 	ETaskManager* taskManager = ETaskManager::GetInstance();
 	ref_count_ptr<SystemResidentTask> task = new SystemResidentTask();
 	taskManager->AddTask(task);
-	taskManager->AddRenderFunction(TTaskFunction<SystemResidentTask>::Create(
-		task, &SystemResidentTask::RenderFps), SystemResidentTask::TASK_PRI_RENDER_FPS);
+	taskManager->AddRenderFunction(TTaskFunction<SystemResidentTask>::Create(task, &SystemResidentTask::RenderFps),
+		SystemResidentTask::TASK_PRI_RENDER_FPS);
 }
 SystemController::~SystemController()
 {
@@ -31,15 +31,12 @@ void SystemController::Reset()
 
 	DnhConfiguration* config = DnhConfiguration::CreateInstance();
 	std::wstring pathPackageScript = config->GetPackageScriptPath();
-	if(pathPackageScript.size() == 0)
-	{
+	if (pathPackageScript.size() == 0) {
 		infoSystem_->UpdateFreePlayerScriptInformationList();
 		sceneManager_->TransTitleScene();
-	}
-	else
-	{
+	} else {
 		ref_count_ptr<ScriptInformation> info = ScriptInformation::CreateScriptInformation(pathPackageScript, false);
-		if(info == NULL)
+		if (info == NULL)
 			ShowErrorDialog(ErrorUtility::GetFileNotFoundErrorMessage(pathPackageScript));
 		sceneManager_->TransPackageScene(info, true);
 	}
@@ -81,10 +78,10 @@ void SceneManager::TransTitleScene()
 	ETaskManager* taskManager = ETaskManager::GetInstance();
 	ref_count_ptr<TitleScene> task = new TitleScene();
 	taskManager->AddTask(task);
-	taskManager->AddWorkFunction(TTaskFunction<TitleScene>::Create(
-		task, &TitleScene::Work), TitleScene::TASK_PRI_WORK);
-	taskManager->AddRenderFunction(TTaskFunction<TitleScene>::Create(
-		task, &TitleScene::Render), TitleScene::TASK_PRI_RENDER);
+	taskManager->AddWorkFunction(TTaskFunction<TitleScene>::Create(task, &TitleScene::Work),
+		TitleScene::TASK_PRI_WORK);
+	taskManager->AddRenderFunction(TTaskFunction<TitleScene>::Create(task, &TitleScene::Render),
+		TitleScene::TASK_PRI_RENDER);
 }
 void SceneManager::TransScriptSelectScene(int type)
 {
@@ -98,25 +95,22 @@ void SceneManager::TransScriptSelectScene(int type)
 	ETaskManager* taskManager = ETaskManager::GetInstance();
 	ref_count_ptr<ScriptSelectScene> task = new ScriptSelectScene();
 	taskManager->AddTask(task);
-	taskManager->AddWorkFunction(TTaskFunction<ScriptSelectScene>::Create(
-		task, &ScriptSelectScene::Work), ScriptSelectScene::TASK_PRI_WORK);
-	taskManager->AddRenderFunction(TTaskFunction<ScriptSelectScene>::Create(
-		task, &ScriptSelectScene::Render), ScriptSelectScene::TASK_PRI_RENDER);
+	taskManager->AddWorkFunction(TTaskFunction<ScriptSelectScene>::Create(task, &ScriptSelectScene::Work),
+		ScriptSelectScene::TASK_PRI_WORK);
+	taskManager->AddRenderFunction(TTaskFunction<ScriptSelectScene>::Create(task, &ScriptSelectScene::Render),
+		ScriptSelectScene::TASK_PRI_RENDER);
 
 	ref_count_ptr<ScriptSelectModel> model = NULL;
-	if(type == ScriptSelectScene::TYPE_SINGLE || 
-		type == ScriptSelectScene::TYPE_PLURAL || 
-		type == ScriptSelectScene::TYPE_STAGE || 
-		type == ScriptSelectScene::TYPE_PACKAGE || 
-		type == ScriptSelectScene::TYPE_DIR || 
-		type == ScriptSelectScene::TYPE_ALL )
-	{
+	if (type == ScriptSelectScene::TYPE_SINGLE
+		|| type == ScriptSelectScene::TYPE_PLURAL
+		|| type == ScriptSelectScene::TYPE_STAGE
+		|| type == ScriptSelectScene::TYPE_PACKAGE
+		|| type == ScriptSelectScene::TYPE_DIR
+		|| type == ScriptSelectScene::TYPE_ALL) {
 		std::wstring dir = EPathProperty::GetStgScriptRootDirectory();
 		SystemInformation* systemInfo = SystemController::GetInstance()->GetSystemInformation();
-		if(type == ScriptSelectScene::TYPE_DIR)
-		{
+		if (type == ScriptSelectScene::TYPE_DIR)
 			dir = systemInfo->GetLastScriptSearchDirectory();
-		}
 		ScriptSelectFileModel* fileModel = new ScriptSelectFileModel(type, dir);
 		std::wstring pathWait = systemInfo->GetLastSelectedScriptPath();
 		fileModel->SetWaitPath(pathWait);
@@ -158,8 +152,7 @@ void SceneManager::TransStgScene(ref_count_ptr<ScriptInformation> infoMain, ref_
 	EDirectInput* input = EDirectInput::GetInstance();
 	input->ClearKeyState();
 
-	try
-	{
+	try {
 		//STGシーン初期化
 		ref_count_ptr<StgSystemInformation> infoStgSystem = new StgSystemInformation();
 		infoStgSystem->SetMainScriptInformation(infoMain);
@@ -177,13 +170,11 @@ void SceneManager::TransStgScene(ref_count_ptr<ScriptInformation> infoMain, ref_
 
 		//STGタスク登録
 		taskManager->AddTask(task);
-		taskManager->AddWorkFunction(TTaskFunction<StgSystemController>::Create(
-			task, &StgSystemController::Work), StgSystemController::TASK_PRI_WORK);
-		taskManager->AddRenderFunction(TTaskFunction<StgSystemController>::Create(
-			task, &StgSystemController::Render), StgSystemController::TASK_PRI_RENDER);
-	}
-	catch(gstd::wexception& e)
-	{
+		taskManager->AddWorkFunction(TTaskFunction<StgSystemController>::Create(task, &StgSystemController::Work),
+			StgSystemController::TASK_PRI_WORK);
+		taskManager->AddRenderFunction(TTaskFunction<StgSystemController>::Create(task, &StgSystemController::Render),
+			StgSystemController::TASK_PRI_RENDER);
+	} catch (gstd::wexception& e) {
 		Logger::WriteTop(e.what());
 
 		SystemController* system = SystemController::GetInstance();
@@ -194,68 +185,59 @@ void SceneManager::TransStgScene(ref_count_ptr<ScriptInformation> infoMain, ref_
 
 void SceneManager::TransStgScene(ref_count_ptr<ScriptInformation> infoMain, ref_count_ptr<ReplayInformation> infoReplay)
 {
-	try
-	{
+	try {
 		std::wstring replayPlayerID = infoReplay->GetPlayerScriptID();
 		std::wstring replayPlayerScriptFileName = infoReplay->GetPlayerScriptFileName();
 
 		//自機を検索
 		ref_count_ptr<ScriptInformation> infoPlayer;
-		std::vector<ref_count_ptr<ScriptInformation> > listPlayer;
+		std::vector<ref_count_ptr<ScriptInformation>> listPlayer;
 		std::vector<std::wstring> listPlayerPath = infoMain->GetPlayerList();
-		if(listPlayerPath.size() == 0)
-		{
-			listPlayer = 
-				SystemController::GetInstance()->GetSystemInformation()->GetFreePlayerScriptInformationList();
-		}
-		else
-		{
+		if (listPlayerPath.size() == 0) {
+			listPlayer = SystemController::GetInstance()->GetSystemInformation()->GetFreePlayerScriptInformationList();
+		} else {
 			listPlayer = infoMain->CreatePlayerScriptInformationList();
 		}
 
-		for(int iPlayer = 0 ; iPlayer < listPlayer.size() ; iPlayer++)
-		{
+		for (int iPlayer = 0; iPlayer < listPlayer.size(); iPlayer++) {
 			ref_count_ptr<ScriptInformation> tInfo = listPlayer[iPlayer];
-			if(tInfo->GetID() != replayPlayerID)continue;
+			if (tInfo->GetID() != replayPlayerID)
+				continue;
 			std::wstring tPlayerScriptFileName = PathProperty::GetFileName(tInfo->GetScriptPath());
-			if(tPlayerScriptFileName != replayPlayerScriptFileName)continue;
+			if (tPlayerScriptFileName != replayPlayerScriptFileName)
+				continue;
 
 			infoPlayer = tInfo;
 			break;
 		}
 
-		if(infoPlayer == NULL)
-		{
+		if (infoPlayer == NULL) {
 			std::wstring log = StringUtility::Format(L"自機スクリプトが見つかりません:[%s]", replayPlayerScriptFileName.c_str());
 			throw gstd::wexception(log.c_str());
 		}
 
 		TransStgScene(infoMain, infoPlayer, infoReplay);
-	}
-	catch(gstd::wexception& e)
-	{
+	} catch (gstd::wexception& e) {
 		Logger::WriteTop(e.what());
 
 		SystemController* system = SystemController::GetInstance();
 		system->ShowErrorDialog(e.what());
 		system->GetSceneManager()->TransScriptSelectScene_Last();
 	}
-
 }
 void SceneManager::TransPackageScene(ref_count_ptr<ScriptInformation> infoMain, bool bOnlyPackage)
 {
 	EDirectInput* input = EDirectInput::GetInstance();
 	input->ClearKeyState();
 
-	try
-	{
+	try {
 		//STGシーン初期化
 		ref_count_ptr<StgSystemInformation> infoStgSystem = new StgSystemInformation();
 		infoStgSystem->SetMainScriptInformation(infoMain);
 		ref_count_ptr<StgSystemController> task = NULL;
-		if(!bOnlyPackage)
+		if (!bOnlyPackage)
 			task = new EStgSystemController();
-		else 
+		else
 			task = new PStgSystemController();
 
 		//STGタスク初期化
@@ -270,26 +252,20 @@ void SceneManager::TransPackageScene(ref_count_ptr<ScriptInformation> infoMain, 
 
 		//STGタスク登録
 		taskManager->AddTask(task);
-		taskManager->AddWorkFunction(TTaskFunction<StgSystemController>::Create(
-			task, &StgSystemController::Work), StgSystemController::TASK_PRI_WORK);
-		taskManager->AddRenderFunction(TTaskFunction<StgSystemController>::Create(
-			task, &StgSystemController::Render), StgSystemController::TASK_PRI_RENDER);
-	}
-	catch(gstd::wexception& e)
-	{
+		taskManager->AddWorkFunction(TTaskFunction<StgSystemController>::Create(task, &StgSystemController::Work),
+			StgSystemController::TASK_PRI_WORK);
+		taskManager->AddRenderFunction(TTaskFunction<StgSystemController>::Create(task, &StgSystemController::Render),
+			StgSystemController::TASK_PRI_RENDER);
+	} catch (gstd::wexception& e) {
 		Logger::WriteTop(e.what());
 
 		SystemController* system = SystemController::GetInstance();
 		system->ShowErrorDialog(e.what());
-		if(!bOnlyPackage)
-		{
+		if (!bOnlyPackage) {
 			system->GetSceneManager()->TransScriptSelectScene_Last();
-		}
-		else
-		{
+		} else {
 			EApplication::GetInstance()->End();
 		}
-
 	}
 }
 
@@ -324,10 +300,10 @@ void TransitionManager::_AddTask(ref_count_ptr<TransitionEffect> effect)
 	ref_count_ptr<SystemTransitionEffectTask> task = new SystemTransitionEffectTask();
 	task->SetTransition(effect);
 	taskManager->AddTask(task);
-	taskManager->AddWorkFunction(TTaskFunction<SystemTransitionEffectTask>::Create(
-		task, &SystemTransitionEffectTask::Work), TASK_PRI);
-	taskManager->AddRenderFunction(TTaskFunction<SystemTransitionEffectTask>::Create(
-		task, &SystemTransitionEffectTask::Render), TASK_PRI);
+	taskManager->AddWorkFunction(TTaskFunction<SystemTransitionEffectTask>::Create(task, &SystemTransitionEffectTask::Work),
+		TASK_PRI);
+	taskManager->AddRenderFunction(TTaskFunction<SystemTransitionEffectTask>::Create(task, &SystemTransitionEffectTask::Render),
+		TASK_PRI);
 }
 void TransitionManager::DoFadeOut()
 {
@@ -347,8 +323,7 @@ void TransitionManager::DoFadeOut()
 void SystemTransitionEffectTask::Work()
 {
 	TransitionEffectTask::Work();
-	if(effect_ != NULL && effect_->IsEnd())
-	{
+	if (effect_ != NULL && effect_->IsEnd()) {
 		WorkRenderTaskManager* taskManager = ETaskManager::GetInstance();
 		taskManager->RemoveTask(this);
 		return;
@@ -371,13 +346,11 @@ SystemInformation::SystemInformation()
 }
 SystemInformation::~SystemInformation()
 {
-
 }
 void SystemInformation::_SearchFreePlayerScript(std::wstring dir)
 {
 	listFreePlayer_ = ScriptInformation::FindPlayerScriptInformationList(dir);
-	for(int iPlayer = 0 ; iPlayer < listFreePlayer_.size() ; iPlayer++)
-	{
+	for (int iPlayer = 0; iPlayer < listFreePlayer_.size(); iPlayer++) {
 		ref_count_ptr<ScriptInformation> info = listFreePlayer_[iPlayer];
 		std::wstring path = info->GetScriptPath();
 		std::wstring log = StringUtility::Format(L"自機スクリプト：%s", path.c_str());
@@ -403,10 +376,10 @@ SystemResidentTask::SystemResidentTask()
 	int screenWidth = graphics->GetScreenWidth();
 	int screenHeight = graphics->GetScreenHeight();
 
-	textFps_.SetFontColorTop(D3DCOLOR_ARGB(255,160,160,255));
-	textFps_.SetFontColorBottom(D3DCOLOR_ARGB(255,64,64,255));
+	textFps_.SetFontColorTop(D3DCOLOR_ARGB(255, 160, 160, 255));
+	textFps_.SetFontColorBottom(D3DCOLOR_ARGB(255, 64, 64, 255));
 	textFps_.SetFontBorderType(directx::DxFont::BORDER_FULL);
-	textFps_.SetFontBorderColor(D3DCOLOR_ARGB(255,255,255,255));
+	textFps_.SetFontBorderColor(D3DCOLOR_ARGB(255, 255, 255, 255));
 	textFps_.SetFontBorderWidth(2);
 	textFps_.SetFontSize(14);
 	textFps_.SetFontBold(true);
@@ -420,8 +393,10 @@ SystemResidentTask::~SystemResidentTask()
 void SystemResidentTask::RenderFps()
 {
 	WorkRenderTaskManager* taskManager = ETaskManager::GetInstance();
-	if(taskManager->GetTask(typeid(EStgSystemController)) != NULL)return;
-	if(taskManager->GetTask(typeid(PStgSystemController)) != NULL)return;
+	if (taskManager->GetTask(typeid(EStgSystemController)) != NULL)
+		return;
+	if (taskManager->GetTask(typeid(PStgSystemController)) != NULL)
+		return;
 
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	graphics->SetBlendMode(DirectGraphics::MODE_BLEND_ALPHA);

--- a/source/TouhouDanmakufu/DnhExecutor/System.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/System.hpp
@@ -1,8 +1,8 @@
 #ifndef __TOUHOUDANMAKUFU_EXE_SYSTEM__
 #define __TOUHOUDANMAKUFU_EXE_SYSTEM__
 
-#include"GcLibImpl.hpp"
-#include"Common.hpp"
+#include "Common.hpp"
+#include "GcLibImpl.hpp"
 
 class SystemController;
 class SceneManager;
@@ -11,140 +11,136 @@ class SystemInformation;
 /**********************************************************
 //SystemController
 **********************************************************/
-class SystemController : public Singleton<SystemController>
-{
-		friend Singleton<SystemController>;
-		SystemController();
+class SystemController : public Singleton<SystemController> {
+	friend Singleton<SystemController>;
 
-		ref_count_ptr<SceneManager> sceneManager_;
-		ref_count_ptr<TransitionManager> transitionManager_;
-		ref_count_ptr<SystemInformation> infoSystem_;
+public:
+	virtual ~SystemController();
+	void Reset();
+	void ClearTaskWithoutSystem();
 
-	public:
-		virtual ~SystemController();
-		void Reset();
-		void ClearTaskWithoutSystem();
+	SceneManager* GetSceneManager() { return sceneManager_.GetPointer(); }
+	TransitionManager* GetTransitionManager() { return transitionManager_.GetPointer(); }
+	SystemInformation* GetSystemInformation() { return infoSystem_.GetPointer(); }
 
-		SceneManager* GetSceneManager(){return sceneManager_.GetPointer();}
-		TransitionManager* GetTransitionManager(){return transitionManager_.GetPointer();}
-		SystemInformation* GetSystemInformation(){return infoSystem_.GetPointer();}
+	void ShowErrorDialog(std::wstring msg);
 
-		void ShowErrorDialog(std::wstring msg);
+private:
+	SystemController();
+
+	ref_count_ptr<SceneManager> sceneManager_;
+	ref_count_ptr<TransitionManager> transitionManager_;
+	ref_count_ptr<SystemInformation> infoSystem_;
 };
-
 
 /**********************************************************
 //SceneManager
 **********************************************************/
-class SceneManager
-{
-	public:
-		SceneManager();
-		virtual ~SceneManager();
+class SceneManager {
+public:
+	SceneManager();
+	virtual ~SceneManager();
 
-		//シーン変更
-		void TransTitleScene();
+	//シーン変更
+	void TransTitleScene();
 
-		void TransScriptSelectScene(int type);
-		void TransScriptSelectScene_All();
-		void TransScriptSelectScene_Single();
-		void TransScriptSelectScene_Plural();
-		void TransScriptSelectScene_Stage();
-		void TransScriptSelectScene_Package();
-		void TransScriptSelectScene_Directory();
-		void TransScriptSelectScene_Last();
+	void TransScriptSelectScene(int type);
+	void TransScriptSelectScene_All();
+	void TransScriptSelectScene_Single();
+	void TransScriptSelectScene_Plural();
+	void TransScriptSelectScene_Stage();
+	void TransScriptSelectScene_Package();
+	void TransScriptSelectScene_Directory();
+	void TransScriptSelectScene_Last();
 
-		void TransStgScene(ref_count_ptr<ScriptInformation> infoMain, ref_count_ptr<ScriptInformation> infoPlayer, ref_count_ptr<ReplayInformation> infoReplay);
-		void TransStgScene(ref_count_ptr<ScriptInformation> infoMain, ref_count_ptr<ReplayInformation> infoReplay);
+	void TransStgScene(ref_count_ptr<ScriptInformation> infoMain, ref_count_ptr<ScriptInformation> infoPlayer, ref_count_ptr<ReplayInformation> infoReplay);
+	void TransStgScene(ref_count_ptr<ScriptInformation> infoMain, ref_count_ptr<ReplayInformation> infoReplay);
 
-		void TransPackageScene(ref_count_ptr<ScriptInformation> infoMain, bool bOnlyPackage = false);
+	void TransPackageScene(ref_count_ptr<ScriptInformation> infoMain, bool bOnlyPackage = false);
 };
 
 /**********************************************************
 //TransitionManager
 **********************************************************/
-class TransitionManager
-{
-		enum
-		{
-			TASK_PRI = 8,
-		};
-		void _CreateCurrentSceneTexture();
-		void _AddTask(ref_count_ptr<TransitionEffect> effect);
-	public:
-		TransitionManager();
-		virtual ~TransitionManager();
+class TransitionManager {
+	enum {
+		TASK_PRI = 8,
+	};
 
-		void DoFadeOut();
+public:
+	TransitionManager();
+	virtual ~TransitionManager();
+	void DoFadeOut();
+
+private:
+	void _CreateCurrentSceneTexture();
+	void _AddTask(ref_count_ptr<TransitionEffect> effect);
 };
 
-class SystemTransitionEffectTask : public TransitionEffectTask
-{
-	public:
-		void Work();
-		void Render();
+class SystemTransitionEffectTask : public TransitionEffectTask {
+public:
+	void Work();
+	void Render();
 };
 
 /**********************************************************
 //SystemInformation
 **********************************************************/
-class SystemInformation
-{
-		int lastTitleSelectedIndex_;
-		std::wstring dirLastScriptSearch_;
-		std::wstring pathLastSelectedScript_;
-		int lastSelectScriptSceneType_;
+class SystemInformation {
+public:
+	SystemInformation();
+	virtual ~SystemInformation();
 
-		int lastPlayerSelectIndex_;
-		std::vector<ref_count_ptr<ScriptInformation> > listLastPlayerSelect_;
+	int GetLastTitleSelectedIndex() { return lastTitleSelectedIndex_; }
+	void SetLastTitleSelectedIndex(int index) { lastTitleSelectedIndex_ = index; }
+	std::wstring GetLastScriptSearchDirectory() { return dirLastScriptSearch_; }
+	void SetLastScriptSearchDirectory(std::wstring dir) { dirLastScriptSearch_ = dir; }
+	std::wstring GetLastSelectedScriptPath() { return pathLastSelectedScript_; }
+	void SetLastSelectedScriptPath(std::wstring path) { pathLastSelectedScript_ = path; }
+	int GetLastSelectScriptSceneType() { return lastSelectScriptSceneType_; }
+	void SetLastSelectScriptSceneType(int type) { lastSelectScriptSceneType_ = type; }
 
+	int GetLastSelectedPlayerIndex() { return lastPlayerSelectIndex_; }
+	std::vector<ref_count_ptr<ScriptInformation>>& GetLastPlayerSelectedList() { return listLastPlayerSelect_; }
+	void SetLastSelectedPlayerIndex(int index, std::vector<ref_count_ptr<ScriptInformation>>& list)
+	{
+		lastPlayerSelectIndex_ = index;
+		listLastPlayerSelect_ = list;
+	}
 
-		std::vector<ref_count_ptr<ScriptInformation> > listFreePlayer_;
+	void UpdateFreePlayerScriptInformationList();
+	std::vector<ref_count_ptr<ScriptInformation>>& GetFreePlayerScriptInformationList() { return listFreePlayer_; }
 
-		void _SearchFreePlayerScript(std::wstring dir);
+private:
+	void _SearchFreePlayerScript(std::wstring dir);
 
-	public:
-		SystemInformation();
-		virtual ~SystemInformation();
+	int lastTitleSelectedIndex_;
+	std::wstring dirLastScriptSearch_;
+	std::wstring pathLastSelectedScript_;
+	int lastSelectScriptSceneType_;
 
-		int GetLastTitleSelectedIndex(){return lastTitleSelectedIndex_;}
-		void SetLastTitleSelectedIndex(int index){lastTitleSelectedIndex_ = index;}
-		std::wstring GetLastScriptSearchDirectory(){return dirLastScriptSearch_;}
-		void SetLastScriptSearchDirectory(std::wstring dir){dirLastScriptSearch_ = dir;}
-		std::wstring GetLastSelectedScriptPath(){return pathLastSelectedScript_;}
-		void SetLastSelectedScriptPath(std::wstring path){pathLastSelectedScript_ = path;}
-		int GetLastSelectScriptSceneType(){return lastSelectScriptSceneType_;}
-		void SetLastSelectScriptSceneType(int type){lastSelectScriptSceneType_ = type;}
+	int lastPlayerSelectIndex_;
+	std::vector<ref_count_ptr<ScriptInformation>> listLastPlayerSelect_;
 
-		int GetLastSelectedPlayerIndex(){return lastPlayerSelectIndex_;}
-		std::vector<ref_count_ptr<ScriptInformation> >& GetLastPlayerSelectedList(){return listLastPlayerSelect_;}
-		void SetLastSelectedPlayerIndex(int index, std::vector<ref_count_ptr<ScriptInformation> >& list){lastPlayerSelectIndex_ = index; listLastPlayerSelect_ = list;}
-
-		void UpdateFreePlayerScriptInformationList();
-		std::vector<ref_count_ptr<ScriptInformation> >& GetFreePlayerScriptInformationList(){return listFreePlayer_;}
+	std::vector<ref_count_ptr<ScriptInformation>> listFreePlayer_;
 };
-
 
 /**********************************************************
 //SystemResidentTask
 **********************************************************/
-class SystemResidentTask : public TaskBase
-{
-	public:
-		enum
-		{
-			TASK_PRI_RENDER_FPS = 9,
-		};
+class SystemResidentTask : public TaskBase {
+public:
+	enum {
+		TASK_PRI_RENDER_FPS = 9,
+	};
 
-	private:
-		DxText textFps_;
+public:
+	SystemResidentTask();
+	~SystemResidentTask();
+	void RenderFps();
 
-	public:
-		SystemResidentTask();
-		~SystemResidentTask();
-		void RenderFps();
+private:
+	DxText textFps_;
 };
 
 #endif
-
-

--- a/source/TouhouDanmakufu/DnhExecutor/TitleScene.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/TitleScene.cpp
@@ -1,5 +1,5 @@
-#include"TitleScene.hpp"
-#include"System.hpp"
+#include "TitleScene.hpp"
+#include "System.hpp"
 
 /**********************************************************
 //TitleScene
@@ -15,27 +15,17 @@ TitleScene::TitleScene()
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	int screenWidth = graphics->GetScreenWidth();
 	int screenHeight = graphics->GetScreenHeight();
-	RECT_D srcBack = {0., 0., 640., 480.};
-	RECT_D destBack = {0., 0., (double)screenWidth, (double)screenHeight};
+	RECT_D srcBack = { 0., 0., 640., 480. };
+	RECT_D destBack = { 0., 0., (double)screenWidth, (double)screenHeight };
 
 	spriteBack_ = new Sprite2D();
 	spriteBack_->SetTexture(textureBack);
 	spriteBack_->SetVertex(srcBack, destBack);
 
-	std::wstring strText[] = {L"All", L"Single", L"Plural", L"Stage", L"Package", L"Directory", L"Quit"};
-	std::wstring strDescription[] = {
-		L"",
-		L"",
-		L"",
-		L"",
-		L"",
-		L"",
-		L"",
-		L""
-	};
-	for(int iItem = 0 ; iItem < ITEM_COUNT ; iItem++)
-	{
-		int x = 48+ iItem * 6 + 12 * pow((double)-1,(int)(iItem - 1));
+	std::wstring strText[] = { L"All", L"Single", L"Plural", L"Stage", L"Package", L"Directory", L"Quit" };
+	std::wstring strDescription[] = { L"", L"", L"", L"", L"", L"", L"", L"" };
+	for (int iItem = 0; iItem < ITEM_COUNT; iItem++) {
+		int x = 48 + iItem * 6 + 12 * pow((double)-1, (int)(iItem - 1));
 		int y = 154 + iItem * 30;
 		AddMenuItem(new TitleSceneMenuItem(strText[iItem], strDescription[iItem], x, y));
 	}
@@ -45,45 +35,41 @@ TitleScene::TitleScene()
 void TitleScene::Work()
 {
 	MenuTask::Work();
-	if(!_IsWaitedKeyFree())return;
+	if (!_IsWaitedKeyFree())
+		return;
 
 	EDirectInput* input = EDirectInput::GetInstance();
-	if(input->GetVirtualKeyState(EDirectInput::KEY_OK) == KEY_PUSH)
-	{
+	if (input->GetVirtualKeyState(EDirectInput::KEY_OK) == KEY_PUSH) {
 		SceneManager* sceneManager = SystemController::GetInstance()->GetSceneManager();
 
 		//選択インデックス保存
 		SystemController::GetInstance()->GetSystemInformation()->SetLastTitleSelectedIndex(cursorY_);
 
-		switch(cursorY_)
-		{
-			case ITEM_ALL:
-				sceneManager->TransScriptSelectScene_All();
-				break;
-			case ITEM_SINGLE:
-				sceneManager->TransScriptSelectScene_Single();
-				break;
-			case ITEM_PLURAL:
-				sceneManager->TransScriptSelectScene_Plural();
-				break;
-			case ITEM_STAGE:
-				sceneManager->TransScriptSelectScene_Stage();
-				break;
-			case ITEM_PACKAGE:
-				sceneManager->TransScriptSelectScene_Package();
-				break;
-			case ITEM_DIRECTORY:
-				sceneManager->TransScriptSelectScene_Directory();
-				break;
-			case ITEM_QUIT:
-				EApplication::GetInstance()->End();
-				break;
+		switch (cursorY_) {
+		case ITEM_ALL:
+			sceneManager->TransScriptSelectScene_All();
+			break;
+		case ITEM_SINGLE:
+			sceneManager->TransScriptSelectScene_Single();
+			break;
+		case ITEM_PLURAL:
+			sceneManager->TransScriptSelectScene_Plural();
+			break;
+		case ITEM_STAGE:
+			sceneManager->TransScriptSelectScene_Stage();
+			break;
+		case ITEM_PACKAGE:
+			sceneManager->TransScriptSelectScene_Package();
+			break;
+		case ITEM_DIRECTORY:
+			sceneManager->TransScriptSelectScene_Directory();
+			break;
+		case ITEM_QUIT:
+			EApplication::GetInstance()->End();
+			break;
 		}
-
 		return;
-	}
-	else if(input->GetVirtualKeyState(EDirectInput::KEY_CANCEL) == KEY_PUSH)
-	{
+	} else if (input->GetVirtualKeyState(EDirectInput::KEY_CANCEL) == KEY_PUSH) {
 		cursorY_ = ITEM_QUIT;
 	}
 }
@@ -104,10 +90,10 @@ TitleSceneMenuItem::TitleSceneMenuItem(std::wstring text, std::wstring descripti
 	pos_.y = y;
 
 	DxText dxText;
-	dxText.SetFontColorTop(D3DCOLOR_ARGB(255,255,255,255));
-	dxText.SetFontColorBottom(D3DCOLOR_ARGB(255,64,64,64));
+	dxText.SetFontColorTop(D3DCOLOR_ARGB(255, 255, 255, 255));
+	dxText.SetFontColorBottom(D3DCOLOR_ARGB(255, 64, 64, 64));
 	dxText.SetFontBorderType(directx::DxFont::BORDER_FULL);
-	dxText.SetFontBorderColor(D3DCOLOR_ARGB(255,32,32,128));
+	dxText.SetFontBorderColor(D3DCOLOR_ARGB(255, 32, 32, 128));
 	dxText.SetFontBorderWidth(2);
 	dxText.SetFontSize(24);
 	dxText.SetFontBold(true);
@@ -126,8 +112,7 @@ void TitleSceneMenuItem::Render()
 	objText_->SetPosition(pos_);
 	objText_->Render();
 
-	if(menu_->GetSelectedMenuItem() == this)
-	{
+	if (menu_->GetSelectedMenuItem() == this) {
 		DirectGraphics* graphics = DirectGraphics::GetBase();
 		graphics->SetBlendMode(DirectGraphics::MODE_BLEND_ADD_RGB);
 

--- a/source/TouhouDanmakufu/DnhExecutor/TitleScene.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/TitleScene.hpp
@@ -1,52 +1,50 @@
 #ifndef __TOUHOUDANMAKUFU_EXE_TITLE_SCENE__
 #define __TOUHOUDANMAKUFU_EXE_TITLE_SCENE__
 
-#include"GcLibImpl.hpp"
-#include"Common.hpp"
+#include "Common.hpp"
+#include "GcLibImpl.hpp"
 
 /**********************************************************
 //TitleScene
 **********************************************************/
-class TitleScene : public TaskBase, public MenuTask
-{
-	public:
-		enum
-		{
-			TASK_PRI_WORK = 5,
-			TASK_PRI_RENDER = 5,
-		};
+class TitleScene : public TaskBase, public MenuTask {
+public:
+	enum {
+		TASK_PRI_WORK = 5,
+		TASK_PRI_RENDER = 5,
+	};
 
-	private:
-		enum
-		{
-			ITEM_COUNT = 7,
-			ITEM_ALL = 0,
-			ITEM_SINGLE,
-			ITEM_PLURAL,
-			ITEM_STAGE,
-			ITEM_PACKAGE,
-			ITEM_DIRECTORY,
-			ITEM_QUIT,
-		};
-		ref_count_ptr<Sprite2D> spriteBack_;
-	public:
-		TitleScene();
-		void Work();
-		void Render();
+private:
+	enum {
+		ITEM_COUNT = 7,
+		ITEM_ALL = 0,
+		ITEM_SINGLE,
+		ITEM_PLURAL,
+		ITEM_STAGE,
+		ITEM_PACKAGE,
+		ITEM_DIRECTORY,
+		ITEM_QUIT,
+	};
+	ref_count_ptr<Sprite2D> spriteBack_;
+
+public:
+	TitleScene();
+	void Work();
+	void Render();
 };
 
-class TitleSceneMenuItem : public TextLightUpMenuItem
-{
-		ref_count_ptr<DxTextRenderObject> objText_;
-		POINT pos_;
+class TitleSceneMenuItem : public TextLightUpMenuItem {
+public:
+	TitleSceneMenuItem(std::wstring text, std::wstring description, int x, int y);
+	virtual ~TitleSceneMenuItem();
+	void Work();
+	void Render();
 
-		TitleScene* _GetTitleScene(){return (TitleScene*)menu_;}
-	public:
-		TitleSceneMenuItem(std::wstring text, std::wstring description, int x, int y);
-		virtual ~TitleSceneMenuItem();
-		void Work();
-		void Render();
+private:
+	ref_count_ptr<DxTextRenderObject> objText_;
+	POINT pos_;
+
+	TitleScene* _GetTitleScene() { return (TitleScene*)menu_; }
 };
 
 #endif
-

--- a/source/TouhouDanmakufu/DnhExecutor/WinMain.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/WinMain.cpp
@@ -1,16 +1,15 @@
-#include"GcLibImpl.hpp"
+#include "GcLibImpl.hpp"
 
 /**********************************************************
 WinMain
 **********************************************************/
 int APIENTRY wWinMain(HINSTANCE hInstance,
-                        HINSTANCE hPrevInstance,
-                        LPWSTR lpCmdLine,
-                        int nCmdShow )
+	HINSTANCE hPrevInstance,
+	LPWSTR lpCmdLine,
+	int nCmdShow)
 {
 	gstd::DebugUtility::DumpMemoryLeaksOnExit();
-	try
-	{
+	try {
 		DnhConfiguration* config = DnhConfiguration::CreateInstance();
 		ELogger* logger = ELogger::CreateInstance();
 		logger->Initialize(config->IsLogFile(), config->IsLogWindow());
@@ -19,20 +18,15 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
 		EApplication* app = EApplication::CreateInstance();
 		app->Initialize();
 		app->Run();
-	}
-	catch(std::exception& e)
-	{
+	} catch (std::exception& e) {
 		std::wstring log = StringUtility::ConvertMultiToWide(e.what());
 		Logger::WriteTop(log);
-	}
-	catch(gstd::wexception& e)
-	{
+	} catch (gstd::wexception& e) {
 		Logger::WriteTop(e.what());
 	}
-//	catch(...)
-//	{
-//		Logger::WriteTop("不明なエラー");
-//	}
+	// catch(...) {
+	// 	Logger::WriteTop("不明なエラー");
+	// }
 
 	EApplication::DeleteInstance();
 	EPathProperty::DeleteInstance();

--- a/source/TouhouDanmakufu/DnhViewer/Common.cpp
+++ b/source/TouhouDanmakufu/DnhViewer/Common.cpp
@@ -1,4 +1,4 @@
-#include"Common.hpp"
+#include "Common.hpp"
 
 /**********************************************************
 //SystemResidentTask
@@ -9,10 +9,10 @@ SystemResidentTask::SystemResidentTask()
 	int screenWidth = graphics->GetScreenWidth();
 	int screenHeight = graphics->GetScreenHeight();
 
-	textFps_.SetFontColorTop(D3DCOLOR_ARGB(255,160,160,255));
-	textFps_.SetFontColorBottom(D3DCOLOR_ARGB(255,64,64,255));
+	textFps_.SetFontColorTop(D3DCOLOR_ARGB(255, 160, 160, 255));
+	textFps_.SetFontColorBottom(D3DCOLOR_ARGB(255, 64, 64, 255));
 	textFps_.SetFontBorderType(directx::DxFont::BORDER_FULL);
-	textFps_.SetFontBorderColor(D3DCOLOR_ARGB(255,255,255,255));
+	textFps_.SetFontBorderColor(D3DCOLOR_ARGB(255, 255, 255, 255));
 	textFps_.SetFontBorderWidth(2);
 	textFps_.SetFontSize(14);
 	textFps_.SetFontBold(true);
@@ -34,5 +34,5 @@ void SystemResidentTask::RenderFps()
 	EFpsController* fpsController = EFpsController::GetInstance();
 	float fps = fpsController->GetCurrentWorkFps();
 	textFps_.SetText(StringUtility::Format(L"%.2ffps", fps));
-	//textFps_.Render();
+	// textFps_.Render();
 }

--- a/source/TouhouDanmakufu/DnhViewer/Common.hpp
+++ b/source/TouhouDanmakufu/DnhViewer/Common.hpp
@@ -1,29 +1,25 @@
 #ifndef __TOUHOUDANMAKUFU_VIEW_COMMON__
 #define __TOUHOUDANMAKUFU_VIEW_COMMON__
 
-#include"../Common/DnhCommon.hpp"
-#include"GcLibImpl.hpp"
+#include "../Common/DnhCommon.hpp"
+#include "GcLibImpl.hpp"
 
 /**********************************************************
 //SystemResidentTask
 **********************************************************/
-class SystemResidentTask : public TaskBase
-{
-	public:
-		enum
-		{
-			TASK_PRI_RENDER_FPS = 9,
-		};
+class SystemResidentTask : public TaskBase {
+public:
+	enum {
+		TASK_PRI_RENDER_FPS = 9,
+	};
 
-	private:
-		DxText textFps_;
+public:
+	SystemResidentTask();
+	~SystemResidentTask();
+	void RenderFps();
 
-	public:
-		SystemResidentTask();
-		~SystemResidentTask();
-		void RenderFps();
+private:
+	DxText textFps_;
 };
 
-
 #endif
-

--- a/source/TouhouDanmakufu/DnhViewer/Constant.hpp
+++ b/source/TouhouDanmakufu/DnhViewer/Constant.hpp
@@ -1,16 +1,13 @@
 #ifndef __TOUHOUDANMAKUFU_VIEW_CONSTANT__
 #define __TOUHOUDANMAKUFU_VIEW_CONSTANT__
 
-#pragma comment(lib,"source/GcLib/ext/ogg_static.lib")
-#pragma comment(lib,"source/GcLib/ext/vorbis_static.lib")
-#pragma comment(lib,"source/GcLib/ext/vorbisfile_static.lib")
+#pragma comment(lib, "source/GcLib/ext/ogg_static.lib")
+#pragma comment(lib, "source/GcLib/ext/vorbis_static.lib")
+#pragma comment(lib, "source/GcLib/ext/vorbisfile_static.lib")
 
-#include"../Common/DnhConstant.hpp"
-#include"../Common/DnhCommon.hpp"
+#include "../Common/DnhCommon.hpp"
+#include "../Common/DnhConstant.hpp"
 
-#include"resource.h"
-
+#include "resource.h"
 
 #endif
-
-

--- a/source/TouhouDanmakufu/DnhViewer/DebugWindow.cpp
+++ b/source/TouhouDanmakufu/DnhViewer/DebugWindow.cpp
@@ -1,5 +1,5 @@
-#include"DebugWindow.hpp"
-#include"MainWindow.hpp"
+#include "DebugWindow.hpp"
+#include "MainWindow.hpp"
 
 /**********************************************************
 //DebugWindow
@@ -11,14 +11,14 @@ void DebugWindow::Initialize()
 {
 	MainWindow* mainWindow = MainWindow::GetInstance();
 	HWND hParent = MainWindow::GetInstance()->GetWindowHandle();
-	hWnd_ = CreateDialog((HINSTANCE)GetWindowLong(hParent,GWL_HINSTANCE),
-							MAKEINTRESOURCE(IDD_DIALOG_DEBUG),
-							hParent,(DLGPROC)this->_StaticWindowProcedure);
+	hWnd_ = CreateDialog((HINSTANCE)GetWindowLong(hParent, GWL_HINSTANCE),
+		MAKEINTRESOURCE(IDD_DIALOG_DEBUG),
+		hParent, (DLGPROC)this->_StaticWindowProcedure);
 	this->Attach(hWnd_);
 
 	int wx = mainWindow->GetClientX() + mainWindow->GetClientWidth() - GetClientWidth();
 	int wy = mainWindow->GetClientY();
-	POINT pos = {wx, wy};
+	POINT pos = { wx, wy };
 	ClientToScreen(hParent, &pos);
 
 	checkPlayerInvincivility_.Attach(GetDlgItem(hWnd_, IDC_CHECK_PLAYER_INVINCIBILITY));
@@ -29,41 +29,34 @@ void DebugWindow::ShowModeless()
 {
 	SetWindowVisible(true);
 }
-LRESULT DebugWindow::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
+LRESULT DebugWindow::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	switch (uMsg)
-	{
-		case WM_CLOSE:
-		{
-			SetWindowVisible(false);
+	switch (uMsg) {
+	case WM_CLOSE: {
+		SetWindowVisible(false);
+		break;
+	}
+	case WM_COMMAND: {
+		switch (wParam & 0xffff) {
+		case IDC_CHECK_PLAYER_INVINCIBILITY:
 			break;
 		}
-		case WM_COMMAND:
-		{
-			switch(wParam & 0xffff)
-			{
-				case IDC_CHECK_PLAYER_INVINCIBILITY:
-					break;
-			}
-			break;
-		}
-
+		break;
+	}
 	}
 	return _CallPreviousWindowProcedure(hWnd, uMsg, wParam, lParam);
 }
 
 void DebugWindow::SetPlayerInvincivility(bool bInvincivility)
 {
-	SendMessage(checkPlayerInvincivility_.GetWindowHandle() , BM_SETCHECK , 
-		bInvincivility ? BST_CHECKED : BST_UNCHECKED , 0);
+	SendMessage(checkPlayerInvincivility_.GetWindowHandle(), BM_SETCHECK,
+		bInvincivility ? BST_CHECKED : BST_UNCHECKED, 0);
 }
 bool DebugWindow::IsPlayerInvincivility()
 {
-	bool res = 
-		SendMessage(checkPlayerInvincivility_.GetWindowHandle() , BM_GETCHECK , 0 , 0) == BST_CHECKED;
+	bool res = SendMessage(checkPlayerInvincivility_.GetWindowHandle(), BM_GETCHECK, 0, 0) == BST_CHECKED;
 	return res;
 }
-
 
 /**********************************************************
 //DebugTask
@@ -82,39 +75,27 @@ void DebugTask::Work()
 	DebugWindow* wndDebug = mainWindow->GetDebugWindow();
 
 	EDirectInput* input = EDirectInput::GetInstance();
-	if(input->GetKeyState(DIK_I) == KEY_PUSH)
-	{
+	if (input->GetKeyState(DIK_I) == KEY_PUSH) {
 		bool bPlayerInvincivility = wndDebug->IsPlayerInvincivility();
 		wndDebug->SetPlayerInvincivility(!bPlayerInvincivility);
 	}
 
-	if(controller == NULL)
-	{
+	if (controller == NULL) {
 		bPlayerInvincivility_ = false;
-	}
-	else
-	{
+	} else {
 		int FRAME_PLAYER_INVINCIVILITY = 256 * 256 * 256;
 		bool bPlayerInvincivility = wndDebug->IsPlayerInvincivility();
 		StgStageController* stageController = controller->GetStageController();
-		if(stageController != NULL)
-		{
+		if (stageController != NULL) {
 			ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController->GetPlayerObject();
-			if(bPlayerInvincivility && objPlayer->GetInvincibilityFrame() < FRAME_PLAYER_INVINCIVILITY)
-			{
+			if (bPlayerInvincivility && objPlayer->GetInvincibilityFrame() < FRAME_PLAYER_INVINCIVILITY) {
 				//自機無敵
 				objPlayer->SetInvincibilityFrame(FRAME_PLAYER_INVINCIVILITY);
-			}
-			else if(bPlayerInvincivility_ && !bPlayerInvincivility)
-			{
+			} else if (bPlayerInvincivility_ && !bPlayerInvincivility) {
 				//自機無敵解除
 				objPlayer->SetInvincibilityFrame(0);
 			}
 		}
-
 		bPlayerInvincivility_ = bPlayerInvincivility;
 	}
-
-
-
 }

--- a/source/TouhouDanmakufu/DnhViewer/DebugWindow.hpp
+++ b/source/TouhouDanmakufu/DnhViewer/DebugWindow.hpp
@@ -1,45 +1,42 @@
 #ifndef __TOUHOUDANMAKUFU_VIEW_DEBUGWINDOW__
 #define __TOUHOUDANMAKUFU_VIEW_DEBUGWINDOW__
 
-#include"Constant.hpp"
-#include"Common.hpp"
+#include "Common.hpp"
+#include "Constant.hpp"
 
 /**********************************************************
 //DebugWindow
 **********************************************************/
-class DebugWindow : public WindowBase
-{
-	protected:
-		WButton checkPlayerInvincivility_;
+class DebugWindow : public WindowBase {
+public:
+	DebugWindow();
+	void Initialize();
+	void ShowModeless();
 
-		virtual LRESULT _WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
-	public:
-		DebugWindow();
-		void Initialize();
-		void ShowModeless();
+	bool IsPlayerInvincivility();
+	void SetPlayerInvincivility(bool bInvincivility);
 
-		bool IsPlayerInvincivility();
-		void SetPlayerInvincivility(bool bInvincivility);
+protected:
+	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	WButton checkPlayerInvincivility_;
 };
 
 /**********************************************************
 //DebugTask
 **********************************************************/
-class DebugTask : public TaskBase
-{
-	public:
-		enum
-		{
-			TASK_PRI_WORK = 0,
-		};
+class DebugTask : public TaskBase {
+public:
+	enum {
+		TASK_PRI_WORK = 0,
+	};
 
-	private:
-		bool bPlayerInvincivility_;
+public:
+	DebugTask();
+	~DebugTask();
+	void Work();
 
-	public:
-		DebugTask();
-		~DebugTask();
-		void Work();
+private:
+	bool bPlayerInvincivility_;
 };
 
 #endif

--- a/source/TouhouDanmakufu/DnhViewer/GcLibImpl.cpp
+++ b/source/TouhouDanmakufu/DnhViewer/GcLibImpl.cpp
@@ -1,17 +1,15 @@
-#include"GcLibImpl.hpp"
-#include"MainWindow.hpp"
-#include"DebugWindow.hpp"
+#include "GcLibImpl.hpp"
+#include "DebugWindow.hpp"
+#include "MainWindow.hpp"
 
 /**********************************************************
 //EApplication
 **********************************************************/
 EApplication::EApplication()
 {
-
 }
 EApplication::~EApplication()
 {
-
 }
 bool EApplication::_Initialize()
 {
@@ -27,8 +25,8 @@ bool EApplication::_Initialize()
 	graphics->Initialize();
 	HWND hWndMain = MainWindow::GetInstance()->GetWindowHandle();
 	WindowLogger::InsertOpenCommandInSystemMenu(hWndMain);
-//	::SetWindowText(hWndMain, "DnhViewer");
-//	::SetClassLong(hWndMain, GCL_HICON, (LONG)LoadIcon(GetApplicationHandle(), MAKEINTRESOURCE(IDI_ICON)));
+	// ::SetWindowText(hWndMain, "DnhViewer");
+	// ::SetClassLong(hWndMain, GCL_HICON, (LONG)LoadIcon(GetApplicationHandle(), MAKEINTRESOURCE(IDI_ICON)));
 
 	ErrorDialog::SetParentWindowHandle(hWndMain);
 
@@ -55,19 +53,23 @@ bool EApplication::_Initialize()
 
 	gstd::ref_count_ptr<gstd::TaskInfoPanel> panelTask = new gstd::TaskInfoPanel();
 	bool bAddTaskPanel = logger->AddPanel(panelTask, L"Task");
-	if(bAddTaskPanel)taskManager->SetInfoPanel(panelTask);
+	if (bAddTaskPanel)
+		taskManager->SetInfoPanel(panelTask);
 
 	gstd::ref_count_ptr<directx::TextureInfoPanel> panelTexture = new directx::TextureInfoPanel();
 	bool bTexturePanel = logger->AddPanel(panelTexture, L"Texture");
-	if(bTexturePanel)textureManager->SetInfoPanel(panelTexture);
+	if (bTexturePanel)
+		textureManager->SetInfoPanel(panelTexture);
 
 	gstd::ref_count_ptr<directx::DxMeshInfoPanel> panelMesh = new directx::DxMeshInfoPanel();
 	bool bMeshPanel = logger->AddPanel(panelMesh, L"Mesh");
-	if(bMeshPanel)meshManager->SetInfoPanel(panelMesh);
+	if (bMeshPanel)
+		meshManager->SetInfoPanel(panelMesh);
 
 	gstd::ref_count_ptr<directx::SoundInfoPanel> panelSound = new directx::SoundInfoPanel();
 	bool bSoundPanel = logger->AddPanel(panelSound, L"Sound");
-	if(bSoundPanel)soundManager->SetInfoPanel(panelSound);
+	if (bSoundPanel)
+		soundManager->SetInfoPanel(panelSound);
 
 	gstd::ref_count_ptr<gstd::ScriptCommonDataInfoPanel> panelCommonData = logger->GetScriptCommonDataInfoPanel();
 	logger->AddPanel(panelCommonData, L"Common Data");
@@ -76,26 +78,25 @@ bool EApplication::_Initialize()
 	logger->AddPanel(panelScript, L"Script");
 
 	DnhConfiguration* config = DnhConfiguration::CreateInstance();
-	if(config->IsLogWindow())
-	{
+	if (config->IsLogWindow()) {
 		logger->LoadState();
 		logger->SetWindowVisible(true);
 	}
 
-//	SystemController* systemController = SystemController::CreateInstance();
-//	systemController->Reset();
+	// SystemController* systemController = SystemController::CreateInstance();
+	// systemController->Reset();
 
 	//常駐タスク登録
 	ref_count_ptr<SystemResidentTask> taskResident = new SystemResidentTask();
 	taskManager->AddTask(taskResident);
-	taskManager->AddRenderFunction(TTaskFunction<SystemResidentTask>::Create(
-		taskResident, &SystemResidentTask::RenderFps), SystemResidentTask::TASK_PRI_RENDER_FPS);
+	taskManager->AddRenderFunction(TTaskFunction<SystemResidentTask>::Create(taskResident, &SystemResidentTask::RenderFps),
+		SystemResidentTask::TASK_PRI_RENDER_FPS);
 
 	//デバッグタスク登録
 	ref_count_ptr<DebugTask> taskDebug = new DebugTask();
 	taskManager->AddTask(taskDebug);
-	taskManager->AddWorkFunction(TTaskFunction<DebugTask>::Create(
-		taskDebug, &DebugTask::Work), DebugTask::TASK_PRI_WORK);
+	taskManager->AddWorkFunction(TTaskFunction<DebugTask>::Create(taskDebug, &DebugTask::Work),
+		DebugTask::TASK_PRI_WORK);
 
 	MainWindow* wndMain = MainWindow::GetInstance();
 	::SetForegroundWindow(wndMain->GetWindowHandle());
@@ -116,8 +117,7 @@ bool EApplication::_Loop()
 	HWND hWndGraphics = mainWindow->GetWindowHandle();
 	HWND hWndLogger = ELogger::GetInstance()->GetWindowHandle();
 	HWND hWndDebug = mainWindow->GetDebugWindow()->GetWindowHandle();
-	if(hWndFocused != hWndGraphics && hWndFocused != hWndLogger && hWndFocused != hWndDebug)
-	{
+	if (hWndFocused != hWndGraphics && hWndFocused != hWndLogger && hWndFocused != hWndDebug) {
 		//非アクティブ時は動作しない
 		::Sleep(10);
 		return true;
@@ -125,17 +125,15 @@ bool EApplication::_Loop()
 
 	EDirectInput* input = EDirectInput::GetInstance();
 	input->Update();
-	if(input->GetKeyState(DIK_R) == KEY_PUSH)
-	{
+	if (input->GetKeyState(DIK_R) == KEY_PUSH) {
 		//リセット
-//		SystemController* systemController = SystemController::CreateInstance();
-//		systemController->Reset();
+		// SystemController* systemController = SystemController::CreateInstance();
+		// systemController->Reset();
 	}
-	
+
 	taskManager->CallWorkFunction();
 
-	if(!fpsController->IsSkip())
-	{
+	if (!fpsController->IsSkip()) {
 		graphics->BeginScene();
 		taskManager->CallRenderFunction();
 		graphics->EndScene();
@@ -147,7 +145,7 @@ bool EApplication::_Loop()
 	SYSTEMTIME time;
 	GetLocalTime(&time);
 	std::wstring fps = StringUtility::Format(L"Work：%.2ffps、Draw：%.2ffps",
-		fpsController->GetCurrentWorkFps(), 
+		fpsController->GetCurrentWorkFps(),
 		fpsController->GetCurrentRenderFps());
 	logger->SetInfo(0, L"fps", fps);
 
@@ -157,23 +155,20 @@ bool EApplication::_Loop()
 	int heightScreen = heightConfig * graphics->GetScreenHeightRatio();
 
 	std::wstring screen = StringUtility::Format(L"width：%d/%d、height：%d/%d",
-		widthScreen, widthConfig, 
+		widthScreen, widthConfig,
 		heightScreen, heightConfig);
 	logger->SetInfo(1, L"screen", screen);
 
-	logger->SetInfo(2, L"font cache", 
-		StringUtility::Format(L"%d", EDxTextRenderer::GetInstance()->GetCacheCount() ));
-	
+	logger->SetInfo(2, L"font cache",
+		StringUtility::Format(L"%d", EDxTextRenderer::GetInstance()->GetCacheCount()));
+
 	//高速動作
 	int fastModeKey = fpsController->GetFastModeKey();
-	if(input->GetKeyState(fastModeKey) == KEY_HOLD)
-	{
-		if(!fpsController->IsFastMode())
+	if (input->GetKeyState(fastModeKey) == KEY_HOLD) {
+		if (!fpsController->IsFastMode())
 			fpsController->SetFastMode(true);
-	}
-	else if(input->GetKeyState(fastModeKey) == KEY_PULL)
-	{
-		if(fpsController->IsFastMode())
+	} else if (input->GetKeyState(fastModeKey) == KEY_PULL) {
+		if (fpsController->IsFastMode())
 			fpsController->SetFastMode(false);
 	}
 	return true;
@@ -202,15 +197,11 @@ bool EApplication::_Finalize()
 	return true;
 }
 
-
-
-
 /**********************************************************
 //EDirectGraphics
 **********************************************************/
 EDirectGraphics::EDirectGraphics()
 {
-
 }
 EDirectGraphics::~EDirectGraphics()
 {

--- a/source/TouhouDanmakufu/DnhViewer/GcLibImpl.hpp
+++ b/source/TouhouDanmakufu/DnhViewer/GcLibImpl.hpp
@@ -1,36 +1,40 @@
 #ifndef __TOUHOUDANMAKUFU_EXE_GCLIBIMPL__
 #define __TOUHOUDANMAKUFU_EXE_GCLIBIMPL__
 
-#include"Constant.hpp"
-#include"../Common/DnhGcLibImpl.hpp"
+#include "../Common/DnhGcLibImpl.hpp"
+#include "Constant.hpp"
 
 /**********************************************************
 //EApplication
 **********************************************************/
-class EApplication : public Singleton<EApplication>, public Application
-{
-		friend Singleton<EApplication>;
-		EApplication();
-	protected:
-		bool _Initialize();
-		bool _Loop();
-		bool _Finalize();
-	public:
-		~EApplication();
+class EApplication : public Singleton<EApplication>, public Application {
+	friend Singleton<EApplication>;
+
+private:
+	EApplication();
+
+protected:
+	bool _Initialize();
+	bool _Loop();
+	bool _Finalize();
+
+public:
+	~EApplication();
 };
 
 /**********************************************************
 //EDirectGraphics
 **********************************************************/
-class EDirectGraphics : public Singleton<EDirectGraphics>, public DirectGraphics
-{
-		friend Singleton<EDirectGraphics>;
-		EDirectGraphics();
+class EDirectGraphics : public Singleton<EDirectGraphics>, public DirectGraphics {
+	friend Singleton<EDirectGraphics>;
 
-	public:
-		~EDirectGraphics();
-		virtual bool Initialize();
-		void SetRenderStateFor2D(int blend);
+private:
+	EDirectGraphics();
+
+public:
+	~EDirectGraphics();
+	virtual bool Initialize();
+	void SetRenderStateFor2D(int blend);
 };
 
 #endif

--- a/source/TouhouDanmakufu/DnhViewer/MainWindow.cpp
+++ b/source/TouhouDanmakufu/DnhViewer/MainWindow.cpp
@@ -1,11 +1,10 @@
-#include"MainWindow.hpp"
+#include "MainWindow.hpp"
 
 /**********************************************************
 //MainWindow
 **********************************************************/
 MainWindow::MainWindow()
 {
-
 }
 MainWindow::~MainWindow()
 {
@@ -16,25 +15,25 @@ bool MainWindow::Initialize()
 	HINSTANCE hInst = ::GetModuleHandle(NULL);
 	std::wstring nameClass = L"DnhViewerMainWindow";
 	WNDCLASSEX wcex;
-	ZeroMemory(&wcex,sizeof(wcex));
-	wcex.cbSize=sizeof(WNDCLASSEX); 
-	wcex.style=CS_HREDRAW|CS_VREDRAW;
-	wcex.lpfnWndProc=(WNDPROC)WindowBase::_StaticWindowProcedure;
-	wcex.hInstance=hInst;
-	wcex.hIcon=NULL;
-	wcex.hCursor=LoadCursor(NULL, IDC_ARROW);
-	wcex.hbrBackground=(HBRUSH)(COLOR_WINDOW);
-	wcex.lpszMenuName=MAKEINTRESOURCE(IDR_MENU_MAIN);
-	wcex.lpszClassName=nameClass.c_str();
-	wcex.hIconSm=NULL;
+	ZeroMemory(&wcex, sizeof(wcex));
+	wcex.cbSize = sizeof(WNDCLASSEX);
+	wcex.style = CS_HREDRAW | CS_VREDRAW;
+	wcex.lpfnWndProc = (WNDPROC)WindowBase::_StaticWindowProcedure;
+	wcex.hInstance = hInst;
+	wcex.hIcon = NULL;
+	wcex.hCursor = LoadCursor(NULL, IDC_ARROW);
+	wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW);
+	wcex.lpszMenuName = MAKEINTRESOURCE(IDR_MENU_MAIN);
+	wcex.lpszClassName = nameClass.c_str();
+	wcex.hIconSm = NULL;
 	::RegisterClassEx(&wcex);
 
 	std::wstring appName = L"DnhViewer ph3 ";
 	appName += DNH_VERSION;
-   	hWnd_=::CreateWindow(wcex.lpszClassName,
+	hWnd_ = ::CreateWindow(wcex.lpszClassName,
 		appName.c_str(),
-		WS_OVERLAPPEDWINDOW,//-WS_SIZEBOX
-		0,0,800,600,NULL,NULL,hInst,NULL);
+		WS_OVERLAPPEDWINDOW, //-WS_SIZEBOX
+		0, 0, 800, 600, NULL, NULL, hInst, NULL);
 	::ShowWindow(hWnd_, SW_HIDE);
 	::UpdateWindow(hWnd_);
 	this->Attach(hWnd_);
@@ -78,123 +77,106 @@ bool MainWindow::Initialize()
 
 	return true;
 }
-LRESULT MainWindow::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
+LRESULT MainWindow::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	switch (uMsg)
-	{
-		case WM_CLOSE:
-		{
-			std::wstring pathLastData = PathProperty::GetModuleDirectory() + PathProperty::GetModuleName() + L".dat";
-			MainWindow::GetInstance()->Save(pathLastData);
-			::DestroyWindow(hWnd);
+	switch (uMsg) {
+	case WM_CLOSE: {
+		std::wstring pathLastData = PathProperty::GetModuleDirectory() + PathProperty::GetModuleName() + L".dat";
+		MainWindow::GetInstance()->Save(pathLastData);
+		::DestroyWindow(hWnd);
+		break;
+	}
+	case WM_DESTROY: {
+		::PostQuitMessage(0);
+		break;
+	}
+	case WM_SIZE: {
+		RECT rect;
+		::GetClientRect(hWnd_, &rect);
+		int wx = rect.left;
+		int wy = rect.top;
+		int wWidth = rect.right - rect.left;
+		int wHeight = rect.bottom - rect.top;
+
+		wndStatus_->SetBounds(wParam, lParam);
+		wndTab_->SetBounds(wx + 8, wy + 4, wWidth - 16, wHeight - 32);
+		::InvalidateRect(wndTab_->GetWindowHandle(), NULL, TRUE);
+		break;
+	}
+	case WM_COMMAND: {
+		switch (wParam & 0xffff) {
+		case ID_MENUITEM_MAIN_EXIT:
+			DestroyWindow(hWnd_);
 			break;
-		}
-		case WM_DESTROY:
-		{
-			::PostQuitMessage(0);
-			break;
-		}
-		case WM_SIZE:
-		{
-			RECT rect;
-			::GetClientRect(hWnd_, &rect);
-			int wx = rect.left;
-			int wy = rect.top;
-			int wWidth = rect.right-rect.left;
-			int wHeight = rect.bottom-rect.top;
 
-			wndStatus_->SetBounds(wParam, lParam);
-			wndTab_->SetBounds(wx+8, wy+4, wWidth-16, wHeight-32);
-			::InvalidateRect(wndTab_->GetWindowHandle(), NULL, TRUE);
-			break;
-		}
-		case WM_COMMAND:
-		{
-			switch(wParam & 0xffff)
-			{
-				case ID_MENUITEM_MAIN_EXIT:
-					DestroyWindow(hWnd_);
-					break;
-
-				case ID_MENUITEM_MAIN_LOGWINDOW:
-				{
-					bool bVisible = !ELogger::GetInstance()->IsWindowVisible();
-					ELogger::GetInstance()->SetWindowVisible(bVisible);
-					break;
-				}
-
-				case ID_MENUITEM_MAIN_DEBUGWINDOW:
-				{
-					bool bVisible = !wndDebug_->IsWindowVisible();
-					wndDebug_->SetWindowVisible(bVisible);
-					break;
-				}
-
-				case ID_MENUITEM_MAIN_FIXEDAREA:
-				{
-					//表示域固定
-					panelScene_->SetFixedArea(!panelScene_->IsFixedArea());
-					panelScene_->LocateParts();
-					break;
-				}
-			}
+		case ID_MENUITEM_MAIN_LOGWINDOW: {
+			bool bVisible = !ELogger::GetInstance()->IsWindowVisible();
+			ELogger::GetInstance()->SetWindowVisible(bVisible);
 			break;
 		}
 
-		case WM_SYSCOMMAND:
-		{
-			int nId = wParam & 0xffff;
-			if (nId == WindowLogger::MENU_ID_OPEN)
-			{
-				ELogger::GetInstance()->ShowLogWindow();
-			}
+		case ID_MENUITEM_MAIN_DEBUGWINDOW: {
+			bool bVisible = !wndDebug_->IsWindowVisible();
+			wndDebug_->SetWindowVisible(bVisible);
 			break;
 		}
 
-		case WM_NOTIFY:
-		{
-			switch (((NMHDR *)lParam)->code)
-			{
-				case TCN_SELCHANGE:
-					wndTab_->ShowPage();
-					break;
-			}
+		case ID_MENUITEM_MAIN_FIXEDAREA: {
+			//表示域固定
+			panelScene_->SetFixedArea(!panelScene_->IsFixedArea());
+			panelScene_->LocateParts();
 			break;
 		}
-		case WM_INITMENUPOPUP:
-		{
-			//HMENU hMenu = (HMENU) wParam;         // サブメニューのハンドル
-			//int pos =  LOWORD(lParam);        // サブメニュー項目の位置
-			HMENU hMenuMain = GetMenu(hWnd_);
-
-			DWORD valueLog = ELogger::GetInstance()->IsWindowVisible() ? MFS_CHECKED : MFS_UNCHECKED;
-			CheckMenuItem(hMenuMain, ID_MENUITEM_MAIN_LOGWINDOW, valueLog | MF_BYCOMMAND);
-
-			DWORD valueDebug = wndDebug_->IsWindowVisible() ? MFS_CHECKED : MFS_UNCHECKED;
-			CheckMenuItem(hMenuMain, ID_MENUITEM_MAIN_DEBUGWINDOW, valueDebug | MF_BYCOMMAND);
-
-			DWORD valueFixed = panelScene_->IsFixedArea() ? MFS_CHECKED : MFS_UNCHECKED;
-			CheckMenuItem(hMenuMain, ID_MENUITEM_MAIN_FIXEDAREA, valueFixed | MF_BYCOMMAND);
-			return FALSE;
 		}
+		break;
+	}
+
+	case WM_SYSCOMMAND: {
+		int nId = wParam & 0xffff;
+		if (nId == WindowLogger::MENU_ID_OPEN) {
+			ELogger::GetInstance()->ShowLogWindow();
+		}
+		break;
+	}
+
+	case WM_NOTIFY: {
+		switch (((NMHDR*)lParam)->code) {
+		case TCN_SELCHANGE:
+			wndTab_->ShowPage();
+			break;
+		}
+		break;
+	}
+	case WM_INITMENUPOPUP: {
+		// HMENU hMenu = (HMENU) wParam;      // サブメニューのハンドル
+		// int pos = LOWORD(lParam);         // サブメニュー項目の位置
+		HMENU hMenuMain = GetMenu(hWnd_);
+
+		DWORD valueLog = ELogger::GetInstance()->IsWindowVisible() ? MFS_CHECKED : MFS_UNCHECKED;
+		CheckMenuItem(hMenuMain, ID_MENUITEM_MAIN_LOGWINDOW, valueLog | MF_BYCOMMAND);
+
+		DWORD valueDebug = wndDebug_->IsWindowVisible() ? MFS_CHECKED : MFS_UNCHECKED;
+		CheckMenuItem(hMenuMain, ID_MENUITEM_MAIN_DEBUGWINDOW, valueDebug | MF_BYCOMMAND);
+
+		DWORD valueFixed = panelScene_->IsFixedArea() ? MFS_CHECKED : MFS_UNCHECKED;
+		CheckMenuItem(hMenuMain, ID_MENUITEM_MAIN_FIXEDAREA, valueFixed | MF_BYCOMMAND);
+		return FALSE;
+	}
 	}
 	return _CallPreviousWindowProcedure(hWnd, uMsg, wParam, lParam);
 }
 void MainWindow::SetStgController(ref_count_ptr<StgControllerForViewer> controller)
 {
-	if(controller_ == controller)return;
-	if(controller == NULL)
-	{
+	if (controller_ == controller)
+		return;
+	if (controller == NULL) {
 		panelScene_->SetStgState(false);
-	}
-	else
-	{
+	} else {
 		panelScene_->SetStgState(true);
 	}
 
 	ETaskManager* task = ETaskManager::GetInstance();
-	if(controller_ != NULL)
-	{
+	if (controller_ != NULL) {
 		EFpsController* fpsController = EFpsController::GetInstance();
 		fpsController->SetFastModeKey(DIK_LCONTROL);
 
@@ -204,38 +186,31 @@ void MainWindow::SetStgController(ref_count_ptr<StgControllerForViewer> controll
 	}
 
 	controller_ = controller;
-	if(controller_ != NULL)
-	{
+	if (controller_ != NULL) {
 		Logger::WriteTop(L"STGシーン開始");
-		try
-		{
+		try {
 			DirectGraphics* graphics = DirectGraphics::GetBase();
 			graphics->GetCamera2D()->Reset();
 
-//			controller_->Initialize();
+			// controller_->Initialize();
 			task->AddTask(controller_);
 			task->AddWorkFunction(TTaskFunction<StgControllerForViewer>::Create(controller_, &StgControllerForViewer::Work), StgSystemController::TASK_PRI_WORK);
 			task->AddRenderFunction(TTaskFunction<StgControllerForViewer>::Create(controller_, &StgControllerForViewer::Render), StgSystemController::TASK_PRI_RENDER);
-		}
-		catch(gstd::wexception& e)
-		{
+		} catch (gstd::wexception& e) {
 			Logger::WriteTop(e.what());
 			ErrorDialog::ShowErrorDialog(e.what());
 		}
-
 	}
 }
 void MainWindow::ClearData()
 {
-
 }
 bool MainWindow::Load(std::wstring path)
 {
 	RecordBuffer record;
 	bool res = record.ReadFromFile(path);
-	if(!res)
-	{
-		//::MessageBox(hWnd_, "読み込み失敗", "設定を開く", MB_OK);
+	if (!res) {
+		// ::MessageBox(hWnd_, "読み込み失敗", "設定を開く", MB_OK);
 		return false;
 	}
 
@@ -272,58 +247,53 @@ bool GraphicsWindow::Initialize()
 	HINSTANCE hInst = ::GetModuleHandle(NULL);
 	std::wstring nameClass = L"DnhViewerGraphicsWindow";
 	WNDCLASSEX wcex;
-	ZeroMemory(&wcex,sizeof(wcex));
-	wcex.cbSize=sizeof(WNDCLASSEX); 
-	wcex.style=CS_HREDRAW|CS_VREDRAW;
-	wcex.lpfnWndProc=(WNDPROC)WindowBase::_StaticWindowProcedure;
-	wcex.hInstance=hInst;
-	wcex.hIcon=NULL;
-	wcex.hCursor=LoadCursor(NULL, IDC_ARROW);
-	wcex.hbrBackground=(HBRUSH)(COLOR_WINDOW+2);
-	wcex.lpszMenuName=NULL;
-	wcex.lpszClassName=nameClass.c_str();
-	wcex.hIconSm=NULL;
+	ZeroMemory(&wcex, sizeof(wcex));
+	wcex.cbSize = sizeof(WNDCLASSEX);
+	wcex.style = CS_HREDRAW | CS_VREDRAW;
+	wcex.lpfnWndProc = (WNDPROC)WindowBase::_StaticWindowProcedure;
+	wcex.hInstance = hInst;
+	wcex.hIcon = NULL;
+	wcex.hCursor = LoadCursor(NULL, IDC_ARROW);
+	wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW + 2);
+	wcex.lpszMenuName = NULL;
+	wcex.lpszClassName = nameClass.c_str();
+	wcex.hIconSm = NULL;
 	::RegisterClassEx(&wcex);
 
-   	hWnd_=::CreateWindow(wcex.lpszClassName,
+	hWnd_ = ::CreateWindow(wcex.lpszClassName,
 		L"",
-		WS_OVERLAPPEDWINDOW-WS_SIZEBOX,
-		0,0,800,600,hParent,NULL,hInst,NULL);
+		WS_OVERLAPPEDWINDOW - WS_SIZEBOX,
+		0, 0, 800, 600, hParent, NULL, hInst, NULL);
 	::ShowWindow(hWnd_, SW_SHOW);
 	::UpdateWindow(hWnd_);
 	this->Attach(hWnd_);
 
-//Windowを画面の中央に移動
+	//Windowを画面の中央に移動
 	MoveWindowCenter();
 
 	::ShowWindow(hWnd_, SW_HIDE);
 
 	return true;
 }
-LRESULT GraphicsWindow::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
+LRESULT GraphicsWindow::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	switch (uMsg)
-	{
-		case WM_CLOSE:
-		{
-			::ShowWindow(hWnd_, SW_HIDE);
-			break;
-		}
+	switch (uMsg) {
+	case WM_CLOSE: {
+		::ShowWindow(hWnd_, SW_HIDE);
+		break;
+	}
 	}
 	return _CallPreviousWindowProcedure(hWnd, uMsg, wParam, lParam);
 }
 void GraphicsWindow::SetWindowType(int type, HWND hParent)
 {
-	if(type == TYPE_WINDOW_PANEL)
-	{
+	if (type == TYPE_WINDOW_PANEL) {
 		RemoveWindowStyle(WS_OVERLAPPEDWINDOW);
 		SetWindowStyle(WS_CHILD);
 		SetWindowLong(hWnd_, GWL_EXSTYLE, WS_EX_STATICEDGE);
 		SetParentWindow(hParent);
 		SetWindowVisible(true);
-	}
-	else if(TYPE_WINDOW_OVERLAPPED)
-	{
+	} else if (TYPE_WINDOW_OVERLAPPED) {
 		RemoveWindowStyle(WS_CHILD);
 		SetWindowStyle(WS_OVERLAPPEDWINDOW);
 		SetWindowLong(hWnd_, GWL_EXSTYLE, 0);
@@ -342,13 +312,12 @@ void StgControllerForViewer::DoEnd()
 void StgControllerForViewer::DoRetry()
 {
 	ScenePanel* panel = MainWindow::GetInstance()->GetScenePanel();
-//	panel->EndStg();
+	// panel->EndStg();
 	panel->StartStg();
 }
 
 ref_count_ptr<StgControllerForViewer> StgControllerForViewer::Create()
 {
 	ref_count_ptr<StgControllerForViewer> res = new StgControllerForViewer();
-
 	return res;
 }

--- a/source/TouhouDanmakufu/DnhViewer/MainWindow.hpp
+++ b/source/TouhouDanmakufu/DnhViewer/MainWindow.hpp
@@ -1,78 +1,73 @@
 #ifndef __TOUHOUDANMAKUFU_VIEW_MAINWINDOW__
 #define __TOUHOUDANMAKUFU_VIEW_MAINWINDOW__
 
-#include"Constant.hpp"
-#include"ScenePanel.hpp"
-#include"DebugWindow.hpp"
-#include"../Common/StgSystem.hpp"
+#include "../Common/StgSystem.hpp"
+#include "Constant.hpp"
+#include "DebugWindow.hpp"
+#include "ScenePanel.hpp"
 
 class StgControllerForViewer;
 class GraphicsWindow;
 /**********************************************************
 //MainWindow
 **********************************************************/
-class MainWindow : public WindowBase , public gstd::Singleton<MainWindow>
-{
-	protected:
-		ref_count_ptr<WTabControll> wndTab_;
-		ref_count_ptr<WStatusBar> wndStatus_;
-		ref_count_ptr<GraphicsWindow> wndGraphics_;
-		ref_count_ptr<ScenePanel> panelScene_;
-		ref_count_ptr<DebugWindow> wndDebug_;
+class MainWindow : public WindowBase, public gstd::Singleton<MainWindow> {
+public:
+	MainWindow();
+	~MainWindow();
+	bool Initialize();
 
-		ref_count_ptr<StgControllerForViewer> controller_;
+	GraphicsWindow* GetGraphicsWindow() { return wndGraphics_.GetPointer(); }
+	ScenePanel* GetScenePanel() { return panelScene_.GetPointer(); }
+	DebugWindow* GetDebugWindow() { return wndDebug_.GetPointer(); }
 
-		virtual LRESULT _WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
-	public:
-		MainWindow();
-		~MainWindow();
-		bool Initialize();
+	ref_count_ptr<StgControllerForViewer> GetStgController() { return controller_; }
+	void SetStgController(ref_count_ptr<StgControllerForViewer> controller);
 
-		GraphicsWindow* GetGraphicsWindow(){return wndGraphics_.GetPointer();}
-		ScenePanel* GetScenePanel(){return panelScene_.GetPointer();}
-		DebugWindow* GetDebugWindow(){return wndDebug_.GetPointer();}
+	void ClearData();
+	bool Load(std::wstring path);
+	bool Save(std::wstring path);
 
-		ref_count_ptr<StgControllerForViewer> GetStgController(){return controller_;}
-		void SetStgController(ref_count_ptr<StgControllerForViewer> controller);
+protected:
+	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-		void ClearData();
-		bool Load(std::wstring path);
-		bool Save(std::wstring path);
+	ref_count_ptr<WTabControll> wndTab_;
+	ref_count_ptr<WStatusBar> wndStatus_;
+	ref_count_ptr<GraphicsWindow> wndGraphics_;
+	ref_count_ptr<ScenePanel> panelScene_;
+	ref_count_ptr<DebugWindow> wndDebug_;
+
+	ref_count_ptr<StgControllerForViewer> controller_;
 };
-
 
 /**********************************************************
 //GraphicsWindow
 **********************************************************/
-class GraphicsWindow : public WindowBase
-{
-	public:
-		enum
-		{
-			TYPE_WINDOW_PANEL,
-			TYPE_WINDOW_OVERLAPPED,
-		};
-	protected:
-		virtual LRESULT _WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
-	public:
-		GraphicsWindow();
-		~GraphicsWindow();
-		bool Initialize();
+class GraphicsWindow : public WindowBase {
+public:
+	enum {
+		TYPE_WINDOW_PANEL,
+		TYPE_WINDOW_OVERLAPPED,
+	};
 
-		void SetWindowType(int type, HWND hParent);
+public:
+	GraphicsWindow();
+	~GraphicsWindow();
+	bool Initialize();
+	void SetWindowType(int type, HWND hParent);
+
+protected:
+	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 };
 
 /**********************************************************
 //StgControllerForViewer
 **********************************************************/
-class StgControllerForViewer : public StgSystemController
-{
-	public:
-		virtual void DoEnd();
-		virtual void DoRetry();
-
-		static ref_count_ptr<StgControllerForViewer> Create();
+class StgControllerForViewer : public StgSystemController {
+public:
+	virtual void DoEnd();
+	virtual void DoRetry();
+	static ref_count_ptr<StgControllerForViewer> Create();
 };
-
 
 #endif

--- a/source/TouhouDanmakufu/DnhViewer/ScenePanel.cpp
+++ b/source/TouhouDanmakufu/DnhViewer/ScenePanel.cpp
@@ -1,42 +1,31 @@
-#include"ScenePanel.hpp"
-#include"MainWindow.hpp"
-
+#include "ScenePanel.hpp"
+#include "MainWindow.hpp"
 
 /**********************************************************
 //EventScenePanel
 **********************************************************/
-LRESULT ScenePanel::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
+LRESULT ScenePanel::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	switch (uMsg)
-	{
-		case WM_COMMAND:
-		{
-			int id = wParam & 0xffff;//LOWORD(wParam);
-			if(id == buttonStart_.GetWindowId())
-			{
-				MainWindow* wndMain = MainWindow::GetInstance();
-				if(wndMain->GetStgController() == NULL)
-				{
-					StartStg();
-				}
-				else
-				{
-					DirectSoundManager* soundManager = DirectSoundManager::GetBase();
-					soundManager->Clear();
-					EndStg();
-				}
-
-			}
-			else if(id == buttonPause_.GetWindowId())
-			{
-				bool bCheck = SendMessage(buttonPause_.GetWindowHandle() , BM_GETCHECK , 0 , 0) == BST_CHECKED;
-				ETaskManager::GetInstance()->SetWorkFunctionEnable(!bCheck);
-				EFpsController::GetInstance()->SetCriticalFrame();
+	switch (uMsg) {
+	case WM_COMMAND: {
+		int id = wParam & 0xffff; // LOWORD(wParam);
+		if (id == buttonStart_.GetWindowId()) {
+			MainWindow* wndMain = MainWindow::GetInstance();
+			if (wndMain->GetStgController() == NULL) {
+				StartStg();
+			} else {
+				DirectSoundManager* soundManager = DirectSoundManager::GetBase();
+				soundManager->Clear();
+				EndStg();
 			}
 
-			break;
+		} else if (id == buttonPause_.GetWindowId()) {
+			bool bCheck = SendMessage(buttonPause_.GetWindowHandle(), BM_GETCHECK, 0, 0) == BST_CHECKED;
+			ETaskManager::GetInstance()->SetWorkFunctionEnable(!bCheck);
+			EFpsController::GetInstance()->SetCriticalFrame();
 		}
-
+		break;
+	}
 	}
 	return WPanel::_WindowProcedure(hWnd, uMsg, wParam, lParam);
 }
@@ -55,7 +44,7 @@ bool ScenePanel::Initialize(HWND hParent)
 	panelPathPlayer_->Initialize(ScriptPathPanel::TYPE_PLAYER, hWnd_);
 
 	WButton::Style styleCheck;
-	styleCheck.SetStyle(WS_CHILD | WS_VISIBLE | BS_PUSHLIKE | BS_AUTOCHECKBOX );
+	styleCheck.SetStyle(WS_CHILD | WS_VISIBLE | BS_PUSHLIKE | BS_AUTOCHECKBOX);
 	buttonPause_.Create(hWnd_, styleCheck);
 	buttonPause_.SetText(L"停止");
 	buttonPause_.SetWindowEnable(false);
@@ -83,21 +72,17 @@ void ScenePanel::LocateParts()
 	int gWidth = 640;
 	int gHeight = 480;
 
-	if(!bFixedArea_)
-	{
+	if (!bFixedArea_) {
 /*
-		if(gWidth > gHeight*4/3)
-		{//横幅が広い
-			gWidth = gHeight*4/3;
-			gHeight = gWidth*3/4;
+		if (gWidth > gHeight * 4 / 3) { //横幅が広い
+			gWidth = gHeight * 4 / 3;
+			gHeight = gWidth * 3 / 4;
 			gHeight = gHeight > wHeight ? wHeight : gHeight;
-			gWidth = gHeight*4/3;
-		}
-		else 
-		{//縦幅が広い
-			gHeight = gWidth*3/4;
+			gWidth = gHeight * 4 / 3;
+		} else { //縦幅が広い
+			gHeight = gWidth * 3 / 4;
 			gHeight = gHeight > wHeight ? wHeight : gHeight;
-			gWidth = gHeight*4/3;
+			gWidth = gHeight * 4 / 3;
 		}
 */
 		DnhConfiguration* config = DnhConfiguration::CreateInstance();
@@ -109,13 +94,16 @@ void ScenePanel::LocateParts()
 		double ratioWH = (double)screenWidth / (double)screenHeight;
 		double ratioHW = (double)screenHeight / (double)screenWidth;
 
-		if(height > wHeight) height = wHeight;
+		if (height > wHeight)
+			height = wHeight;
 		width = (double)height / ratioHW;
 
-		if(width > wWidth)width = wWidth;
+		if (width > wWidth)
+			width = wWidth;
 		height = (double)width / ratioWH;
 
-		if(height > wHeight) height = wHeight;
+		if (height > wHeight)
+			height = wHeight;
 		width = (double)height / ratioHW;
 
 		gWidth = width;
@@ -131,23 +119,21 @@ bool ScenePanel::StartStg()
 	std::wstring pathEnemy = panelPathEnemy_->GetPath();
 	std::wstring pathPlayer = panelPathPlayer_->GetPath();
 	bool res = false;
-	try
-	{
+	try {
 		ref_count_ptr<ScriptInformation> infoEnemy = panelPathEnemy_->GetSelectedScriptInformation();
-		if(infoEnemy == NULL)throw gstd::wexception(L"敵スクリプトが不正です");
+		if (infoEnemy == NULL)
+			throw gstd::wexception(L"敵スクリプトが不正です");
 
 		ref_count_ptr<StgControllerForViewer> controller = StgControllerForViewer::Create();
-		if(infoEnemy->GetType() == ScriptInformation::TYPE_PACKAGE)
-		{
+		if (infoEnemy->GetType() == ScriptInformation::TYPE_PACKAGE) {
 			ref_count_ptr<StgSystemInformation> infoStgSystem = new StgSystemInformation();
 			infoStgSystem->SetMainScriptInformation(infoEnemy);
 			controller->Initialize(infoStgSystem);
 			controller->Start(NULL, NULL);
-		}
-		else
-		{
+		} else {
 			ref_count_ptr<ScriptInformation> infoPlayer = panelPathPlayer_->GetSelectedScriptInformation();
-			if(infoPlayer == NULL)throw gstd::wexception(L"自機スクリプトが不正です");
+			if (infoPlayer == NULL)
+				throw gstd::wexception(L"自機スクリプトが不正です");
 
 			ref_count_ptr<StgSystemInformation> infoStgSystem = new StgSystemInformation();
 			infoStgSystem->SetMainScriptInformation(infoEnemy);
@@ -158,14 +144,10 @@ bool ScenePanel::StartStg()
 		}
 
 		wndMain->SetStgController(controller);
-	}
-	catch(gstd::wexception& e)
-	{
+	} catch (gstd::wexception& e) {
 		ErrorDialog::ShowErrorDialog(e.what());
 		Logger::WriteTop(e.what());
-	}
-	catch(...)
-	{
+	} catch (...) {
 		MessageBox(hWnd_, L"開始失敗", L"error", MB_OK);
 		Logger::WriteTop(L"開始失敗");
 	}
@@ -180,16 +162,13 @@ bool ScenePanel::EndStg()
 }
 void ScenePanel::SetStgState(bool bStart)
 {
-	if(bStart)
-	{
+	if (bStart) {
 		buttonStart_.SetText(L"終了");
 		buttonPause_.SetWindowEnable(true);
 
 		panelPathEnemy_->SetWindowEnable(false);
 		panelPathPlayer_->SetWindowEnable(false);
-	}
-	else
-	{
+	} else {
 		buttonStart_.SetText(L"開始");
 		buttonPause_.SetWindowEnable(false);
 		panelPathEnemy_->SetWindowEnable(true);
@@ -218,7 +197,6 @@ void ScenePanel::Write(RecordBuffer& record)
 //ScriptPathPanel
 ScenePanel::ScriptPathPanel::~ScriptPathPanel()
 {
-
 }
 bool ScenePanel::ScriptPathPanel::Initialize(int type, HWND hParent)
 {
@@ -232,13 +210,12 @@ bool ScenePanel::ScriptPathPanel::Initialize(int type, HWND hParent)
 
 	{
 		labelPath_.Create(hWnd_);
-		if(type == TYPE_ENEMY)
+		if (type == TYPE_ENEMY)
 			labelPath_.SetText(L"敵スクリプト");
 		else
 			labelPath_.SetText(L"自機スクリプト");
 
 		editPath_.Create(hWnd_, styleEdit);
-
 
 		buttonPath_.Create(hWnd_, stylePath);
 		buttonPath_.SetText(L"選択");
@@ -250,9 +227,9 @@ bool ScenePanel::ScriptPathPanel::Initialize(int type, HWND hParent)
 
 	DragAcceptFiles(hWnd_, TRUE);
 
-	if(type == TYPE_ENEMY)
+	if (type == TYPE_ENEMY)
 		dialogSelect_ = new EnemySelectDialog();
-	else 
+	else
 		dialogSelect_ = new PlayerSelectDialog();
 
 	dialogSelect_->Initialize();
@@ -264,21 +241,18 @@ void ScenePanel::ScriptPathPanel::SetWindowEnable(bool bEnable)
 	editPath_.SetWindowEnable(bEnable);
 	buttonPath_.SetWindowEnable(bEnable);
 }
-LRESULT ScenePanel::ScriptPathPanel::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
+LRESULT ScenePanel::ScriptPathPanel::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	switch (uMsg)
-	{
-		case WM_COMMAND:
-		{
-			int id = wParam & 0xffff;//LOWORD(wParam);
-			if(id == buttonPath_.GetWindowId())
-			{
+	switch (uMsg) {
+	case WM_COMMAND: {
+		int id = wParam & 0xffff; // LOWORD(wParam);
+		if (id == buttonPath_.GetWindowId()) {
 /*
 				std::string path;
 				path.resize(MAX_PATH*4);
 				OPENFILENAME ofn;
-				ZeroMemory(&ofn,sizeof(OPENFILENAME));
-				ofn.lStructSize=sizeof(OPENFILENAME);
+				ZeroMemory(&ofn, sizeof(OPENFILENAME));
+				ofn.lStructSize = sizeof(OPENFILENAME);
 				ofn.hwndOwner = hWnd_;
 				ofn.nMaxFile = path.size();
 				ofn.lpstrFile = &path[0];
@@ -287,71 +261,64 @@ LRESULT ScenePanel::ScriptPathPanel::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM
 				ofn.lpstrDefExt = ".txt";
 				ofn.lpstrFilter = "全てのファイル (*.*)\0*.*\0";
 				ofn.lpstrTitle = "スクリプトを開く";
-				if(GetOpenFileName(&ofn))
-				{
+				if (GetOpenFileName(&ofn))
 					editPath_.SetText(path);
-				}
 */
-				std::wstring path = editPath_.GetText();
-				dialogSelect_->ShowModal(path);
+			std::wstring path = editPath_.GetText();
+			dialogSelect_->ShowModal(path);
 
-				ref_count_ptr<ScriptInformation> info = dialogSelect_->GetSelectedScript();
-				if(info != NULL)
-				{
-					infoSelected_ = info;
-					editPath_.SetText(info->GetScriptPath());
-				}
+			ref_count_ptr<ScriptInformation> info = dialogSelect_->GetSelectedScript();
+			if (info != NULL) {
+				infoSelected_ = info;
+				editPath_.SetText(info->GetScriptPath());
+			}
+		}
+		break;
+	}
+	case WM_DROPFILES: {
+		wchar_t szFileName[MAX_PATH];
+		HDROP hDrop = (HDROP)wParam;
+		UINT uFileNo = DragQueryFile((HDROP)wParam, 0xFFFFFFFF, NULL, 0);
+
+		for (int iDrop = 0; iDrop < (int)uFileNo; iDrop++) {
+			DragQueryFile(hDrop, iDrop, szFileName, sizeof(szFileName));
+			std::wstring path = szFileName;
+
+			ref_count_ptr<ScriptInformation> info = _CreateScriptInformation(path);
+			if (info != NULL) {
+				infoSelected_ = info;
+				editPath_.SetText(info->GetScriptPath());
 			}
 			break;
 		}
-		case WM_DROPFILES:
-		{
-			wchar_t szFileName[MAX_PATH];
-			HDROP hDrop = (HDROP)wParam;
-			UINT uFileNo = DragQueryFile((HDROP)wParam,0xFFFFFFFF,NULL,0);
+		DragFinish(hDrop);
 
-			for(int iDrop = 0 ; iDrop < (int)uFileNo ; iDrop++)
-			{
-				DragQueryFile(hDrop, iDrop, szFileName, sizeof(szFileName));
-				std::wstring path = szFileName;
-
-				ref_count_ptr<ScriptInformation> info = _CreateScriptInformation(path);
-				if(info != NULL)
-				{
-					infoSelected_ = info;
-					editPath_.SetText(info->GetScriptPath());
-				}
-				break;
-			}
-			DragFinish(hDrop);
-
-			break;
-		}
+		break;
+	}
 	}
 	return WPanel::_WindowProcedure(hWnd, uMsg, wParam, lParam);
 }
 ref_count_ptr<ScriptInformation> ScenePanel::ScriptPathPanel::_CreateScriptInformation(std::wstring path)
 {
 	File file(path);
-	if(!file.Open())return NULL;
+	if (!file.Open())
+		return NULL;
 
 	std::string source = "";
 	int size = file.GetSize();
 	source.resize(size);
 	file.Read(&source[0], size);
 
-	ref_count_ptr<ScriptInformation> info = 
-		ScriptInformation::CreateScriptInformation(path, L"", source);
+	ref_count_ptr<ScriptInformation> info = ScriptInformation::CreateScriptInformation(path, L"", source);
 
 	return info;
 }
 void ScenePanel::ScriptPathPanel::SetPath(std::wstring path)
 {
 	ref_count_ptr<ScriptInformation> info = _CreateScriptInformation(path);
-	if(info == NULL)return;
+	if (info == NULL)
+		return;
 
 	infoSelected_ = info;
 	editPath_.SetText(path);
 }
-
-

--- a/source/TouhouDanmakufu/DnhViewer/ScenePanel.hpp
+++ b/source/TouhouDanmakufu/DnhViewer/ScenePanel.hpp
@@ -1,65 +1,67 @@
 #ifndef __TOUHOUDANMAKUFU_VIEW_SCENEPANEL__
 #define __TOUHOUDANMAKUFU_VIEW_SCENEPANEL__
 
-#include"Constant.hpp"
-#include"Common.hpp"
-#include"ScriptSelect.hpp"
+#include "Common.hpp"
+#include "Constant.hpp"
+#include "ScriptSelect.hpp"
 
 /**********************************************************
 //ScenePanel
 **********************************************************/
-class ScenePanel : public WPanel
-{
+class ScenePanel : public WPanel {
+public:
+	virtual void LocateParts();
+	bool Initialize(HWND hParent);
+
+	bool StartStg();
+	bool EndStg();
+	void SetStgState(bool bStart);
+
+	bool IsFixedArea() { return bFixedArea_; }
+	void SetFixedArea(bool bFixed) { bFixedArea_ = bFixed; }
+
+	void ClearData();
+	virtual void Read(RecordBuffer& record);
+	virtual void Write(RecordBuffer& record);
+
+private:
+	LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
 	class ScriptPathPanel;
-		bool bFixedArea_;
-		ref_count_ptr<ScriptPathPanel> panelPathEnemy_;
-		ref_count_ptr<ScriptPathPanel> panelPathPlayer_;
 
-		WButton buttonStart_;
-		WButton buttonPause_;
+	bool bFixedArea_;
+	ref_count_ptr<ScriptPathPanel> panelPathEnemy_;
+	ref_count_ptr<ScriptPathPanel> panelPathPlayer_;
 
-		LRESULT _WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
-	public:
-		virtual void LocateParts();
-		bool Initialize(HWND hParent);
-
-		bool StartStg();
-		bool EndStg();
-		void SetStgState(bool bStart);
-
-		bool IsFixedArea(){return bFixedArea_;}
-		void SetFixedArea(bool bFixed){bFixedArea_ = bFixed;}
-
-		void ClearData();
-		virtual void Read(RecordBuffer& record);
-		virtual void Write(RecordBuffer& record);
+	WButton buttonStart_;
+	WButton buttonPause_;
 };
 
-class ScenePanel::ScriptPathPanel : public WPanel
-{
-	public:
-		enum
-		{
-			TYPE_ENEMY,
-			TYPE_PLAYER,
-		};
-	protected:
-		WLabel labelPath_;
-		WEditBox editPath_;
-		WButton buttonPath_;
-		ref_count_ptr<ScriptSelectDialog> dialogSelect_;
-		ref_count_ptr<ScriptInformation> infoSelected_;
+class ScenePanel::ScriptPathPanel : public WPanel {
+public:
+	enum {
+		TYPE_ENEMY,
+		TYPE_PLAYER,
+	};
 
-		LRESULT _WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
-		ref_count_ptr<ScriptInformation> _CreateScriptInformation(std::wstring path);
-	public:
-		virtual ~ScriptPathPanel();
-		bool Initialize(int type, HWND hParent);
-		void SetWindowEnable(bool bEnable);
-		std::wstring GetPath(){return editPath_.GetText();}
-		void SetPath(std::wstring path);
-		
-		ref_count_ptr<ScriptInformation> GetSelectedScriptInformation(){return infoSelected_;}
+public:
+	virtual ~ScriptPathPanel();
+	bool Initialize(int type, HWND hParent);
+	void SetWindowEnable(bool bEnable);
+	std::wstring GetPath() { return editPath_.GetText(); }
+	void SetPath(std::wstring path);
+
+	ref_count_ptr<ScriptInformation> GetSelectedScriptInformation() { return infoSelected_; }
+
+protected:
+	LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	ref_count_ptr<ScriptInformation> _CreateScriptInformation(std::wstring path);
+
+	WLabel labelPath_;
+	WEditBox editPath_;
+	WButton buttonPath_;
+	ref_count_ptr<ScriptSelectDialog> dialogSelect_;
+	ref_count_ptr<ScriptInformation> infoSelected_;
 };
 
 #endif

--- a/source/TouhouDanmakufu/DnhViewer/ScriptSelect.cpp
+++ b/source/TouhouDanmakufu/DnhViewer/ScriptSelect.cpp
@@ -1,5 +1,5 @@
-#include"ScriptSelect.hpp"
-#include"MainWindow.hpp"
+#include "ScriptSelect.hpp"
+#include "MainWindow.hpp"
 
 /**********************************************************
 //ScriptSelectDialog
@@ -17,10 +17,10 @@ void ScriptSelectDialog::Initialize()
 	SetWindowVisible(false);
 
 	//ListView
-	HWND hList=GetDlgItem(hWnd_, IDC_LIST_SELECT_SCRIPT);
+	HWND hList = GetDlgItem(hWnd_, IDC_LIST_SELECT_SCRIPT);
 	listView_.Attach(hList);
-	DWORD dwStyle=ListView_GetExtendedListViewStyle(hList);
-	dwStyle |= LVS_EX_FULLROWSELECT|LVS_EX_GRIDLINES;
+	DWORD dwStyle = ListView_GetExtendedListViewStyle(hList);
+	dwStyle |= LVS_EX_FULLROWSELECT | LVS_EX_GRIDLINES;
 	ListView_SetExtendedListViewStyle(hList, dwStyle);
 
 	listView_.AddColumn(48, LIST_TYPE, L"Type");
@@ -39,132 +39,119 @@ void ScriptSelectDialog::_SearchScript(std::wstring dir)
 	HANDLE hFind;
 	std::wstring findDir = dir + L"*.*";
 	hFind = FindFirstFile(findDir.c_str(), &data);
-	do 
-	{
+	do {
 		std::wstring name = data.cFileName;
-		if((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) && 
-			(name != L".." && name != L"."))
-		{
+		if ((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) && (name != L".." && name != L".")) {
 			//ディレクトリ
 			std::wstring tDir = dir + name;
 			tDir += L"/";
-
 			_SearchScript(tDir);
 			continue;
 		}
-		if(wcscmp(data.cFileName, L"..")==0 || wcscmp(data.cFileName, L".")==0)
+		if (wcscmp(data.cFileName, L"..") == 0 || wcscmp(data.cFileName, L".") == 0)
 			continue;
 
 		//ファイル
 		std::wstring path = dir + name;
 
-		std::vector<ref_count_ptr<ScriptInformation> >listInfo = 
-			ScriptInformation::CreateScriptInformationList(path, true);
-		for(int iInfo = 0 ; iInfo < listInfo.size() ; iInfo++)
-		{
+		std::vector<ref_count_ptr<ScriptInformation>> listInfo = ScriptInformation::CreateScriptInformationList(path, true);
+		for (int iInfo = 0; iInfo < listInfo.size(); iInfo++) {
 			ref_count_ptr<ScriptInformation> info = listInfo[iInfo];
-			if(!_IsValidScript(info))continue;
-
+			if (!_IsValidScript(info))
+				continue;
 			listInfo_.push_back(info);
 		}
 
-	}while(FindNextFile(hFind,&data));
+	} while (FindNextFile(hFind, &data));
 	FindClose(hFind);
 }
 
-LRESULT ScriptSelectDialog::_WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam)
+LRESULT ScriptSelectDialog::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-	switch (uMsg)
-	{
-		case WM_DESTROY:
-		{
-			_FinishMessageLoop();
-			break;
-		}
-		case WM_CLOSE:
+	switch (uMsg) {
+	case WM_DESTROY: {
+		_FinishMessageLoop();
+		break;
+	}
+	case WM_CLOSE:
+		SetWindowVisible(false);
+		_FinishMessageLoop();
+		break;
+	case WM_COMMAND: {
+		switch (wParam & 0xffff) {
+		case IDCANCEL: //閉じるボタン
 			SetWindowVisible(false);
 			_FinishMessageLoop();
 			break;
-		case WM_COMMAND:
-		{
-			switch(wParam & 0xffff)
-			{
-				case IDCANCEL://閉じるボタン
-					SetWindowVisible(false);
-					_FinishMessageLoop();
-					break;
 
-				case IDOK:
+		case IDOK: {
+			int index = listView_.GetSelectedRow();
+			if (index != -1)
+				infoSelected_ = listInfo_[index];
+			else
+				infoSelected_ = NULL;
+			SetWindowVisible(false);
+			_FinishMessageLoop();
+			break;
+		}
+
+		case IDC_BUTTON_RELOAD_SCRIPT:
+			_Filter();
+			break;
+		}
+		break;
+	}
+	case WM_SIZE: {
+		RECT rect;
+		::GetClientRect(hWnd_, &rect);
+		int wx = rect.left;
+		int wy = rect.top;
+		int wWidth = rect.right - rect.left;
+		int wHeight = rect.bottom - rect.top;
+
+		int topList = wy + 110;
+		int heightList = wHeight - topList - 40;
+		listView_.SetBounds(wx + 10, topList, wWidth - 20, heightList);
+
+		combo_.SetBounds(wx + 64, wy + 60, 200, 100);
+
+		int topButton = topList + heightList + 10;
+		int widthButton = buttonOk_.GetClientWidth();
+		int heightButton = buttonOk_.GetClientHeight();
+		buttonCancel_.SetBounds(wWidth - widthButton * 1 - 8, topButton, widthButton, heightButton);
+		buttonOk_.SetBounds(wWidth - widthButton * 2 - 16, topButton, widthButton, heightButton);
+
+		break;
+	}
+	case WM_NOTIFY: {
+		LPNMHDR lpnmhdr = (LPNMHDR)lParam;
+		if (lpnmhdr->hwndFrom == listView_.GetWindowHandle()) {
+			switch (lpnmhdr->code) {
+			case NM_DBLCLK:
+			// case NM_CLICK:
 				{
 					int index = listView_.GetSelectedRow();
-					if(index != -1)
+					if (index != -1)
 						infoSelected_ = listInfo_[index];
-					else infoSelected_ = NULL;
+					else
+						infoSelected_ = NULL;
 					SetWindowVisible(false);
 					_FinishMessageLoop();
 					break;
 				}
-
-				case IDC_BUTTON_RELOAD_SCRIPT:
-					_Filter();
-					break;
 			}
-			break;
 		}
-		case WM_SIZE:
-		{
-			RECT rect;
-			::GetClientRect(hWnd_, &rect);
-			int wx = rect.left;
-			int wy = rect.top;
-			int wWidth = rect.right-rect.left;
-			int wHeight = rect.bottom-rect.top;
-
-			int topList = wy+110;
-			int heightList = wHeight - topList - 40;
-			listView_.SetBounds(wx+10, topList, wWidth-20, heightList);
-
-			combo_.SetBounds(wx + 64, wy + 60, 200, 100 );
-
-			int topButton = topList + heightList + 10;
-			int widthButton = buttonOk_.GetClientWidth();
-			int heightButton = buttonOk_.GetClientHeight();
-			buttonCancel_.SetBounds(wWidth - widthButton * 1 - 8, topButton, widthButton, heightButton);
-			buttonOk_.SetBounds(wWidth - widthButton * 2 - 16, topButton, widthButton, heightButton);
-
-			break;
-		}
-		case WM_NOTIFY:
-		{
-			LPNMHDR lpnmhdr = (LPNMHDR)lParam;
-			if(lpnmhdr->hwndFrom == listView_.GetWindowHandle())
-			{
-				switch( lpnmhdr->code )
-				{
-					case NM_DBLCLK:
-					//case NM_CLICK:
-					{
-						int index = listView_.GetSelectedRow();
-						if(index != -1)
-							infoSelected_ = listInfo_[index];
-						else infoSelected_ = NULL;
-						SetWindowVisible(false);
-						_FinishMessageLoop();
-						break;
-					}
-				}
-			}
-			break;
-		}
+		break;
+	}
 	}
 	return _CallPreviousWindowProcedure(hWnd, uMsg, wParam, lParam);
 }
 void ScriptSelectDialog::ShowModal(std::wstring path)
 {
-	for(int iInfo = 0 ; iInfo < listInfo_.size() ; iInfo++)
-	{
+	for (int iInfo = 0; iInfo < listInfo_.size(); iInfo++) {
 		ref_count_ptr<ScriptInformation> info = listInfo_[iInfo];
-		if(!File::IsEqualsPath(path, info->GetScriptPath()))continue;
+		if (!File::IsEqualsPath(path, info->GetScriptPath()))
+			continue;
 		listView_.SetSelectedRow(iInfo);
 		break;
 	}
@@ -178,7 +165,6 @@ void ScriptSelectDialog::ShowModal(std::wstring path)
 **********************************************************/
 EnemySelectDialog::EnemySelectDialog()
 {
-
 }
 void EnemySelectDialog::Initialize()
 {
@@ -211,17 +197,23 @@ void EnemySelectDialog::_Filter()
 
 	std::sort(listInfo_.begin(), listInfo_.end(), ScriptInformation::Sort());
 
-	std::vector<ref_count_ptr<ScriptInformation> >::iterator itr = listInfo_.begin();
-	for(int iRow = 0; itr != listInfo_.end() ; itr++, iRow++)
-	{
+	std::vector<ref_count_ptr<ScriptInformation>>::iterator itr = listInfo_.begin();
+	for (int iRow = 0; itr != listInfo_.end(); itr++, iRow++) {
 		ref_count_ptr<ScriptInformation> info = (*itr);
 		std::wstring strType = L"";
-		switch(info->GetType())
-		{
-		case ScriptInformation::TYPE_SINGLE:strType = KEY_SINGLE;break;
-		case ScriptInformation::TYPE_PLURAL:strType = KEY_PLURAL;break;
-		case ScriptInformation::TYPE_STAGE:strType = KEY_STAGE;break;
-		case ScriptInformation::TYPE_PACKAGE:strType = KEY_PACKAGE;break;
+		switch (info->GetType()) {
+		case ScriptInformation::TYPE_SINGLE:
+			strType = KEY_SINGLE;
+			break;
+		case ScriptInformation::TYPE_PLURAL:
+			strType = KEY_PLURAL;
+			break;
+		case ScriptInformation::TYPE_STAGE:
+			strType = KEY_STAGE;
+			break;
+		case ScriptInformation::TYPE_PACKAGE:
+			strType = KEY_PACKAGE;
+			break;
 		}
 
 		std::wstring path = info->GetScriptPath();
@@ -232,42 +224,39 @@ void EnemySelectDialog::_Filter()
 		path = StringUtility::ReplaceAll(path, root, L"");
 
 		std::wstring archive = info->GetArchivePath();
-		if(archive.size() > 0)
-		{
+		if (archive.size() > 0) {
 			archive = PathProperty::ReplaceYenToSlash(archive);
 			archive = StringUtility::ReplaceAll(archive, root, L"");
 		}
-		
+
 		listView_.SetText(iRow, LIST_TYPE, strType);
 		listView_.SetText(iRow, LIST_NAME, PathProperty::GetFileName(path));
 		listView_.SetText(iRow, LIST_ARCHIVE, archive);
 		listView_.SetText(iRow, LIST_PATH, path);
 		listView_.SetText(iRow, LIST_TEXT, info->GetText());
 	}
-
 }
 bool EnemySelectDialog::_IsValidScript(ref_count_ptr<ScriptInformation> info)
 {
 	int type = combo_.GetSelectedIndex();
 	int typeScript = info->GetType();
 	bool bTarget = false;
-	switch(type)
-	{
-		case INDEX_SINGLE:
-			bTarget = (typeScript == ScriptInformation::TYPE_SINGLE);
-			break;
-		case INDEX_PLURAL:
-			bTarget = (typeScript == ScriptInformation::TYPE_PLURAL);
-			break;
-		case INDEX_STAGE:
-			bTarget = (typeScript == ScriptInformation::TYPE_STAGE);
-			break;
-		case INDEX_PACKAGE:
-			bTarget = (typeScript == ScriptInformation::TYPE_PACKAGE);
-			break;
-		case INDEX_ALL:
-			bTarget = (typeScript != ScriptInformation::TYPE_PLAYER);
-			break;
+	switch (type) {
+	case INDEX_SINGLE:
+		bTarget = (typeScript == ScriptInformation::TYPE_SINGLE);
+		break;
+	case INDEX_PLURAL:
+		bTarget = (typeScript == ScriptInformation::TYPE_PLURAL);
+		break;
+	case INDEX_STAGE:
+		bTarget = (typeScript == ScriptInformation::TYPE_STAGE);
+		break;
+	case INDEX_PACKAGE:
+		bTarget = (typeScript == ScriptInformation::TYPE_PACKAGE);
+		break;
+	case INDEX_ALL:
+		bTarget = (typeScript != ScriptInformation::TYPE_PLAYER);
+		break;
 	}
 
 	return bTarget;
@@ -278,7 +267,6 @@ bool EnemySelectDialog::_IsValidScript(ref_count_ptr<ScriptInformation> info)
 **********************************************************/
 PlayerSelectDialog::PlayerSelectDialog()
 {
-
 }
 void PlayerSelectDialog::Initialize()
 {
@@ -308,14 +296,14 @@ void PlayerSelectDialog::_Filter()
 
 	std::sort(listInfo_.begin(), listInfo_.end(), ScriptInformation::Sort());
 
-	std::vector<ref_count_ptr<ScriptInformation> >::iterator itr = listInfo_.begin();
-	for(int iRow = 0; itr != listInfo_.end() ; itr++, iRow++)
-	{
+	std::vector<ref_count_ptr<ScriptInformation>>::iterator itr = listInfo_.begin();
+	for (int iRow = 0; itr != listInfo_.end(); itr++, iRow++) {
 		ref_count_ptr<ScriptInformation> info = (*itr);
 		std::wstring strType = L"";
-		switch(info->GetType())
-		{
-		case ScriptInformation::TYPE_PLAYER:strType = KEY_PLAYER;break;
+		switch (info->GetType()) {
+		case ScriptInformation::TYPE_PLAYER:
+			strType = KEY_PLAYER;
+			break;
 		}
 
 		std::wstring path = info->GetScriptPath();
@@ -326,33 +314,28 @@ void PlayerSelectDialog::_Filter()
 		path = StringUtility::ReplaceAll(path, root, L"");
 
 		std::wstring archive = info->GetArchivePath();
-		if(archive.size() > 0)
-		{
+		if (archive.size() > 0) {
 			archive = PathProperty::ReplaceYenToSlash(archive);
 			archive = StringUtility::ReplaceAll(archive, root, L"");
 		}
-		
+
 		listView_.SetText(iRow, LIST_TYPE, strType);
 		listView_.SetText(iRow, LIST_NAME, PathProperty::GetFileName(path));
 		listView_.SetText(iRow, LIST_ARCHIVE, archive);
 		listView_.SetText(iRow, LIST_PATH, path);
 		listView_.SetText(iRow, LIST_TEXT, info->GetText());
 	}
-
 }
 bool PlayerSelectDialog::_IsValidScript(ref_count_ptr<ScriptInformation> info)
 {
 	int type = combo_.GetSelectedIndex();
 	int typeScript = info->GetType();
 	bool bTarget = false;
-	switch(type)
-	{
-		case INDEX_PLAYER:
-			bTarget = (typeScript == ScriptInformation::TYPE_PLAYER);
-			break;
+	switch (type) {
+	case INDEX_PLAYER:
+		bTarget = (typeScript == ScriptInformation::TYPE_PLAYER);
+		break;
 	}
 
 	return bTarget;
 }
-
-

--- a/source/TouhouDanmakufu/DnhViewer/ScriptSelect.hpp
+++ b/source/TouhouDanmakufu/DnhViewer/ScriptSelect.hpp
@@ -1,85 +1,86 @@
 #ifndef __TOUHOUDANMAKUFU_VIEW_SCRIPTSELECT__
 #define __TOUHOUDANMAKUFU_VIEW_SCRIPTSELECT__
 
-#include"Constant.hpp"
-#include"Common.hpp"
+#include "Common.hpp"
+#include "Constant.hpp"
 
 /**********************************************************
 //ScriptSelectDialog
 **********************************************************/
-class ScriptSelectDialog : public ModalDialog
-{
-	protected:
-		const static std::wstring KEY_ALL;
-		const static std::wstring KEY_SINGLE;
-		const static std::wstring KEY_PLURAL;
-		const static std::wstring KEY_STAGE;
-		const static std::wstring KEY_PACKAGE;
-		const static std::wstring KEY_PLAYER;
+class ScriptSelectDialog : public ModalDialog {
+protected:
+	const static std::wstring KEY_ALL;
+	const static std::wstring KEY_SINGLE;
+	const static std::wstring KEY_PLURAL;
+	const static std::wstring KEY_STAGE;
+	const static std::wstring KEY_PACKAGE;
+	const static std::wstring KEY_PLAYER;
 
-		enum
-		{
-			LIST_TYPE,
-			LIST_NAME,
-			LIST_PATH,
-			LIST_ARCHIVE,
-			LIST_TEXT,
-		};
+	enum {
+		LIST_TYPE,
+		LIST_NAME,
+		LIST_PATH,
+		LIST_ARCHIVE,
+		LIST_TEXT,
+	};
 
-	protected:
-		WListView listView_;
-		WButton buttonOk_;
-		WButton buttonCancel_;
-		WComboBox combo_;
+public:
+	virtual void Initialize();
+	virtual void ShowModal(std::wstring path);
 
-		std::vector<ref_count_ptr<ScriptInformation> > listInfo_;
-		ref_count_ptr<ScriptInformation> infoSelected_;
+	ref_count_ptr<ScriptInformation> GetSelectedScript() { return infoSelected_; }
 
-		virtual bool _IsValidScript(ref_count_ptr<ScriptInformation> info){return NULL;}
-		void _SearchScript(std::wstring dir);
-		virtual void _Filter(){}
-		virtual LRESULT _WindowProcedure(HWND hWnd,UINT uMsg,WPARAM wParam,LPARAM lParam);
-	public:
-		virtual void Initialize();
-		virtual void ShowModal(std::wstring path);
+protected:
+	virtual bool _IsValidScript(ref_count_ptr<ScriptInformation> info) { return NULL; }
+	void _SearchScript(std::wstring dir);
+	virtual void _Filter() {}
+	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-		ref_count_ptr<ScriptInformation> GetSelectedScript(){return infoSelected_;}
+	WListView listView_;
+	WButton buttonOk_;
+	WButton buttonCancel_;
+	WComboBox combo_;
+
+	std::vector<ref_count_ptr<ScriptInformation>> listInfo_;
+	ref_count_ptr<ScriptInformation> infoSelected_;
 };
 
 /**********************************************************
 //EnemySelectDialog
 **********************************************************/
-class EnemySelectDialog : public ScriptSelectDialog
-{
-		enum
-		{
-			INDEX_ALL = 0,
-			INDEX_SINGLE,
-			INDEX_PLURAL,
-			INDEX_STAGE,
-			INDEX_PACKAGE,
-		};
-		virtual void _Filter();
-		virtual bool _IsValidScript(ref_count_ptr<ScriptInformation> info);
-	public:
-		EnemySelectDialog();
-		void Initialize();
+class EnemySelectDialog : public ScriptSelectDialog {
+	enum {
+		INDEX_ALL = 0,
+		INDEX_SINGLE,
+		INDEX_PLURAL,
+		INDEX_STAGE,
+		INDEX_PACKAGE,
+	};
+
+public:
+	EnemySelectDialog();
+	void Initialize();
+
+private:
+	virtual void _Filter();
+	virtual bool _IsValidScript(ref_count_ptr<ScriptInformation> info);
 };
 
 /**********************************************************
 //PlayerSelectDialog
 **********************************************************/
-class PlayerSelectDialog : public ScriptSelectDialog
-{
-		enum
-		{
-			INDEX_PLAYER = 0,
-		};
-		virtual void _Filter();
-		virtual bool _IsValidScript(ref_count_ptr<ScriptInformation> info);
-	public:
-		PlayerSelectDialog();
-		void Initialize();
+class PlayerSelectDialog : public ScriptSelectDialog {
+	enum {
+		INDEX_PLAYER = 0,
+	};
+
+public:
+	PlayerSelectDialog();
+	void Initialize();
+
+private:
+	virtual void _Filter();
+	virtual bool _IsValidScript(ref_count_ptr<ScriptInformation> info);
 };
 
 #endif

--- a/source/TouhouDanmakufu/DnhViewer/WinMain.cpp
+++ b/source/TouhouDanmakufu/DnhViewer/WinMain.cpp
@@ -1,19 +1,17 @@
-#include"GcLibImpl.hpp"
-#include"MainWindow.hpp"
-
+#include "GcLibImpl.hpp"
+#include "MainWindow.hpp"
 
 /**********************************************************
 WinMain
 **********************************************************/
 int APIENTRY wWinMain(HINSTANCE hInstance,
-                        HINSTANCE hPrevInstance,
-                        LPWSTR lpCmdLine,
-                        int nCmdShow )
+	HINSTANCE hPrevInstance,
+	LPWSTR lpCmdLine,
+	int nCmdShow)
 {
 	gstd::DebugUtility::DumpMemoryLeaksOnExit();
 
-	try
-	{
+	try {
 		DnhConfiguration* config = DnhConfiguration::CreateInstance();
 		ELogger* logger = ELogger::CreateInstance();
 		logger->Initialize(config->IsLogFile(), config->IsLogWindow());
@@ -24,20 +22,15 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
 		EApplication* app = EApplication::CreateInstance();
 		app->Initialize();
 		app->Run();
-	}
-	catch(std::exception& e)
-	{
+	} catch (std::exception& e) {
 		std::wstring log = StringUtility::ConvertMultiToWide(e.what());
 		Logger::WriteTop(log);
-	}
-	catch(gstd::wexception& e)
-	{
+	} catch (gstd::wexception& e) {
 		Logger::WriteTop(e.what());
 	}
-//	catch(...)
-//	{
-//		Logger::WriteTop("不明なエラー");
-//	}
+	// catch(...) {
+	// 	Logger::WriteTop("不明なエラー");
+	// }
 
 	EApplication::DeleteInstance();
 	MainWindow::DeleteInstance();
@@ -47,4 +40,3 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
 
 	return 0;
 }
-


### PR DESCRIPTION
Currently the source code looks quite messy. Lack of spaces and/or tabs overuse, no newline wraps on if(...)do; statements etc.

In order to make it at least a bit more readable, I parsed it through clang-format, integrated with VS Code. Style is based on WebKit. Used it because function brackets are pushed into new line, but the rest of them remains in the same line, especially classes. One can then easily distinguish between them. Exact style used: `{ BasedOnStyle: WebKit, UseTab: Always, IndentWidth: 4, TabWidth: 4 }`

There's a lot of work to do in that matter - CppCheck and clang-tidy shall catch a bunch of performance and style bugs. It's the best I can do right now, feel free to comment on PR, style used or so, if necessary.