### PR TITLE
Applying const-correctness and C++11 readability features

### DIFF
--- a/source/GcLib/directx/DirectGraphics.cpp
+++ b/source/GcLib/directx/DirectGraphics.cpp
@@ -20,21 +20,19 @@ DirectGraphicsConfig::DirectGraphicsConfig()
 	bUseWaitTimer_ = false;
 	bPseudoFullScreen_ = true;
 }
-DirectGraphicsConfig::~DirectGraphicsConfig()
-{
-}
+DirectGraphicsConfig::~DirectGraphicsConfig() = default;
 
 /**********************************************************
 //DirectGraphics
 **********************************************************/
-DirectGraphics* DirectGraphics::thisBase_ = NULL;
+DirectGraphics* DirectGraphics::thisBase_ = nullptr;
 
 DirectGraphics::DirectGraphics()
 {
-	pDirect3D_ = NULL;
-	pDevice_ = NULL;
-	pBackSurf_ = NULL;
-	pZBuffer_ = NULL;
+	pDirect3D_ = nullptr;
+	pDevice_ = nullptr;
+	pBackSurf_ = nullptr;
+	pZBuffer_ = nullptr;
 	camera_ = new DxCamera();
 	camera2D_ = new DxCamera2D();
 }
@@ -42,15 +40,15 @@ DirectGraphics::~DirectGraphics()
 {
 	Logger::WriteTop(L"DirectGraphics：終了開始");
 
-	if (pZBuffer_ != NULL)
+	if (pZBuffer_ != nullptr)
 		pZBuffer_->Release();
-	if (pBackSurf_ != NULL)
+	if (pBackSurf_ != nullptr)
 		pBackSurf_->Release();
-	if (pDevice_ != NULL)
+	if (pDevice_ != nullptr)
 		pDevice_->Release();
-	if (pDirect3D_ != NULL)
+	if (pDirect3D_ != nullptr)
 		pDirect3D_->Release();
-	thisBase_ = NULL;
+	thisBase_ = nullptr;
 	Logger::WriteTop(L"DirectGraphics：終了完了");
 }
 bool DirectGraphics::Initialize(HWND hWnd)
@@ -59,12 +57,12 @@ bool DirectGraphics::Initialize(HWND hWnd)
 }
 bool DirectGraphics::Initialize(HWND hWnd, DirectGraphicsConfig& config)
 {
-	if (thisBase_ != NULL)
+	if (thisBase_ != nullptr)
 		return false;
 
 	Logger::WriteTop(L"DirectGraphics：初期化");
 	pDirect3D_ = Direct3DCreate9(D3D_SDK_VERSION);
-	if (pDirect3D_ == NULL)
+	if (pDirect3D_ == nullptr)
 		throw gstd::wexception(L"Direct3DCreate9失敗");
 
 	config_ = config;
@@ -87,7 +85,7 @@ bool DirectGraphics::Initialize(HWND hWnd, DirectGraphicsConfig& config)
 		d3dppFull_.BackBufferCount = 1;
 	else
 		d3dppFull_.BackBufferCount = 2;
-	if (config_.IsWaitTimerEnable() == false)
+	if (!config_.IsWaitTimerEnable())
 		d3dppFull_.FullScreen_RefreshRateInHz = 60;
 	d3dppFull_.EnableAutoDepthStencil = TRUE;
 	d3dppFull_.AutoDepthStencilFormat = D3DFMT_D16;
@@ -161,7 +159,7 @@ bool DirectGraphics::Initialize(HWND hWnd, DirectGraphicsConfig& config)
 
 	thisBase_ = this;
 
-	if (camera2D_ != NULL)
+	if (camera2D_ != nullptr)
 		camera2D_->Reset();
 	_InitializeDeviceState();
 
@@ -174,23 +172,21 @@ bool DirectGraphics::Initialize(HWND hWnd, DirectGraphicsConfig& config)
 
 void DirectGraphics::_ReleaseDxResource()
 {
-	if (pZBuffer_ != NULL)
+	if (pZBuffer_ != nullptr)
 		pZBuffer_->Release();
-	if (pBackSurf_ != NULL)
+	if (pBackSurf_ != nullptr)
 		pBackSurf_->Release();
-	std::list<DirectGraphicsListener*>::iterator itr;
-	for (itr = listListener_.begin(); itr != listListener_.end(); itr++) {
-		(*itr)->ReleaseDirectGraphics();
-	}
+
+	for (auto& listener : listListener_)
+		listener->ReleaseDirectGraphics();
 }
 void DirectGraphics::_RestoreDxResource()
 {
 	pDevice_->GetRenderTarget(0, &pBackSurf_);
 	pDevice_->GetDepthStencilSurface(&pZBuffer_);
-	std::list<DirectGraphicsListener*>::iterator itr;
-	for (itr = listListener_.begin(); itr != listListener_.end(); itr++) {
-		(*itr)->RestoreDirectGraphics();
-	}
+
+	for (auto& listener : listListener_)
+		listener->RestoreDirectGraphics();
 	_InitializeDeviceState();
 }
 void DirectGraphics::_Restore()
@@ -226,7 +222,7 @@ void DirectGraphics::_InitializeDeviceState()
 {
 	D3DXMATRIX viewMat;
 	D3DXMATRIX persMat;
-	if (camera_ != NULL) {
+	if (camera_ != nullptr) {
 		camera_->UpdateDeviceWorldViewMatrix();
 	} else {
 		D3DVECTOR viewFrom = D3DXVECTOR3(100, 300, -500);
@@ -266,8 +262,7 @@ void DirectGraphics::_InitializeDeviceState()
 }
 void DirectGraphics::AddDirectGraphicsListener(DirectGraphicsListener* listener)
 {
-	std::list<DirectGraphicsListener*>::iterator itr;
-	for (itr = listListener_.begin(); itr != listListener_.end(); itr++) {
+	for (auto itr = listListener_.begin(); itr != listListener_.end(); ++itr) {
 		if ((*itr) == listener)
 			return;
 	}
@@ -275,8 +270,7 @@ void DirectGraphics::AddDirectGraphicsListener(DirectGraphicsListener* listener)
 }
 void DirectGraphics::RemoveDirectGraphicsListener(DirectGraphicsListener* listener)
 {
-	std::list<DirectGraphicsListener*>::iterator itr;
-	for (itr = listListener_.begin(); itr != listListener_.end(); itr++) {
+	for (auto itr = listListener_.begin(); itr != listListener_.end(); ++itr) {
 		if ((*itr) != listener)
 			continue;
 		listListener_.erase(itr);
@@ -294,7 +288,7 @@ void DirectGraphics::EndScene()
 {
 	pDevice_->EndScene();
 
-	HRESULT hr = pDevice_->Present(NULL, NULL, NULL, NULL);
+	HRESULT hr = pDevice_->Present(nullptr, nullptr, nullptr, nullptr);
 	if (FAILED(hr)) {
 		_Restore();
 		_InitializeDeviceState();
@@ -305,16 +299,16 @@ void DirectGraphics::ClearRenderTarget()
 	int width = GetScreenWidth();
 	int height = GetScreenWidth();
 	D3DRECT rcDest = { 0, 0, width, height };
-	if (textureTarget_ == NULL) {
-		pDevice_->Clear(0, NULL, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0, 0, 0), 1.0, 0);
+	if (textureTarget_ == nullptr) {
+		pDevice_->Clear(0, nullptr, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0, 0, 0), 1.0, 0);
 	} else {
-		pDevice_->Clear(0, NULL, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER, D3DCOLOR_ARGB(0, 0, 0, 0), 1.0, 0);
+		pDevice_->Clear(0, nullptr, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER, D3DCOLOR_ARGB(0, 0, 0, 0), 1.0, 0);
 	}
 }
 void DirectGraphics::ClearRenderTarget(RECT rect)
 {
 	D3DRECT rcDest = { rect.left, rect.top, rect.right, rect.bottom };
-	if (textureTarget_ == NULL) {
+	if (textureTarget_ == nullptr) {
 		pDevice_->Clear(1, &rcDest, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0, 0, 0), 1.0, 0);
 	} else {
 		pDevice_->Clear(1, &rcDest, D3DCLEAR_TARGET | D3DCLEAR_ZBUFFER, D3DCOLOR_ARGB(0, 0, 0, 0), 1.0, 0);
@@ -323,7 +317,7 @@ void DirectGraphics::ClearRenderTarget(RECT rect)
 void DirectGraphics::SetRenderTarget(gstd::ref_count_ptr<Texture> texture)
 {
 	textureTarget_ = texture;
-	if (texture == NULL) {
+	if (texture == nullptr) {
 		pDevice_->SetRenderTarget(0, pBackSurf_);
 		pDevice_->SetDepthStencilSurface(pZBuffer_);
 	} else {
@@ -334,11 +328,11 @@ void DirectGraphics::SetRenderTarget(gstd::ref_count_ptr<Texture> texture)
 }
 void DirectGraphics::SetLightingEnable(bool bEnable)
 {
-	pDevice_->SetRenderState(D3DRS_LIGHTING, bEnable);
+	pDevice_->SetRenderState(D3DRS_LIGHTING, static_cast<DWORD>(bEnable));
 }
 void DirectGraphics::SetSpecularEnable(bool bEnable)
 {
-	pDevice_->SetRenderState(D3DRS_SPECULARENABLE, bEnable);
+	pDevice_->SetRenderState(D3DRS_SPECULARENABLE, static_cast<DWORD>(bEnable));
 }
 void DirectGraphics::SetCullingMode(DWORD mode)
 {
@@ -350,15 +344,15 @@ void DirectGraphics::SetShadingMode(DWORD mode)
 }
 void DirectGraphics::SetZBufferEnable(bool bEnable)
 {
-	pDevice_->SetRenderState(D3DRS_ZENABLE, bEnable);
+	pDevice_->SetRenderState(D3DRS_ZENABLE, static_cast<DWORD>(bEnable));
 }
 void DirectGraphics::SetZWriteEnalbe(bool bEnable)
 {
-	pDevice_->SetRenderState(D3DRS_ZWRITEENABLE, bEnable);
+	pDevice_->SetRenderState(D3DRS_ZWRITEENABLE, static_cast<DWORD>(bEnable));
 }
 void DirectGraphics::SetAlphaTest(bool bEnable, DWORD ref, D3DCMPFUNC func)
 {
-	pDevice_->SetRenderState(D3DRS_ALPHATESTENABLE, bEnable);
+	pDevice_->SetRenderState(D3DRS_ALPHATESTENABLE, static_cast<DWORD>(bEnable));
 	if (bEnable) {
 		pDevice_->SetRenderState(D3DRS_ALPHAFUNC, func);
 		pDevice_->SetRenderState(D3DRS_ALPHAREF, ref);
@@ -549,12 +543,12 @@ void DirectGraphics::SetDirectionalLight(D3DVECTOR& dir)
 	D3DLIGHT9 light;
 	ZeroMemory(&light, sizeof(D3DLIGHT9));
 	light.Type = D3DLIGHT_DIRECTIONAL;
-	light.Diffuse.r = 0.5f;
-	light.Diffuse.g = 0.5f;
-	light.Diffuse.b = 0.5f;
-	light.Ambient.r = 0.5f;
-	light.Ambient.g = 0.5f;
-	light.Ambient.b = 0.5f;
+	light.Diffuse.r = 0.5F;
+	light.Diffuse.g = 0.5F;
+	light.Diffuse.b = 0.5F;
+	light.Ambient.r = 0.5F;
+	light.Ambient.g = 0.5F;
+	light.Ambient.b = 0.5F;
 	light.Direction = dir;
 	pDevice_->SetLight(0, &light);
 	pDevice_->LightEnable(0, TRUE);
@@ -567,8 +561,8 @@ void DirectGraphics::SetViewPort(int x, int y, int width, int height)
 	viewPort.Y = y;
 	viewPort.Width = width;
 	viewPort.Height = height;
-	viewPort.MinZ = 0.0f;
-	viewPort.MaxZ = 1.0f;
+	viewPort.MinZ = 0.0F;
+	viewPort.MaxZ = 1.0F;
 	pDevice_->SetViewport(&viewPort);
 }
 void DirectGraphics::ResetViewPort()
@@ -631,10 +625,10 @@ POINT DirectGraphics::GetMousePosition() const
 void DirectGraphics::SaveBackSurfaceToFile(const std::wstring& path)
 {
 	RECT rect = { 0, 0, config_.GetScreenWidth(), config_.GetScreenHeight() };
-	LPDIRECT3DSURFACE9 pBackSurface = NULL;
+	LPDIRECT3DSURFACE9 pBackSurface = nullptr;
 	pDevice_->GetRenderTarget(0, &pBackSurface);
 	D3DXSaveSurfaceToFile(path.c_str(), D3DXIFF_BMP,
-		pBackSurface, NULL, &rect);
+		pBackSurface, nullptr, &rect);
 	pBackSurface->Release();
 }
 bool DirectGraphics::IsPixelShaderSupported(int major, int minor) const
@@ -648,19 +642,16 @@ bool DirectGraphics::IsPixelShaderSupported(int major, int minor) const
 /**********************************************************
 //DirectGraphicsPrimaryWindow
 **********************************************************/
-DirectGraphicsPrimaryWindow::DirectGraphicsPrimaryWindow()
-{
-}
-DirectGraphicsPrimaryWindow::~DirectGraphicsPrimaryWindow()
-{
-}
+DirectGraphicsPrimaryWindow::DirectGraphicsPrimaryWindow() = default;
+DirectGraphicsPrimaryWindow::~DirectGraphicsPrimaryWindow() = default;
+
 void DirectGraphicsPrimaryWindow::_PauseDrawing()
 {
 	//	gstd::Application::GetBase()->SetActive(false);
 	// ウインドウのメニューバーを描画する
 	::DrawMenuBar(hWnd_);
 	// ウインドウのフレームを描画する
-	::RedrawWindow(hWnd_, NULL, NULL, RDW_FRAME);
+	::RedrawWindow(hWnd_, nullptr, nullptr, RDW_FRAME);
 }
 void DirectGraphicsPrimaryWindow::_RestartDrawing()
 {
@@ -673,7 +664,7 @@ bool DirectGraphicsPrimaryWindow::Initialize()
 }
 bool DirectGraphicsPrimaryWindow::Initialize(DirectGraphicsConfig& config)
 {
-	HINSTANCE hInst = ::GetModuleHandle(NULL);
+	HINSTANCE hInst = ::GetModuleHandle(nullptr);
 	{
 		std::wstring nameClass = L"DirectGraphicsPrimaryWindow";
 		WNDCLASSEX wcex;
@@ -682,12 +673,12 @@ bool DirectGraphicsPrimaryWindow::Initialize(DirectGraphicsConfig& config)
 		// wcex.style=CS_HREDRAW|CS_VREDRAW;
 		wcex.lpfnWndProc = (WNDPROC)WindowBase::_StaticWindowProcedure;
 		wcex.hInstance = hInst;
-		wcex.hIcon = NULL;
-		wcex.hCursor = LoadCursor(NULL, IDC_ARROW);
+		wcex.hIcon = nullptr;
+		wcex.hCursor = LoadCursor(nullptr, IDC_ARROW);
 		wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW + 5);
-		wcex.lpszMenuName = NULL;
+		wcex.lpszMenuName = nullptr;
 		wcex.lpszClassName = nameClass.c_str();
-		wcex.hIconSm = NULL;
+		wcex.hIconSm = nullptr;
 		::RegisterClassEx(&wcex);
 
 		int wWidth = config.GetScreenWidth();
@@ -700,10 +691,10 @@ bool DirectGraphicsPrimaryWindow::Initialize(DirectGraphicsConfig& config)
 		hWnd_ = ::CreateWindow(wcex.lpszClassName,
 			L"",
 			WS_OVERLAPPEDWINDOW - WS_SIZEBOX,
-			0, 0, wWidth, wHeight, NULL, NULL, hInst, NULL);
+			0, 0, wWidth, wHeight, nullptr, nullptr, hInst, nullptr);
 	}
 
-	HWND hWndGraphics = NULL;
+	HWND hWndGraphics = nullptr;
 	if (config.IsPseudoFullScreen()) {
 		//擬似フルスクリーンの場合は、子ウィンドウにDirectGraphicsを配置する
 		std::wstring nameClass = L"DirectGraphicsPrimaryWindow.Child";
@@ -713,7 +704,7 @@ bool DirectGraphicsPrimaryWindow::Initialize(DirectGraphicsConfig& config)
 		wcex.style = CS_HREDRAW | CS_VREDRAW;
 		wcex.lpfnWndProc = (WNDPROC)WindowBase::_StaticWindowProcedure;
 		wcex.hInstance = hInst;
-		wcex.hCursor = LoadCursor(NULL, IDC_ARROW);
+		wcex.hCursor = LoadCursor(nullptr, IDC_ARROW);
 		wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW + 5);
 		wcex.lpszClassName = nameClass.c_str();
 		::RegisterClassEx(&wcex);
@@ -723,7 +714,7 @@ bool DirectGraphicsPrimaryWindow::Initialize(DirectGraphicsConfig& config)
 		HWND hWnd = ::CreateWindow(wcex.lpszClassName,
 			L"",
 			WS_CHILD | WS_VISIBLE,
-			0, 0, screenWidth, screenHeight, hWnd_, NULL, hInst, NULL);
+			0, 0, screenWidth, screenHeight, hWnd_, nullptr, hInst, nullptr);
 		wndGraphics_.Attach(hWnd);
 
 		hWndGraphics = hWnd;
@@ -736,7 +727,8 @@ bool DirectGraphicsPrimaryWindow::Initialize(DirectGraphicsConfig& config)
 	this->Attach(hWnd_);
 
 	//Windowを画面の中央に移動
-	RECT drect, mrect;
+	RECT drect;
+	RECT mrect;
 	HWND hDesk = ::GetDesktopWindow();
 	::GetWindowRect(hDesk, &drect);
 	::GetWindowRect(hWnd_, &mrect);
@@ -763,7 +755,7 @@ LRESULT DirectGraphicsPrimaryWindow::_WindowProcedure(HWND hWnd, UINT uMsg, WPAR
 		return FALSE;
 	}
 	case WM_ACTIVATEAPP: {
-		if ((BOOL)wParam)
+		if ((BOOL)wParam != 0)
 			_RestartDrawing();
 		else
 			_PauseDrawing();
@@ -780,7 +772,7 @@ LRESULT DirectGraphicsPrimaryWindow::_WindowProcedure(HWND hWnd, UINT uMsg, WPAR
 		return FALSE;
 	}
 	case WM_SIZE: {
-		if (wndGraphics_.GetWindowHandle() != NULL) {
+		if (wndGraphics_.GetWindowHandle() != nullptr) {
 			RECT rect;
 			::GetClientRect(hWnd, &rect);
 			int width = rect.right;
@@ -809,7 +801,7 @@ LRESULT DirectGraphicsPrimaryWindow::_WindowProcedure(HWND hWnd, UINT uMsg, WPAR
 		int tw = ::GetSystemMetrics(SM_CXEDGE) + 10 + GetSystemMetrics(SM_CXBORDER) + GetSystemMetrics(SM_CXDLGFRAME);
 		int th = ::GetSystemMetrics(SM_CYEDGE) + 10 + GetSystemMetrics(SM_CYBORDER) + GetSystemMetrics(SM_CYDLGFRAME) + GetSystemMetrics(SM_CYCAPTION);
 
-		MINMAXINFO* info = (MINMAXINFO*)lParam;
+		auto* info = (MINMAXINFO*)lParam;
 		int wWidth = ::GetSystemMetrics(SM_CXFULLSCREEN);
 		int wHeight = ::GetSystemMetrics(SM_CYFULLSCREEN);
 
@@ -879,7 +871,8 @@ void DirectGraphicsPrimaryWindow::ChangeScreenMode()
 			//Windowを画面の中央に移動
 			int tw = ::GetSystemMetrics(SM_CXEDGE) + 10 + GetSystemMetrics(SM_CXBORDER) + GetSystemMetrics(SM_CXDLGFRAME);
 			int th = ::GetSystemMetrics(SM_CYEDGE) + 10 + GetSystemMetrics(SM_CYBORDER) + GetSystemMetrics(SM_CYDLGFRAME) + GetSystemMetrics(SM_CYCAPTION);
-			RECT drect, mrect;
+			RECT drect;
+			RECT mrect;
 			HWND hDesk = ::GetDesktopWindow();
 			::GetWindowRect(hDesk, &drect);
 			::GetWindowRect(hAttachedWindow_, &mrect);
@@ -957,9 +950,8 @@ DxCamera::DxCamera()
 {
 	Reset();
 }
-DxCamera::~DxCamera()
-{
-}
+DxCamera::~DxCamera() = default;
+
 void DxCamera::Reset()
 {
 	radius_ = 500;
@@ -992,7 +984,7 @@ D3DXMATRIX DxCamera::GetMatrixLookAtLH()
 
 	D3DXVECTOR3 vCameraUp(0, 1, 0);
 	{
-		D3DXQUATERNION qRot(0, 0, 0, 1.0f);
+		D3DXQUATERNION qRot(0, 0, 0, 1.0F);
 		D3DXQuaternionRotationYawPitchRoll(&qRot,
 			Math::DegreeToRadian(yaw_), Math::DegreeToRadian(pitch_), Math::DegreeToRadian(roll_));
 		D3DXMATRIX matRot;
@@ -1009,7 +1001,7 @@ D3DXMATRIX DxCamera::GetMatrixLookAtLH()
 
 		float pitch = pitch_;
 
-		D3DXQUATERNION qRot(0, 0, 0, 1.0f);
+		D3DXQUATERNION qRot(0, 0, 0, 1.0F);
 		D3DXQuaternionRotationYawPitchRoll(&qRot,
 			Math::DegreeToRadian(yaw_), Math::DegreeToRadian(pitch_), Math::DegreeToRadian(0));
 		D3DXMATRIX matRot;
@@ -1026,7 +1018,7 @@ D3DXMATRIX DxCamera::GetMatrixLookAtLH()
 void DxCamera::UpdateDeviceWorldViewMatrix()
 {
 	DirectGraphics* graph = DirectGraphics::GetBase();
-	if (graph == NULL)
+	if (graph == nullptr)
 		return;
 	IDirect3DDevice9* device = graph->GetDevice();
 
@@ -1036,7 +1028,7 @@ void DxCamera::UpdateDeviceWorldViewMatrix()
 void DxCamera::SetProjectionMatrix(float width, float height, float posNear, float posFar)
 {
 	DirectGraphics* graph = DirectGraphics::GetBase();
-	if (graph == NULL)
+	if (graph == nullptr)
 		return;
 	IDirect3DDevice9* device = graph->GetDevice();
 
@@ -1066,7 +1058,7 @@ void DxCamera::SetProjectionMatrix(float width, float height, float posNear, flo
 void DxCamera::UpdateDeviceProjectionMatrix()
 {
 	DirectGraphics* graph = DirectGraphics::GetBase();
-	if (graph == NULL)
+	if (graph == nullptr)
 		return;
 	IDirect3DDevice9* device = graph->GetDevice();
 	device->SetTransform(D3DTS_PROJECTION, &matProjection_);
@@ -1120,15 +1112,14 @@ DxCamera2D::DxCamera2D()
 	angleZ_ = 0;
 	bEnable_ = false;
 }
-DxCamera2D::~DxCamera2D()
-{
-}
+DxCamera2D::~DxCamera2D() = default;
+
 void DxCamera2D::Reset()
 {
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	int width = graphics->GetScreenWidth();
 	int height = graphics->GetScreenHeight();
-	if (posReset_ == NULL) {
+	if (posReset_ == nullptr) {
 		pos_.x = width / 2;
 		pos_.y = height / 2;
 	} else {

--- a/source/GcLib/directx/DirectGraphics.cpp
+++ b/source/GcLib/directx/DirectGraphics.cpp
@@ -575,15 +575,15 @@ void DirectGraphics::ResetViewPort()
 {
 	SetViewPort(0, 0, GetScreenWidth(), GetScreenHeight());
 }
-int DirectGraphics::GetScreenWidth()
+int DirectGraphics::GetScreenWidth() const
 {
 	return config_.GetScreenWidth();
 }
-int DirectGraphics::GetScreenHeight()
+int DirectGraphics::GetScreenHeight() const
 {
 	return config_.GetScreenHeight();
 }
-double DirectGraphics::GetScreenWidthRatio()
+double DirectGraphics::GetScreenWidthRatio() const
 {
 	RECT rect;
 	::GetWindowRect(hAttachedWindow_, &rect);
@@ -597,7 +597,7 @@ double DirectGraphics::GetScreenWidthRatio()
 
 	return widthWindow / widthView;
 }
-double DirectGraphics::GetScreenHeightRatio()
+double DirectGraphics::GetScreenHeightRatio() const
 {
 	RECT rect;
 	::GetWindowRect(hAttachedWindow_, &rect);
@@ -611,7 +611,7 @@ double DirectGraphics::GetScreenHeightRatio()
 
 	return heightWindow / heightView;
 }
-POINT DirectGraphics::GetMousePosition()
+POINT DirectGraphics::GetMousePosition() const
 {
 	POINT res = { 0, 0 };
 	GetCursorPos(&res);
@@ -628,7 +628,7 @@ POINT DirectGraphics::GetMousePosition()
 
 	return res;
 }
-void DirectGraphics::SaveBackSurfaceToFile(std::wstring path)
+void DirectGraphics::SaveBackSurfaceToFile(const std::wstring& path)
 {
 	RECT rect = { 0, 0, config_.GetScreenWidth(), config_.GetScreenHeight() };
 	LPDIRECT3DSURFACE9 pBackSurface = NULL;
@@ -637,7 +637,7 @@ void DirectGraphics::SaveBackSurfaceToFile(std::wstring path)
 		pBackSurface, NULL, &rect);
 	pBackSurface->Release();
 }
-bool DirectGraphics::IsPixelShaderSupported(int major, int minor)
+bool DirectGraphics::IsPixelShaderSupported(int major, int minor) const
 {
 	D3DCAPS9 caps;
 	pDevice_->GetDeviceCaps(&caps);
@@ -977,7 +977,7 @@ void DxCamera::Reset()
 	clipFar_ = 2000;
 }
 
-D3DXVECTOR3 DxCamera::GetCameraPosition()
+D3DXVECTOR3 DxCamera::GetCameraPosition() const
 {
 	D3DXVECTOR3 res;
 	res.x = pos_.x + (float)(radius_ * cos(D3DXToRadian(angleElevation_)) * cos(D3DXToRadian(angleAzimuth_)));

--- a/source/GcLib/directx/DirectGraphics.hpp
+++ b/source/GcLib/directx/DirectGraphics.hpp
@@ -54,7 +54,7 @@ protected:
 
 class DirectGraphicsListener {
 public:
-	virtual ~DirectGraphicsListener() {}
+	virtual ~DirectGraphicsListener() = default;
 	virtual void ReleaseDirectGraphics() {}
 	virtual void RestoreDirectGraphics() {}
 	virtual void StartChangeScreenMode() { ReleaseDirectGraphics(); }
@@ -172,14 +172,14 @@ protected:
 class DirectGraphicsPrimaryWindow : public DirectGraphics, public gstd::WindowBase {
 public:
 	DirectGraphicsPrimaryWindow();
-	~DirectGraphicsPrimaryWindow();
+	~DirectGraphicsPrimaryWindow() override;
 	virtual bool Initialize();
 	virtual bool Initialize(DirectGraphicsConfig& config);
 	void ChangeScreenMode();
 
 protected:
 	gstd::WindowBase wndGraphics_;
-	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam); //オーバーライド用プロシージャ
+	LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override; //オーバーライド用プロシージャ
 	void _PauseDrawing();
 	void _RestartDrawing();
 };

--- a/source/GcLib/directx/DirectGraphics.hpp
+++ b/source/GcLib/directx/DirectGraphics.hpp
@@ -21,23 +21,23 @@ public:
 public:
 	DirectGraphicsConfig();
 	virtual ~DirectGraphicsConfig();
-	bool IsShowWindow() { return bShowWindow_; }
+	bool IsShowWindow() const { return bShowWindow_; }
 	void SetShowWindow(bool b) { bShowWindow_ = b; }
-	int GetScreenWidth() { return widthScreen_; }
+	int GetScreenWidth() const { return widthScreen_; }
 	void SetScreenWidth(int width) { widthScreen_ = width; }
-	int GetScreenHeight() { return heightScreen_; }
+	int GetScreenHeight() const { return heightScreen_; }
 	void SetScreenHeight(int height) { heightScreen_ = height; }
-	bool IsWindowed() { return bWindowed_; }
+	bool IsWindowed() const { return bWindowed_; }
 	void SetWindowd(bool bWindowed) { bWindowed_ = bWindowed; }
-	bool IsReferenceEnable() { return bUseRef_; }
+	bool IsReferenceEnable() const { return bUseRef_; }
 	void SetReferenceEnable(bool bEnable) { bUseRef_ = bEnable; }
-	int GetColorMode() { return colorMode_; }
+	int GetColorMode() const { return colorMode_; }
 	void SetColorMode(int mode) { colorMode_ = mode; }
-	bool IsTripleBufferEnable() { return bUseTripleBuffer_; }
+	bool IsTripleBufferEnable() const { return bUseTripleBuffer_; }
 	void SetTripleBufferEnable(bool bEnable) { bUseTripleBuffer_ = bEnable; }
-	bool IsWaitTimerEnable() { return bUseWaitTimer_; }
+	bool IsWaitTimerEnable() const { return bUseWaitTimer_; }
 	void SetWaitTimerEnable(bool bEnable) { bUseWaitTimer_ = bEnable; }
-	bool IsPseudoFullScreen() { return bPseudoFullScreen_; }
+	bool IsPseudoFullScreen() const { return bPseudoFullScreen_; }
 	void SetbPseudoFullScreen(bool b) { bPseudoFullScreen_ = b; }
 
 protected:
@@ -94,9 +94,9 @@ public:
 	virtual bool Initialize(HWND hWnd, DirectGraphicsConfig& config);
 	void AddDirectGraphicsListener(DirectGraphicsListener* listener);
 	void RemoveDirectGraphicsListener(DirectGraphicsListener* listener);
-	int GetScreenMode() { return modeScreen_; }
-	D3DPRESENT_PARAMETERS GetFullScreenPresentParameter() { return d3dppFull_; }
-	D3DPRESENT_PARAMETERS GetWindowPresentParameter() { return d3dppWin_; }
+	int GetScreenMode() const { return modeScreen_; }
+	D3DPRESENT_PARAMETERS GetFullScreenPresentParameter() const { return d3dppFull_; }
+	D3DPRESENT_PARAMETERS GetWindowPresentParameter() const { return d3dppWin_; }
 
 	IDirect3DDevice9* GetDevice() { return pDevice_; }
 	DirectGraphicsConfig& GetConfigData() { return config_; }
@@ -130,16 +130,16 @@ public:
 	void SetViewPort(int x, int y, int width, int height);
 	void ResetViewPort();
 
-	int GetScreenWidth();
-	int GetScreenHeight();
-	double GetScreenWidthRatio();
-	double GetScreenHeightRatio();
-	POINT GetMousePosition();
+	int GetScreenWidth() const;
+	int GetScreenHeight() const;
+	double GetScreenWidthRatio() const;
+	double GetScreenHeightRatio() const;
+	POINT GetMousePosition() const;
 	gstd::ref_count_ptr<DxCamera> GetCamera() { return camera_; }
 	gstd::ref_count_ptr<DxCamera2D> GetCamera2D() { return camera2D_; }
 
-	void SaveBackSurfaceToFile(std::wstring path);
-	bool IsPixelShaderSupported(int major, int minor);
+	void SaveBackSurfaceToFile(const std::wstring& path);
+	bool IsPixelShaderSupported(int major, int minor) const;
 
 protected:
 	IDirect3D9* pDirect3D_;
@@ -192,8 +192,8 @@ public:
 	DxCamera();
 	virtual ~DxCamera();
 	void Reset();
-	D3DXVECTOR3 GetCameraPosition();
-	D3DXVECTOR3 GetFocusPosition() { return pos_; }
+	D3DXVECTOR3 GetCameraPosition() const;
+	D3DXVECTOR3 GetFocusPosition() const { return pos_; }
 	void SetFocus(float x, float y, float z)
 	{
 		pos_.x = x;
@@ -203,22 +203,22 @@ public:
 	void SetFocusX(float x) { pos_.x = x; }
 	void SetFocusY(float y) { pos_.y = y; }
 	void SetFocusZ(float z) { pos_.z = z; }
-	float GetRadius() { return radius_; }
+	float GetRadius() const { return radius_; }
 	void SetRadius(float r) { radius_ = r; }
-	float GetAzimuthAngle() { return angleAzimuth_; }
+	float GetAzimuthAngle() const { return angleAzimuth_; }
 	void SetAzimuthAngle(float angle) { angleAzimuth_ = angle; }
-	float GetElevationAngle() { return angleElevation_; }
+	float GetElevationAngle() const { return angleElevation_; }
 	void SetElevationAngle(float angle) { angleElevation_ = angle; }
 
-	float GetYaw() { return yaw_; }
+	float GetYaw() const { return yaw_; }
 	void SetYaw(float yaw) { yaw_ = yaw; }
-	float GetPitch() { return pitch_; }
+	float GetPitch() const { return pitch_; }
 	void SetPitch(float pitch) { pitch_ = pitch; }
-	float GetRoll() { return roll_; }
+	float GetRoll() const { return roll_; }
 	void SetRoll(float roll) { roll_ = roll; }
 
-	double GetNearClip() { return clipNear_; }
-	double GetFarClip() { return clipFar_; }
+	double GetNearClip() const { return clipNear_; }
+	double GetFarClip() const { return clipFar_; }
 
 	D3DXMATRIX GetMatrixLookAtLH();
 	void UpdateDeviceWorldViewMatrix();
@@ -250,12 +250,12 @@ public:
 	DxCamera2D();
 	virtual ~DxCamera2D();
 
-	bool IsEnable() { return bEnable_; }
+	bool IsEnable() const { return bEnable_; }
 	void SetEnable(bool bEnable) { bEnable_ = bEnable; }
 
-	D3DXVECTOR2 GetFocusPosition() { return pos_; }
-	float GetFocusX() { return pos_.x; }
-	float GetFocusY() { return pos_.y; }
+	D3DXVECTOR2 GetFocusPosition() const { return pos_; }
+	float GetFocusX() const { return pos_.x; }
+	float GetFocusY() const { return pos_.y; }
 	void SetFocus(float x, float y)
 	{
 		pos_.x = x;
@@ -270,11 +270,11 @@ public:
 		ratioX_ = ratio;
 		ratioY_ = ratio;
 	}
-	double GetRatioX() { return ratioX_; }
+	double GetRatioX() const { return ratioX_; }
 	void SetRatioX(double ratio) { ratioX_ = ratio; }
-	double GetRatioY() { return ratioY_; }
+	double GetRatioY() const { return ratioY_; }
 	void SetRatioY(double ratio) { ratioY_ = ratio; }
-	double GetAngleZ() { return angleZ_; }
+	double GetAngleZ() const { return angleZ_; }
 	void SetAngleZ(double angle) { angleZ_ = angle; }
 
 	RECT GetClip() { return rcClip_; }

--- a/source/GcLib/directx/DirectInput.cpp
+++ b/source/GcLib/directx/DirectInput.cpp
@@ -6,50 +6,50 @@ using namespace directx;
 /**********************************************************
 //DirectInput
 **********************************************************/
-DirectInput* DirectInput::thisBase_ = NULL;
+DirectInput* DirectInput::thisBase_ = nullptr;
 DirectInput::DirectInput()
 {
-	hWnd_ = NULL;
-	pInput_ = NULL;
-	pKeyboard_ = NULL;
-	pMouse_ = NULL;
+	hWnd_ = nullptr;
+	pInput_ = nullptr;
+	pKeyboard_ = nullptr;
+	pMouse_ = nullptr;
 }
 DirectInput::~DirectInput()
 {
 	Logger::WriteTop(L"DirectInput：終了開始");
-	for (int iPad = 0; iPad < pJoypad_.size(); iPad++) {
-		if (pJoypad_[iPad] == NULL)
+	for (auto & iPad : pJoypad_) {
+		if (iPad == NULL)
 			continue;
-		pJoypad_[iPad]->Unacquire();
-		if (pJoypad_[iPad] != NULL)
-			pJoypad_[iPad]->Release();
+		iPad->Unacquire();
+		if (iPad != NULL)
+			iPad->Release();
 	}
 
-	if (pMouse_ != NULL) {
+	if (pMouse_ != nullptr) {
 		pMouse_->Unacquire();
 		pMouse_->Release();
 	}
 
-	if (pKeyboard_ != NULL) {
+	if (pKeyboard_ != nullptr) {
 		pKeyboard_->Unacquire();
 		pKeyboard_->Release();
 	}
 
-	if (pInput_ != NULL)
+	if (pInput_ != nullptr)
 		pInput_->Release();
-	thisBase_ = NULL;
+	thisBase_ = nullptr;
 	Logger::WriteTop(L"DirectInput：終了完了");
 }
 
 bool DirectInput::Initialize(HWND hWnd)
 {
-	if (thisBase_ != NULL)
+	if (thisBase_ != nullptr)
 		return false;
 	Logger::WriteTop(L"DirectInput：初期化");
 	hWnd_ = hWnd;
 
 	HINSTANCE hInst = ::GetModuleHandle(NULL);
-	HRESULT hrInput = DirectInput8Create(hInst, DIRECTINPUT_VERSION, IID_IDirectInput8, (void**)&pInput_, NULL);
+	HRESULT hrInput = DirectInput8Create(hInst, DIRECTINPUT_VERSION, IID_IDirectInput8, (void**)&pInput_, nullptr);
 	if (FAILED(hrInput)) {
 		Logger::WriteTop(L"DirectInput：DirectInput8Create失敗");
 		return false; // DirectInput8の作成に失敗
@@ -73,7 +73,7 @@ bool DirectInput::_InitializeKeyBoard()
 {
 	Logger::WriteTop(L"DirectIuput：キーボード初期化");
 
-	HRESULT hrDevice = pInput_->CreateDevice(GUID_SysKeyboard, &pKeyboard_, NULL);
+	HRESULT hrDevice = pInput_->CreateDevice(GUID_SysKeyboard, &pKeyboard_, nullptr);
 	if (FAILED(hrDevice)) {
 		Logger::WriteTop(L"DirectInput：キーボードのデバイスオブジェクト作成失敗");
 		return false;
@@ -102,7 +102,7 @@ bool DirectInput::_InitializeMouse()
 {
 	Logger::WriteTop(L"DirectIuput：マウス初期化");
 
-	HRESULT hrDevice = pInput_->CreateDevice(GUID_SysMouse, &pMouse_, NULL);
+	HRESULT hrDevice = pInput_->CreateDevice(GUID_SysMouse, &pMouse_, nullptr);
 	if (FAILED(hrDevice)) {
 		Logger::WriteTop(L"DirectInput：マウスのデバイスオブジェクト作成失敗");
 		return false;
@@ -147,14 +147,14 @@ bool DirectInput::_InitializeJoypad()
 }
 BOOL CALLBACK DirectInput::_GetJoypadStaticCallback(LPDIDEVICEINSTANCE lpddi, LPVOID pvRef)
 {
-	DirectInput* input = (DirectInput*)pvRef;
+	auto* input = (DirectInput*)pvRef;
 	return input->_GetJoypadCallback(lpddi);
 }
 BOOL DirectInput::_GetJoypadCallback(LPDIDEVICEINSTANCE lpddi)
 {
 	Logger::WriteTop(L"DirectInput：ジョイパッドを見つけました");
-	LPDIRECTINPUTDEVICE8 pJoypad = NULL;
-	HRESULT hrDevice = pInput_->CreateDevice(lpddi->guidInstance, &pJoypad, NULL);
+	LPDIRECTINPUTDEVICE8 pJoypad = nullptr;
+	HRESULT hrDevice = pInput_->CreateDevice(lpddi->guidInstance, &pJoypad, nullptr);
 	if (FAILED(hrDevice)) {
 		Logger::WriteTop(L"DirectInput：入力装置のデバイスオブジェクト作成失敗");
 		return DIENUM_CONTINUE;
@@ -173,7 +173,7 @@ BOOL DirectInput::_GetJoypadCallback(LPDIDEVICEINSTANCE lpddi)
 
 	HRESULT hrFormat = pJoypad->SetDataFormat(&c_dfDIJoystick);
 	if (FAILED(hrFormat)) {
-		if (pJoypad != NULL)
+		if (pJoypad != nullptr)
 			pJoypad->Release();
 		Logger::WriteTop(L"DirectInput：ジョイパッドのデータフォーマット設定失敗");
 		return DIENUM_CONTINUE;
@@ -181,7 +181,7 @@ BOOL DirectInput::_GetJoypadCallback(LPDIDEVICEINSTANCE lpddi)
 
 	HRESULT hrCoop = pJoypad->SetCooperativeLevel(hWnd_, DISCL_NONEXCLUSIVE | DISCL_BACKGROUND);
 	if (FAILED(hrCoop)) {
-		if (pJoypad != NULL)
+		if (pJoypad != nullptr)
 			pJoypad->Release();
 		Logger::WriteTop(L"DirectInput：ジョイパッドの動作設定失敗");
 		return DIENUM_CONTINUE;
@@ -197,7 +197,7 @@ BOOL DirectInput::_GetJoypadCallback(LPDIDEVICEINSTANCE lpddi)
 	diprg.lMax = +1000;
 	HRESULT hrRangeX = pJoypad->SetProperty(DIPROP_RANGE, &diprg.diph);
 	if (FAILED(hrRangeX)) {
-		if (pJoypad != NULL)
+		if (pJoypad != nullptr)
 			pJoypad->Release();
 		Logger::WriteTop(L"DirectInput：ジョイパッドデバイスのx軸関係の設定に失敗しました");
 		return DIENUM_CONTINUE;
@@ -207,7 +207,7 @@ BOOL DirectInput::_GetJoypadCallback(LPDIDEVICEINSTANCE lpddi)
 	diprg.diph.dwObj = DIJOFS_Y;
 	HRESULT hrRangeY = pJoypad->SetProperty(DIPROP_RANGE, &diprg.diph);
 	if (FAILED(hrRangeY)) {
-		if (pJoypad != NULL)
+		if (pJoypad != nullptr)
 			pJoypad->Release();
 		Logger::WriteTop(L"DirectInput：ジョイパッドデバイスのy軸関係の設定に失敗しました");
 		return DIENUM_CONTINUE;
@@ -229,7 +229,7 @@ BOOL DirectInput::_GetJoypadCallback(LPDIDEVICEINSTANCE lpddi)
 	dipdw.dwData = 2500;
 	HRESULT hrDeadX = pJoypad->SetProperty(DIPROP_DEADZONE, &dipdw.diph);
 	if (FAILED(hrDeadX)) {
-		if (pJoypad != NULL)
+		if (pJoypad != nullptr)
 			pJoypad->Release();
 		Logger::WriteTop(L"DirectInput：ジョイパッドデバイスのx軸の無効ゾーンの設定に失敗しました");
 		return DIENUM_CONTINUE;
@@ -239,7 +239,7 @@ BOOL DirectInput::_GetJoypadCallback(LPDIDEVICEINSTANCE lpddi)
 	dipdw.diph.dwObj = DIJOFS_Y;
 	HRESULT hrDeadY = pJoypad->SetProperty(DIPROP_DEADZONE, &dipdw.diph);
 	if (FAILED(hrDeadY)) {
-		if (pJoypad != NULL)
+		if (pJoypad != nullptr)
 			pJoypad->Release();
 		Logger::WriteTop(L"DirectInput：ジョイパッドデバイスのy軸の無効ゾーンの設定に失敗しました");
 		return DIENUM_CONTINUE;
@@ -316,7 +316,7 @@ int DirectInput::_GetStateSub(bool flag, int state)
 
 bool DirectInput::_IdleKeyboard()
 {
-	if (!pInput_ || !pKeyboard_)
+	if ((pInput_ == nullptr) || (pKeyboard_ == nullptr))
 		return false;
 
 	HRESULT hr = pKeyboard_->GetDeviceState(MAX_KEY, stateKey_);
@@ -329,10 +329,10 @@ bool DirectInput::_IdleKeyboard()
 }
 bool DirectInput::_IdleJoypad()
 {
-	if (pJoypad_.size() == 0)
+	if (pJoypad_.empty())
 		return false;
 	for (int iPad = 0; iPad < pJoypad_.size(); iPad++) {
-		if (!pInput_ || !pJoypad_[iPad])
+		if ((pInput_ == nullptr) || (pJoypad_[iPad] == nullptr))
 			return false;
 
 		pJoypad_[iPad]->Poll();
@@ -347,7 +347,7 @@ bool DirectInput::_IdleJoypad()
 }
 bool DirectInput::_IdleMouse()
 {
-	if (!pInput_ || !pMouse_)
+	if ((pInput_ == nullptr) || (pMouse_ == nullptr))
 		return false;
 
 	HRESULT hr = pMouse_->GetDeviceState(sizeof(DIMOUSESTATE), &stateMouse_);
@@ -424,8 +424,8 @@ void DirectInput::ResetMouseState()
 }
 void DirectInput::ResetKeyState()
 {
-	for (int iKey = 0; iKey < MAX_KEY; iKey++)
-		bufKey_[iKey] = KEY_FREE;
+	for (int& iKey : bufKey_)
+		iKey = KEY_FREE;
 	ZeroMemory(&stateKey_, sizeof(stateKey_));
 }
 void DirectInput::ResetPadState()
@@ -460,26 +460,19 @@ VirtualKey::VirtualKey(int keyboard, int padIndex, int padButton)
 	padButton_ = padButton;
 	state_ = KEY_FREE;
 }
-VirtualKey::~VirtualKey()
-{
-}
+VirtualKey::~VirtualKey() = default;
 
 //VirtualKeyManager
-VirtualKeyManager::VirtualKeyManager()
-{
-}
-VirtualKeyManager::~VirtualKeyManager()
-{
-}
+VirtualKeyManager::VirtualKeyManager() = default;
+VirtualKeyManager::~VirtualKeyManager() = default;
 
 void VirtualKeyManager::Update()
 {
 	DirectInput::Update();
 
-	std::map<int, gstd::ref_count_ptr<VirtualKey>>::iterator itr = mapKey_.begin();
-	for (; itr != mapKey_.end(); itr++) {
-		int id = itr->first;
-		gstd::ref_count_ptr<VirtualKey> key = itr->second;
+	for (auto& map : mapKey_) {
+		int id = map.first;
+		gstd::ref_count_ptr<VirtualKey> key = map.second;
 
 		int state = _GetVirtualKeyState(id);
 		key->SetKeyState(state);
@@ -488,18 +481,18 @@ void VirtualKeyManager::Update()
 void VirtualKeyManager::ClearKeyState()
 {
 	DirectInput::ResetInputState();
-	std::map<int, gstd::ref_count_ptr<VirtualKey>>::iterator itr = mapKey_.begin();
-	for (; itr != mapKey_.end(); itr++) {
-		gstd::ref_count_ptr<VirtualKey> key = itr->second;
+	for (auto& map : mapKey_) {
+		gstd::ref_count_ptr<VirtualKey> key = map.second;
 		key->SetKeyState(KEY_FREE);
 	}
 }
 int VirtualKeyManager::_GetVirtualKeyState(int id)
 {
-	if (mapKey_.find(id) == mapKey_.end())
+	auto keyItr = mapKey_.find(id);
+	if (keyItr == mapKey_.end())
 		return KEY_FREE;
 
-	gstd::ref_count_ptr<VirtualKey> key = mapKey_[id];
+	gstd::ref_count_ptr<VirtualKey> key = keyItr->second;
 
 	int res = KEY_FREE;
 	if (key->keyboard_ >= 0 && key->keyboard_ < MAX_KEY)
@@ -517,31 +510,30 @@ int VirtualKeyManager::_GetVirtualKeyState(int id)
 
 int VirtualKeyManager::GetVirtualKeyState(int id)
 {
-	if (mapKey_.find(id) == mapKey_.end())
-		return KEY_FREE;
-	gstd::ref_count_ptr<VirtualKey> key = mapKey_[id];
-	return key->GetKeyState();
+	auto keyItr = mapKey_.find(id);
+	if (keyItr != mapKey_.end()) {
+		gstd::ref_count_ptr<VirtualKey> key = keyItr->second;
+		return key->GetKeyState();
+	}
+	return KEY_FREE;
 }
 
 gstd::ref_count_ptr<VirtualKey> VirtualKeyManager::GetVirtualKey(int id)
 {
-	if (mapKey_.find(id) == mapKey_.end())
-		return NULL;
-	return mapKey_[id];
+	auto keyItr = mapKey_.find(id);
+	if (keyItr != mapKey_.end())
+		return keyItr->second;
+	return nullptr;
 }
 bool VirtualKeyManager::IsTargetKeyCode(int key)
 {
-	bool res = false;
-	std::map<int, gstd::ref_count_ptr<VirtualKey>>::iterator itr = mapKey_.begin();
-	for (; itr != mapKey_.end(); itr++) {
-		gstd::ref_count_ptr<VirtualKey> vKey = itr->second;
+	for (auto map : mapKey_) {
+		gstd::ref_count_ptr<VirtualKey> vKey = map.second;
 		int keyCode = vKey->GetKeyCode();
-		if (key == keyCode) {
-			res = true;
-			break;
-		}
+		if (key == keyCode)
+			return true;
 	}
-	return res;
+	return false;
 }
 
 /**********************************************************
@@ -553,9 +545,7 @@ KeyReplayManager::KeyReplayManager(VirtualKeyManager* input)
 	input_ = input;
 	state_ = STATE_RECORD;
 }
-KeyReplayManager::~KeyReplayManager()
-{
-}
+KeyReplayManager::~KeyReplayManager() = default;
 void KeyReplayManager::AddTarget(int key)
 {
 	listTarget_.push_back(key);
@@ -564,9 +554,7 @@ void KeyReplayManager::AddTarget(int key)
 void KeyReplayManager::Update()
 {
 	if (state_ == STATE_RECORD) {
-		std::list<int>::iterator itrTarget = listTarget_.begin();
-		for (; itrTarget != listTarget_.end(); itrTarget++) {
-			int idKey = *itrTarget;
+		for (int idKey : listTarget_) {
 			int keyState = input_->GetVirtualKeyState(idKey);
 			bool bInsert = (frame_ == 0 || mapLastKeyState_[idKey] != keyState);
 			if (bInsert) {
@@ -579,11 +567,8 @@ void KeyReplayManager::Update()
 			mapLastKeyState_[idKey] = keyState;
 		}
 	} else if (state_ == STATE_REPLAY) {
-		std::list<int>::iterator itrTarget = listTarget_.begin();
-		for (; itrTarget != listTarget_.end(); itrTarget++) {
-			int idKey = *itrTarget;
-			std::list<ReplayData>::iterator itrData = listReplayData_.begin();
-			for (; itrData != listReplayData_.end();) {
+		for (int idKey : listTarget_) {
+			for (auto itrData = listReplayData_.begin(); itrData != listReplayData_.end();) {
 				ReplayData data = *itrData;
 				if (data.frame_ > frame_)
 					break;
@@ -605,18 +590,14 @@ void KeyReplayManager::Update()
 }
 bool KeyReplayManager::IsTargetKeyCode(int key) const
 {
-	bool res = false;
-	std::list<int>::const_iterator itrTarget = listTarget_.begin();
-	for (; itrTarget != listTarget_.end(); itrTarget++) {
-		int idKey = *itrTarget;
+	for (int idKey : listTarget_) {
 		gstd::ref_count_ptr<VirtualKey> vKey = input_->GetVirtualKey(idKey);
 		int keyCode = vKey->GetKeyCode();
 		if (key == keyCode) {
-			res = true;
-			break;
+			return true;
 		}
 	}
-	return res;
+	return false;
 }
 void KeyReplayManager::ReadRecord(gstd::RecordBuffer& record)
 {
@@ -638,9 +619,7 @@ void KeyReplayManager::WriteRecord(gstd::RecordBuffer& record)
 	record.SetRecordAsInteger("count", countReplayData);
 
 	ByteBuffer buffer;
-	std::list<ReplayData>::iterator itrData = listReplayData_.begin();
-	for (; itrData != listReplayData_.end(); itrData++) {
-		ReplayData data = *itrData;
+	for (auto& data : listReplayData_) {
 		buffer.Write(&data, sizeof(ReplayData));
 	}
 

--- a/source/GcLib/directx/DirectInput.cpp
+++ b/source/GcLib/directx/DirectInput.cpp
@@ -382,19 +382,19 @@ void DirectInput::Update()
 			bufPad_[iPad][iButton + 4] = _GetPadButton(iPad, iButton, bufPad_[iPad][iButton + 4]);
 	}
 }
-int DirectInput::GetKeyState(int key)
+int DirectInput::GetKeyState(int key) const
 {
 	if (key < 0 || key >= MAX_KEY)
 		return KEY_FREE;
 	return bufKey_[key];
 }
-int DirectInput::GetMouseState(int button)
+int DirectInput::GetMouseState(int button) const
 {
 	if (button < 0 || button >= MAX_MOUSE_BUTTON)
 		return KEY_FREE;
 	return bufMouse_[button];
 }
-int DirectInput::GetPadState(int padNo, int button)
+int DirectInput::GetPadState(int padNo, int button) const
 {
 	int res = KEY_FREE;
 	if (padNo < bufPad_.size())
@@ -603,10 +603,10 @@ void KeyReplayManager::Update()
 	}
 	frame_++;
 }
-bool KeyReplayManager::IsTargetKeyCode(int key)
+bool KeyReplayManager::IsTargetKeyCode(int key) const
 {
 	bool res = false;
-	std::list<int>::iterator itrTarget = listTarget_.begin();
+	std::list<int>::const_iterator itrTarget = listTarget_.begin();
 	for (; itrTarget != listTarget_.end(); itrTarget++) {
 		int idKey = *itrTarget;
 		gstd::ref_count_ptr<VirtualKey> vKey = input_->GetVirtualKey(idKey);

--- a/source/GcLib/directx/DirectInput.hpp
+++ b/source/GcLib/directx/DirectInput.hpp
@@ -40,13 +40,13 @@ public:
 	virtual bool Initialize(HWND hWnd);
 
 	virtual void Update(); //キーをセットする
-	int GetKeyState(int key);
-	int GetMouseState(int button);
-	int GetPadState(int padNo, int button);
+	int GetKeyState(int key) const;
+	int GetMouseState(int button) const;
+	int GetPadState(int padNo, int button) const;
 
-	int GetMouseMoveX() { return stateMouse_.lX; } //マウスの移動量を取得X
-	int GetMouseMoveY() { return stateMouse_.lY; } //マウスの移動量を取得Y
-	int GetMouseMoveZ() { return stateMouse_.lZ; } //マウスの移動量を取得Z
+	int GetMouseMoveX() const { return stateMouse_.lX; } //マウスの移動量を取得X
+	int GetMouseMoveY() const { return stateMouse_.lY; } //マウスの移動量を取得Y
+	int GetMouseMoveZ() const { return stateMouse_.lZ; } //マウスの移動量を取得Z
 	POINT GetMousePosition();
 
 	void ResetInputState();
@@ -54,7 +54,7 @@ public:
 	void ResetKeyState();
 	void ResetPadState();
 
-	int GetPadDeviceCount() { return bufPad_.size(); }
+	int GetPadDeviceCount() const { return bufPad_.size(); }
 	DIDEVICEINSTANCE GetPadDeviceInformation(int padIndex);
 
 protected:
@@ -99,14 +99,14 @@ class VirtualKey {
 public:
 	VirtualKey(int keyboard, int padIndex, int padButton);
 	virtual ~VirtualKey();
-	int GetKeyState() { return state_; }
+	int GetKeyState() const { return state_; }
 	void SetKeyState(int state) { state_ = state; }
 
-	int GetKeyCode() { return keyboard_; }
+	int GetKeyCode() const { return keyboard_; }
 	void SetKeyCode(int code) { keyboard_ = code; }
-	int GetPadIndex() { return padIndex_; }
+	int GetPadIndex() const { return padIndex_; }
 	void SetPadIndex(int index) { padIndex_ = index; }
-	int GetPadButton() { return padButton_; }
+	int GetPadButton() const { return padButton_; }
 	void SetPadButton(int button) { padButton_ = button; }
 
 private:
@@ -150,7 +150,7 @@ public:
 	virtual ~KeyReplayManager();
 	void SetManageState(int state) { state_ = state; }
 	void AddTarget(int key);
-	bool IsTargetKeyCode(int key);
+	bool IsTargetKeyCode(int key) const;
 
 	void Update();
 	void ReadRecord(gstd::RecordBuffer& record);

--- a/source/GcLib/directx/DirectInput.hpp
+++ b/source/GcLib/directx/DirectInput.hpp
@@ -22,16 +22,6 @@ enum {
 //DirectInput
 **********************************************************/
 class DirectInput {
-	static DirectInput* thisBase_;
-
-public:
-	enum {
-		MAX_JOYPAD = 4,
-		MAX_KEY = 256,
-		MAX_MOUSE_BUTTON = 4,
-		MAX_PAD_BUTTON = 16,
-	};
-
 public:
 	DirectInput();
 	virtual ~DirectInput();
@@ -57,21 +47,12 @@ public:
 	int GetPadDeviceCount() const { return bufPad_.size(); }
 	DIDEVICEINSTANCE GetPadDeviceInformation(int padIndex);
 
+	static constexpr int MAX_JOYPAD = 4;
+	static constexpr int MAX_KEY = 256;
+	static constexpr int MAX_MOUSE_BUTTON = 4;
+	static constexpr int MAX_PAD_BUTTON = 16;
+
 protected:
-	HWND hWnd_;
-	LPDIRECTINPUT8 pInput_;
-	LPDIRECTINPUTDEVICE8 pKeyboard_;
-	LPDIRECTINPUTDEVICE8 pMouse_;
-	std::vector<LPDIRECTINPUTDEVICE8> pJoypad_; // パッドデバイスオブジェクト
-	BYTE stateKey_[MAX_KEY];
-	DIMOUSESTATE stateMouse_;
-	std::vector<DIJOYSTATE> statePad_;
-	std::vector<int> padRes_; //パッドの遊び
-
-	int bufKey_[MAX_KEY]; //現フレームのキーの状態
-	int bufMouse_[MAX_MOUSE_BUTTON]; //現フレームのマウスの状態
-	std::vector<std::vector<int>> bufPad_; //現フレームのパッドの状態
-
 	bool _InitializeKeyBoard();
 	bool _InitializeMouse();
 	bool _InitializeJoypad();
@@ -87,6 +68,23 @@ protected:
 	int _GetPadDirection(int index, UINT code, int state); //ジョイスティック方向キーの状態取得
 	int _GetPadButton(int index, int buttonNo, int state); //ジョイスティックのボタンの状態を取得
 	int _GetStateSub(bool flag, int state);
+
+	HWND hWnd_;
+	LPDIRECTINPUT8 pInput_;
+	LPDIRECTINPUTDEVICE8 pKeyboard_;
+	LPDIRECTINPUTDEVICE8 pMouse_;
+	std::vector<LPDIRECTINPUTDEVICE8> pJoypad_; // パッドデバイスオブジェクト
+	BYTE stateKey_[MAX_KEY];
+	DIMOUSESTATE stateMouse_;
+	std::vector<DIJOYSTATE> statePad_;
+	std::vector<int> padRes_; //パッドの遊び
+
+	std::array<int, MAX_KEY> bufKey_; //現フレームのキーの状態
+	std::array<int, MAX_MOUSE_BUTTON> bufMouse_; //現フレームのマウスの状態
+	std::vector<std::vector<int>> bufPad_; //現フレームのパッドの状態
+
+private:
+	static DirectInput* thisBase_;
 };
 
 /**********************************************************
@@ -119,8 +117,8 @@ private:
 class VirtualKeyManager : public DirectInput {
 public:
 	VirtualKeyManager();
-	~VirtualKeyManager();
-	virtual void Update(); //キーをセットする
+	~VirtualKeyManager() override;
+	void Update() override; //キーをセットする
 	void ClearKeyState();
 
 	void AddKeyMap(int id, gstd::ref_count_ptr<VirtualKey> key) { mapKey_[id] = key; }

--- a/source/GcLib/directx/DirectSound.cpp
+++ b/source/GcLib/directx/DirectSound.cpp
@@ -6,12 +6,12 @@ using namespace directx;
 /**********************************************************
 //DirectSoundManager
 **********************************************************/
-DirectSoundManager* DirectSoundManager::thisBase_ = NULL;
+DirectSoundManager* DirectSoundManager::thisBase_ = nullptr;
 
 DirectSoundManager::DirectSoundManager()
 {
-	pDirectSound_ = NULL;
-	pDirectSoundBuffer_ = NULL;
+	pDirectSound_ = nullptr;
+	pDirectSoundBuffer_ = nullptr;
 	CreateSoundDivision(SoundDivision::DIVISION_BGM);
 	CreateSoundDivision(SoundDivision::DIVISION_SE);
 	CreateSoundDivision(SoundDivision::DIVISION_VOICE);
@@ -23,22 +23,22 @@ DirectSoundManager::~DirectSoundManager()
 	threadManage_->Stop();
 	threadManage_->Join();
 	delete threadManage_;
-	if (pDirectSoundBuffer_ != NULL)
+	if (pDirectSoundBuffer_ != nullptr)
 		pDirectSoundBuffer_->Release();
-	if (pDirectSound_ != NULL)
+	if (pDirectSound_ != nullptr)
 		pDirectSound_->Release();
-	panelInfo_ = NULL;
-	thisBase_ = NULL;
+	panelInfo_ = nullptr;
+	thisBase_ = nullptr;
 	Logger::WriteTop(L"DirectSound：終了完了");
 }
 bool DirectSoundManager::Initialize(HWND hWnd)
 {
-	if (thisBase_ != NULL)
+	if (thisBase_ != nullptr)
 		return false;
 
 	Logger::WriteTop(L"DirectSound：初期化");
 
-	HRESULT hrSound = DirectSoundCreate8(NULL, &pDirectSound_, NULL);
+	HRESULT hrSound = DirectSoundCreate8(nullptr, &pDirectSound_, nullptr);
 	if (FAILED(hrSound)) {
 		Logger::WriteTop(L"DirectSoundCreate8失敗");
 		return false; // DirectSound8の作成に失敗
@@ -56,8 +56,8 @@ bool DirectSoundManager::Initialize(HWND hWnd)
 	desc.dwSize = sizeof(DSBUFFERDESC);
 	desc.dwFlags = DSBCAPS_CTRLVOLUME | DSBCAPS_PRIMARYBUFFER;
 	desc.dwBufferBytes = 0;
-	desc.lpwfxFormat = NULL;
-	HRESULT hrBuf = pDirectSound_->CreateSoundBuffer(&desc, (LPDIRECTSOUNDBUFFER*)&pDirectSoundBuffer_, NULL);
+	desc.lpwfxFormat = nullptr;
+	HRESULT hrBuf = pDirectSound_->CreateSoundBuffer(&desc, (LPDIRECTSOUNDBUFFER*)&pDirectSoundBuffer_, nullptr);
 	if (FAILED(hrBuf)) {
 		Logger::WriteTop(L"CreateSoundBuffer失敗");
 		return false;
@@ -90,13 +90,11 @@ void DirectSoundManager::Clear()
 {
 	try {
 		Lock lock(lock_);
-		std::map<std::wstring, std::list<gstd::ref_count_ptr<SoundPlayer>>>::iterator itrNameMap;
-		for (itrNameMap = mapPlayer_.begin(); itrNameMap != mapPlayer_.end(); itrNameMap++) {
-			std::list<gstd::ref_count_ptr<SoundPlayer>>& listPlayer = itrNameMap->second;
-			std::list<gstd::ref_count_ptr<SoundPlayer>>::iterator itrPlayer;
-			for (itrPlayer = listPlayer.begin(); itrPlayer != listPlayer.end(); itrPlayer++) {
-				SoundPlayer* player = (*itrPlayer).GetPointer();
-				if (player == NULL)
+		for (auto& itrNameMap : mapPlayer_) {
+			std::list<gstd::ref_count_ptr<SoundPlayer>>& listPlayer = itrNameMap.second;
+			for (auto& itrPlayer : listPlayer) {
+				SoundPlayer* player = itrPlayer.GetPointer();
+				if (player == nullptr)
 					continue;
 				player->Stop();
 			}
@@ -114,7 +112,7 @@ gstd::ref_count_ptr<SoundPlayer> DirectSoundManager::GetPlayer(const std::wstrin
 			res = _CreatePlayer(path);
 		} else {
 			res = _GetPlayer(path);
-			if (res == NULL) {
+			if (res == nullptr) {
 				res = _CreatePlayer(path);
 			}
 		}
@@ -126,14 +124,15 @@ gstd::ref_count_ptr<SoundPlayer> DirectSoundManager::GetPlayer(const std::wstrin
 gstd::ref_count_ptr<SoundPlayer> DirectSoundManager::_GetPlayer(const std::wstring& path)
 {
 	if (mapPlayer_.find(path) == mapPlayer_.end())
-		return NULL;
+		return nullptr;
 
-	gstd::ref_count_ptr<SoundPlayer> res = NULL;
+	gstd::ref_count_ptr<SoundPlayer> res = nullptr;
 
 	for (auto& itrNameMap : mapPlayer_) {
-		for (auto& itrPlayer : itrNameMap.second) {
+		std::list<gstd::ref_count_ptr<SoundPlayer>>& listPlayer = itrNameMap.second;
+		for (auto& itrPlayer : listPlayer) {
 			SoundPlayer* player = itrPlayer.GetPointer();
-			if (player == NULL)
+			if (player == nullptr)
 				continue;
 			if (player->bDelete_)
 				continue;
@@ -152,10 +151,10 @@ gstd::ref_count_ptr<SoundPlayer> DirectSoundManager::_CreatePlayer(std::wstring 
 	try {
 		path = PathProperty::GetUnique(path);
 		ref_count_ptr<FileReader> reader = fileManager->GetFileReader(path);
-		if (reader == NULL)
-			throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path).c_str());
+		if (reader == nullptr)
+			throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path));
 		if (!reader->Open())
-			throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path).c_str());
+			throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path));
 
 		//フォーマット確認
 		int sizeFile = reader->GetFileSize();
@@ -167,7 +166,7 @@ gstd::ref_count_ptr<SoundPlayer> DirectSoundManager::_CreatePlayer(std::wstring 
 		header.SetSize(64);
 		reader->Read(header.GetPointer(), header.GetSize());
 
-		if (!memcmp(header.GetPointer(), "RIFF", 4)) { //WAVE
+		if (memcmp(header.GetPointer(), "RIFF", 4) == 0) { //WAVE
 			format = SD_WAVE;
 			WAVEFORMATEX pcmwf;
 			ZeroMemory(&pcmwf, sizeof(PCMWAVEFORMAT));
@@ -176,9 +175,9 @@ gstd::ref_count_ptr<SoundPlayer> DirectSoundManager::_CreatePlayer(std::wstring 
 				format = SD_AWAVE; //waveヘッダmp3
 			else
 				format = SD_WAVE;
-		} else if (!memcmp(header.GetPointer(), "OggS", 4)) { //OggVorbis
+		} else if (memcmp(header.GetPointer(), "OggS", 4) == 0) { //OggVorbis
 			format = SD_OGG;
-		} else if (!memcmp(header.GetPointer(), "MThd", 4)) { //midi
+		} else if (memcmp(header.GetPointer(), "MThd", 4) == 0) { //midi
 			format = SD_MIDI;
 		} else { //多分mp3
 			format = SD_MP3;
@@ -201,9 +200,9 @@ gstd::ref_count_ptr<SoundPlayer> DirectSoundManager::_CreatePlayer(std::wstring 
 		}
 
 		bool bSuccess = true;
-		bSuccess &= res != NULL;
+		bSuccess &= (res != nullptr);
 
-		if (res != NULL) {
+		if (res != nullptr) {
 			//ファイルを読み込みサウンドバッファを作成
 			bSuccess &= res->_CreateBuffer(reader);
 			res->Seek(0);
@@ -255,7 +254,7 @@ bool DirectSoundManager::AddSoundInfoFromFile(const std::wstring& path)
 	bool res = false;
 	FileManager* fileManager = FileManager::GetBase();
 	ref_count_ptr<FileReader> reader = fileManager->GetFileReader(path);
-	if (reader == NULL || !reader->Open()) {
+	if (reader == nullptr || !reader->Open()) {
 		Logger::WriteTop(ErrorUtility::GetFileNotFoundErrorMessage(path));
 		return false;
 	}
@@ -273,7 +272,8 @@ bool DirectSoundManager::AddSoundInfoFromFile(const std::wstring& path)
 			if (tok.GetType() == Token::TK_EOF) //Eofの識別子が来たらファイルの調査終了
 			{
 				break;
-			} else if (tok.GetType() == Token::TK_ID) {
+			}
+			if (tok.GetType() == Token::TK_ID) {
 				std::wstring element = tok.GetElement();
 				if (element == L"SoundInfo") {
 					tok = scanner.Next();
@@ -313,7 +313,7 @@ bool DirectSoundManager::AddSoundInfoFromFile(const std::wstring& path)
 						}
 					}
 
-					if (name.size() > 0) {
+					if (!name.empty()) {
 						mapInfo_[name] = info;
 						std::wstring log = StringUtility::Format(L"音声情報設定:path[%s] title[%s] start[%.3f] end[%.3f]",
 							name.c_str(), info->GetTitle().c_str(), info->GetLoopStartTime(), info->GetLoopEndTime());
@@ -346,9 +346,10 @@ void DirectSoundManager::SetFadeDeleteAll()
 	try {
 		Lock lock(lock_);
 		for (auto& itrNameMap : mapPlayer_) {
-			for (auto& itrPlayer : itrNameMap.second) {
+			std::list<gstd::ref_count_ptr<SoundPlayer>>& listPlayer = itrNameMap.second;
+			for (auto& itrPlayer : listPlayer) {
 				SoundPlayer* player = itrPlayer.GetPointer();
-				if (player == NULL)
+				if (player == nullptr)
 					continue;
 				player->SetFadeDelete(SoundPlayer::FADE_DEFAULT);
 			}
@@ -376,7 +377,7 @@ void DirectSoundManager::SoundManageThread::_Run()
 			_Arrange();
 		}
 
-		if (manager->panelInfo_ != NULL && this->GetStatus() == RUN) {
+		if (manager->panelInfo_ != nullptr && this->GetStatus() == RUN) {
 			//クリティカルセクションの中で更新すると
 			//メインスレッドとロックする可能性があります
 			manager->panelInfo_->Update(manager);
@@ -390,14 +391,12 @@ void DirectSoundManager::SoundManageThread::_Arrange()
 	DirectSoundManager* manager = _GetOuter();
 	std::set<std::wstring> setRemoveKey;
 	std::map<std::wstring, std::list<gstd::ref_count_ptr<SoundPlayer>>>& mapPlayer = manager->mapPlayer_;
-	std::map<std::wstring, std::list<gstd::ref_count_ptr<SoundPlayer>>>::iterator itrNameMap;
-	for (itrNameMap = mapPlayer.begin(); itrNameMap != mapPlayer.end(); itrNameMap++) {
-		std::list<gstd::ref_count_ptr<SoundPlayer>>& listPlayer = itrNameMap->second;
-		std::list<gstd::ref_count_ptr<SoundPlayer>>::iterator itrPlayer;
-		for (itrPlayer = listPlayer.begin(); itrPlayer != listPlayer.end();) {
+	for (auto& itrNameMap : mapPlayer) {
+		std::list<gstd::ref_count_ptr<SoundPlayer>>& listPlayer = itrNameMap.second;
+		for (auto itrPlayer = listPlayer.begin(); itrPlayer != listPlayer.end();) {
 			SoundPlayer* player = (*itrPlayer).GetPointer();
 			bool bDelete = false;
-			if (player != NULL) {
+			if (player != nullptr) {
 				bDelete |= player->bDelete_;
 				bDelete |= player->bAutoDelete_ && !player->IsPlaying();
 			}
@@ -407,16 +406,14 @@ void DirectSoundManager::SoundManageThread::_Arrange()
 				player->Stop();
 				itrPlayer = listPlayer.erase(itrPlayer);
 			} else
-				itrPlayer++;
+				++itrPlayer;
 		}
 
-		if (listPlayer.size() == 0)
-			setRemoveKey.insert(itrNameMap->first);
+		if (listPlayer.empty())
+			setRemoveKey.insert(itrNameMap.first);
 	}
 
-	std::set<std::wstring>::iterator itrRemove;
-	for (itrRemove = setRemoveKey.begin(); itrRemove != setRemoveKey.end(); itrRemove++) {
-		std::wstring key = *itrRemove;
+	for (auto& key : setRemoveKey) {
 		mapPlayer.erase(key);
 	}
 }
@@ -426,13 +423,11 @@ void DirectSoundManager::SoundManageThread::_Fade()
 	int timeGap = timeCurrent_ - timePrevious_;
 	std::map<std::wstring, std::list<gstd::ref_count_ptr<SoundPlayer>>>& mapPlayer = manager->mapPlayer_;
 
-	std::map<std::wstring, std::list<gstd::ref_count_ptr<SoundPlayer>>>::iterator itrNameMap;
-	for (itrNameMap = mapPlayer.begin(); itrNameMap != mapPlayer.end(); itrNameMap++) {
-		std::list<gstd::ref_count_ptr<SoundPlayer>>& listPlayer = itrNameMap->second;
-		std::list<gstd::ref_count_ptr<SoundPlayer>>::iterator itrPlayer;
-		for (itrPlayer = listPlayer.begin(); itrPlayer != listPlayer.end(); itrPlayer++) {
-			SoundPlayer* player = (*itrPlayer).GetPointer();
-			if (player == NULL)
+	for (auto& itrNameMap : mapPlayer) {
+		std::list<gstd::ref_count_ptr<SoundPlayer>>& listPlayer = itrNameMap.second;
+		for (auto& itrPlayer : listPlayer) {
+			SoundPlayer* player = itrPlayer.GetPointer();
+			if (player == nullptr)
 				continue;
 			double rateFade = player->GetFadeVolumeRate();
 			if (rateFade == 0)
@@ -500,33 +495,25 @@ void SoundInfoPanel::Update(DirectSoundManager* soundManager)
 	{
 		Lock lock(soundManager->GetLock());
 		std::map<std::wstring, std::list<gstd::ref_count_ptr<SoundPlayer>>>& mapPlayer = soundManager->mapPlayer_;
-		std::map<std::wstring, std::list<gstd::ref_count_ptr<SoundPlayer>>>::iterator itrNameMap;
-		for (itrNameMap = mapPlayer.begin(); itrNameMap != mapPlayer.end(); itrNameMap++) {
-			std::wstring path = itrNameMap->first;
-			std::list<gstd::ref_count_ptr<SoundPlayer>>& listPlayer = itrNameMap->second;
-			std::list<gstd::ref_count_ptr<SoundPlayer>>::iterator itrPlayer;
-			for (itrPlayer = listPlayer.begin(); itrPlayer != listPlayer.end(); itrPlayer++) {
-				SoundPlayer* player = (*itrPlayer).GetPointer();
-				if (player == NULL)
+		for (auto& itrNameMap : mapPlayer) {
+			std::wstring path = itrNameMap.first;
+			std::list<gstd::ref_count_ptr<SoundPlayer>>& listPlayer = itrNameMap.second;
+			for (auto& player : listPlayer) {
+				if (player == nullptr)
 					continue;
-
-				int address = (int)player;
+				int address = (int)&player;
 				Info info;
 				info.address = address;
 				info.path = path;
-				info.countRef = (*itrPlayer).GetReferenceCount();
+				info.countRef = player.GetReferenceCount();
 				listInfo.push_back(info);
 			}
 		}
 	}
 
 	std::set<std::wstring> setKey;
-	std::list<Info>::iterator itrInfo;
-	for (itrInfo = listInfo.begin(); itrInfo != listInfo.end(); itrInfo++) {
-		Info& info = *itrInfo;
+	for (auto& info : listInfo) {
 		int address = info.address;
-		std::wstring path = info.path;
-		int countRef = info.countRef;
 		std::wstring key = StringUtility::Format(L"%08x", address);
 		int index = wndListView_.GetIndexInColumn(key, ROW_ADDRESS);
 		if (index == -1) {
@@ -534,9 +521,9 @@ void SoundInfoPanel::Update(DirectSoundManager* soundManager)
 			wndListView_.SetText(index, ROW_ADDRESS, key);
 		}
 
-		wndListView_.SetText(index, ROW_FILENAME, PathProperty::GetFileName(path));
-		wndListView_.SetText(index, ROW_FULLPATH, path);
-		wndListView_.SetText(index, ROW_COUNT_REFFRENCE, StringUtility::Format(L"%d", countRef));
+		wndListView_.SetText(index, ROW_FILENAME, PathProperty::GetFileName(info.path));
+		wndListView_.SetText(index, ROW_FULLPATH, info.path);
+		wndListView_.SetText(index, ROW_COUNT_REFFRENCE, StringUtility::Format(L"%d", info.countRef));
 
 		setKey.insert(key);
 	}
@@ -556,17 +543,15 @@ SoundDivision::SoundDivision()
 {
 	rateVolume_ = 100;
 }
-SoundDivision::~SoundDivision()
-{
-}
+SoundDivision::~SoundDivision() = default;
 
 /**********************************************************
 //SoundPlayer
 **********************************************************/
 SoundPlayer::SoundPlayer()
 {
-	pDirectSoundBuffer_ = NULL;
-	reader_ = NULL;
+	pDirectSoundBuffer_ = nullptr;
+	reader_ = nullptr;
 
 	ZeroMemory(&formatWave_, sizeof(WAVEFORMATEX));
 	bLoop_ = false;
@@ -583,13 +568,13 @@ SoundPlayer::SoundPlayer()
 SoundPlayer::~SoundPlayer()
 {
 	Stop();
-	if (pDirectSoundBuffer_ != NULL)
+	if (pDirectSoundBuffer_ != nullptr)
 		pDirectSoundBuffer_->Release();
 }
 void SoundPlayer::_SetSoundInfo()
 {
 	gstd::ref_count_ptr<SoundInfo> info = manager_->GetSoundInfo(path_);
-	if (info == NULL)
+	if (info == nullptr)
 		return;
 	timeLoopStart_ = info->GetLoopStartTime();
 	timeLoopEnd_ = info->GetLoopEndTime();
@@ -600,13 +585,11 @@ void SoundPlayer::SetSoundDivision(gstd::ref_count_ptr<SoundDivision> div)
 }
 void SoundPlayer::SetSoundDivision(int index)
 {
-	{
-		Lock lock(lock_);
-		DirectSoundManager* manager = DirectSoundManager::GetBase();
-		gstd::ref_count_ptr<SoundDivision> div = manager->GetSoundDivision(index);
-		if (div != NULL)
-			SetSoundDivision(div);
-	}
+	Lock lock(lock_);
+	DirectSoundManager* manager = DirectSoundManager::GetBase();
+	gstd::ref_count_ptr<SoundDivision> div = manager->GetSoundDivision(index);
+	if (div != nullptr)
+		SetSoundDivision(div);
 }
 bool SoundPlayer::Play()
 {
@@ -627,90 +610,72 @@ bool SoundPlayer::IsPlaying() const
 }
 double SoundPlayer::GetVolumeRate()
 {
-	double res = 0;
-	{
-		Lock lock(lock_);
-		res = rateVolume_;
-	}
-	return res;
+	Lock lock(lock_);
+	return rateVolume_;
 }
 bool SoundPlayer::SetVolumeRate(double rateVolume)
 {
-	{
-		Lock lock(lock_);
-		if (rateVolume < 0)
-			rateVolume = 0.0;
-		if (rateVolume > 100)
-			rateVolume = 100.0;
-		rateVolume_ = rateVolume;
+	Lock lock(lock_);
+	if (rateVolume < 0)
+		rateVolume = 0.0;
+	if (rateVolume > 100)
+		rateVolume = 100.0;
+	rateVolume_ = rateVolume;
 
-		double rateDiv = 100.0;
-		if (division_ != NULL)
-			rateDiv = division_->GetVolumeRate();
-		double rate = rateVolume_ / 100.0 * rateDiv / 100.0;
+	double rateDiv = 100.0;
+	if (division_ != nullptr)
+		rateDiv = division_->GetVolumeRate();
+	double rate = rateVolume_ / 100.0 * rateDiv / 100.0;
 
-		//int volume = (int)((double)(DirectSoundManager::SD_VOLUME_MAX - DirectSoundManager::SD_VOLUME_MIN) * rate);
-		//pDirectSoundBuffer_->SetVolume(DirectSoundManager::SD_VOLUME_MIN+volume);
-		int volume = _GetValumeAsDirectSoundDecibel(rate);
-		pDirectSoundBuffer_->SetVolume(volume);
-	}
-
+	//int volume = (int)((double)(DirectSoundManager::SD_VOLUME_MAX - DirectSoundManager::SD_VOLUME_MIN) * rate);
+	//pDirectSoundBuffer_->SetVolume(DirectSoundManager::SD_VOLUME_MIN+volume);
+	int volume = _GetValumeAsDirectSoundDecibel(rate);
+	pDirectSoundBuffer_->SetVolume(volume);
 	return true;
 }
 bool SoundPlayer::SetPanRate(double ratePan)
 {
-	{
-		Lock lock(lock_);
-		if (ratePan < -100)
-			ratePan = -100.0;
-		if (ratePan > 100)
-			ratePan = 100.0;
+	Lock lock(lock_);
+	if (ratePan < -100)
+		ratePan = -100.0;
+	if (ratePan > 100)
+		ratePan = 100.0;
 
-		double rateDiv = 100.0;
-		if (division_ != NULL)
-			rateDiv = division_->GetVolumeRate();
-		double rate = rateVolume_ / 100.0 * rateDiv / 100.0;
-		int volume = (int)((double)(DirectSoundManager::SD_VOLUME_MAX - DirectSoundManager::SD_VOLUME_MIN) * rate);
-		//int volume = _GetValumeAsDirectSoundDecibel(rate);
+	double rateDiv = 100.0;
+	if (division_ != nullptr)
+		rateDiv = division_->GetVolumeRate();
+	double rate = rateVolume_ / 100.0 * rateDiv / 100.0;
+	int volume = (int)((double)(DirectSoundManager::SD_VOLUME_MAX - DirectSoundManager::SD_VOLUME_MIN) * rate);
+	//int volume = _GetValumeAsDirectSoundDecibel(rate);
 
-		double span = (DSBPAN_RIGHT - DSBPAN_LEFT) / 2;
-		span = volume / 2;
-		double pan = span * ratePan / 100;
-		HRESULT hr = pDirectSoundBuffer_->SetPan((int)pan);
-	}
-
+	double span = (DSBPAN_RIGHT - DSBPAN_LEFT) / 2;
+	span = volume / 2;
+	double pan = span * ratePan / 100;
+	HRESULT hr = pDirectSoundBuffer_->SetPan((int)pan);
 	return true;
 }
-double SoundPlayer::GetFadeVolumeRate()
+double SoundPlayer::GetFadeVolumeRate() const
 {
-	double res = 0;
-	{
-		Lock lock(lock_);
-		res = rateVolumeFadePerSec_;
-	}
-	return res;
+	Lock lock(lock_);
+	return rateVolumeFadePerSec_;
 }
 void SoundPlayer::SetFade(double rateVolumeFadePerSec)
 {
-	{
-		Lock lock(lock_);
-		rateVolumeFadePerSec_ = rateVolumeFadePerSec;
-	}
+	Lock lock(lock_);
+	rateVolumeFadePerSec_ = rateVolumeFadePerSec;
 }
 void SoundPlayer::SetFadeDelete(double rateVolumeFadePerSec)
 {
-	{
-		Lock lock(lock_);
-		bFadeDelete_ = true;
-		SetFade(rateVolumeFadePerSec);
-	}
+	Lock lock(lock_);
+	bFadeDelete_ = true;
+	SetFade(rateVolumeFadePerSec);
 }
 int SoundPlayer::_GetValumeAsDirectSoundDecibel(float rate)
 {
 	int result = 0;
-	if (rate >= 1.0f) {
+	if (rate >= 1.0F) {
 		result = DSBVOLUME_MAX;
-	} else if (rate <= 0.0f) {
+	} else if (rate <= 0.0F) {
 		result = DSBVOLUME_MIN;
 	} else {
 		// 10dBで音量2倍。
@@ -718,7 +683,7 @@ int SoundPlayer::_GetValumeAsDirectSoundDecibel(float rate)
 		//	 = 10 * log2(音量)
 		//	 = 10 * ( log10(音量) / log10(2) )
 		//	 = 33.2... * log10(音量)
-		result = (int)(33.2f * log10(rate) * 100);
+		result = (int)(33.2F * log10(rate) * 100);
 	}
 	return result;
 }
@@ -732,16 +697,14 @@ SoundPlayer::PlayStyle::PlayStyle()
 	timeStart_ = 0;
 	bRestart_ = false;
 }
-SoundPlayer::PlayStyle::~PlayStyle()
-{
-}
+SoundPlayer::PlayStyle::~PlayStyle() = default;
 
 /**********************************************************
 //SoundStreamingPlayer
 **********************************************************/
 SoundStreamingPlayer::SoundStreamingPlayer()
 {
-	pDirectSoundNotify_ = NULL;
+	pDirectSoundNotify_ = nullptr;
 	ZeroMemory(hEvent_, sizeof(HANDLE) * 3);
 	thread_ = new StreamingThread(this);
 	bStreaming_ = true;
@@ -750,10 +713,10 @@ SoundStreamingPlayer::SoundStreamingPlayer()
 SoundStreamingPlayer::~SoundStreamingPlayer()
 {
 	this->Stop();
-	for (int iEvent = 0; iEvent < 3; iEvent++) {
-		::CloseHandle(hEvent_[iEvent]);
+	for (auto & iEvent : hEvent_) {
+		::CloseHandle(iEvent);
 	}
-	if (pDirectSoundNotify_ != NULL)
+	if (pDirectSoundNotify_ != nullptr)
 		pDirectSoundNotify_->Release();
 	delete thread_;
 }
@@ -763,7 +726,7 @@ void SoundStreamingPlayer::_CreateSoundEvent(const WAVEFORMATEX& formatWave)
 	HRESULT hrNotify = pDirectSoundBuffer_->QueryInterface(IID_IDirectSoundNotify, (LPVOID*)&pDirectSoundNotify_);
 	DSBPOSITIONNOTIFY pn[3];
 	for (int iEvent = 0; iEvent < 3; iEvent++) {
-		hEvent_[iEvent] = CreateEvent(NULL, FALSE, FALSE, NULL);
+		hEvent_[iEvent] = CreateEvent(nullptr, FALSE, FALSE, nullptr);
 		pn[iEvent].hEventNotify = hEvent_[iEvent];
 	}
 
@@ -778,89 +741,86 @@ void SoundStreamingPlayer::_CreateSoundEvent(const WAVEFORMATEX& formatWave)
 }
 void SoundStreamingPlayer::_CopyStream(int indexCopy)
 {
-	{
-		Lock lock(lock_);
-		LPVOID pMem1, pMem2;
-		DWORD dwSize1, dwSize2;
+	Lock lock(lock_);
+	LPVOID pMem1;
+	LPVOID pMem2;
+	DWORD dwSize1;
+	DWORD dwSize2;
 
-		HRESULT hr = pDirectSoundBuffer_->Lock(sizeCopy_ * indexCopy, sizeCopy_, &pMem1, &dwSize1, &pMem2, &dwSize2, 0);
-		if (hr == DSERR_BUFFERLOST) {
-			hr = pDirectSoundBuffer_->Restore();
-			hr = pDirectSoundBuffer_->Lock(sizeCopy_ * indexCopy, sizeCopy_, &pMem1, &dwSize1, &pMem2, &dwSize2, 0);
-		}
-		if (FAILED(hr))
-			_RequestStop();
-
-		if (bRequestStop_) {
-			Stop();
-		}
-
-		if (!bStreaming_ || (IsPlaying() && !bRequestStop_)) {
-			if (dwSize1 > 0)
-				_CopyBuffer(pMem1, dwSize1); //バッファ前半
-			if (dwSize2 > 0)
-				_CopyBuffer(pMem2, dwSize2); //バッファ後半
-		} else {
-			//演奏中でなければ無音を書き込む
-			memset(pMem1, 0, dwSize1);
-			if (dwSize2 != 0)
-				memcpy(pMem2, 0, dwSize2);
-		}
-		pDirectSoundBuffer_->Unlock(pMem1, dwSize1, pMem2, dwSize2);
+	HRESULT hr = pDirectSoundBuffer_->Lock(sizeCopy_ * indexCopy, sizeCopy_, &pMem1, &dwSize1, &pMem2, &dwSize2, 0);
+	if (hr == DSERR_BUFFERLOST) {
+		hr = pDirectSoundBuffer_->Restore();
+		hr = pDirectSoundBuffer_->Lock(sizeCopy_ * indexCopy, sizeCopy_, &pMem1, &dwSize1, &pMem2, &dwSize2, 0);
 	}
+	if (FAILED(hr))
+		_RequestStop();
+
+	if (bRequestStop_) {
+		Stop();
+	}
+
+	if (!bStreaming_ || (IsPlaying() && !bRequestStop_)) {
+		if (dwSize1 > 0)
+			_CopyBuffer(pMem1, dwSize1); //バッファ前半
+		if (dwSize2 > 0)
+			_CopyBuffer(pMem2, dwSize2); //バッファ後半
+	} else {
+		//演奏中でなければ無音を書き込む
+		memset(pMem1, 0, dwSize1);
+		if (dwSize2 != 0)
+			memcpy(pMem2, nullptr, dwSize2);
+	}
+	pDirectSoundBuffer_->Unlock(pMem1, dwSize1, pMem2, dwSize2);
 }
 bool SoundStreamingPlayer::Play(PlayStyle& style)
 {
 	if (IsPlaying())
 		return true;
 
-	{
-		Lock lock(lock_);
-		if (bFadeDelete_)
-			SetVolumeRate(100);
-		bFadeDelete_ = false;
+	Lock lock(lock_);
+	if (bFadeDelete_)
+		SetVolumeRate(100);
+	bFadeDelete_ = false;
 
-		SetFade(0);
+	SetFade(0);
 
-		bLoop_ = style.IsLoopEnable();
-		timeLoopStart_ = style.GetLoopStartTime();
-		timeLoopEnd_ = style.GetLoopEndTime();
-		//		if(timeLoopEnd_ == 0)timeLoopEnd_ = (double)sizeWave_ / (double)formatWave_.nAvgBytesPerSec;
-		//		fadeValuePerMillSec_ = 0;
+	bLoop_ = style.IsLoopEnable();
+	timeLoopStart_ = style.GetLoopStartTime();
+	timeLoopEnd_ = style.GetLoopEndTime();
+	// if(timeLoopEnd_ == 0)timeLoopEnd_ = (double)sizeWave_ / (double)formatWave_.nAvgBytesPerSec;
+	// fadeValuePerMillSec_ = 0;
 
-		_SetSoundInfo();
+	_SetSoundInfo();
 
-		bRequestStop_ = false;
-		if (!(bPause_ && style.IsRestart())) {
-			this->Seek(style.GetStartTime());
-			pDirectSoundBuffer_->SetCurrentPosition(0);
-		}
-
-		if (bStreaming_) {
-			thread_->Start();
-			pDirectSoundBuffer_->Play(0, 0, DSBPLAY_LOOPING); //再生開始
-		} else {
-			DWORD dwFlags = 0;
-			if (style.IsLoopEnable())
-				dwFlags = DSBPLAY_LOOPING;
-			pDirectSoundBuffer_->Play(0, 0, dwFlags);
-		}
-		bPause_ = false;
+	bRequestStop_ = false;
+	if (!(bPause_ && style.IsRestart())) {
+		this->Seek(style.GetStartTime());
+		pDirectSoundBuffer_->SetCurrentPosition(0);
 	}
+
+	if (bStreaming_) {
+		thread_->Start();
+		pDirectSoundBuffer_->Play(0, 0, DSBPLAY_LOOPING); //再生開始
+	} else {
+		DWORD dwFlags = 0;
+		if (style.IsLoopEnable())
+			dwFlags = DSBPLAY_LOOPING;
+		pDirectSoundBuffer_->Play(0, 0, dwFlags);
+	}
+	bPause_ = false;
+
 	return true;
 }
 bool SoundStreamingPlayer::Stop()
 {
-	{
-		Lock lock(lock_);
-		if (IsPlaying())
-			bPause_ = true;
+	Lock lock(lock_);
+	if (IsPlaying())
+		bPause_ = true;
 
-		if (pDirectSoundBuffer_ != NULL)
-			pDirectSoundBuffer_->Stop();
+	if (pDirectSoundBuffer_ != nullptr)
+		pDirectSoundBuffer_->Stop();
 
-		thread_->Stop();
-	}
+	thread_->Stop();
 	return true;
 }
 bool SoundStreamingPlayer::IsPlaying() const
@@ -892,12 +852,9 @@ void SoundStreamingPlayer::StreamingThread::_Run()
 /**********************************************************
 //SoundPlayerWave
 **********************************************************/
-SoundPlayerWave::SoundPlayerWave()
-{
-}
-SoundPlayerWave::~SoundPlayerWave()
-{
-}
+SoundPlayerWave::SoundPlayerWave() = default;
+SoundPlayerWave::~SoundPlayerWave() = default;
+
 bool SoundPlayerWave::_CreateBuffer(gstd::ref_count_ptr<gstd::FileReader> reader)
 {
 	FileManager* fileManager = FileManager::GetBase();
@@ -950,13 +907,15 @@ bool SoundPlayerWave::_CreateBuffer(gstd::ref_count_ptr<gstd::FileReader> reader
 		desc.dwFlags = DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLPAN | DSBCAPS_GETCURRENTPOSITION2 | DSBCAPS_GLOBALFOCUS | DSBCAPS_LOCDEFER;
 		desc.dwBufferBytes = sizeWave;
 		desc.lpwfxFormat = &formatWave_;
-		HRESULT hrBuffer = soundManager->GetDirectSound()->CreateSoundBuffer(&desc, (LPDIRECTSOUNDBUFFER*)&pDirectSoundBuffer_, NULL);
+		HRESULT hrBuffer = soundManager->GetDirectSound()->CreateSoundBuffer(&desc, (LPDIRECTSOUNDBUFFER*)&pDirectSoundBuffer_, nullptr);
 		if (FAILED(hrBuffer))
 			throw(false);
 
 		//Bufferへ書き込む
-		LPVOID pMem1, pMem2;
-		DWORD dwSize1, dwSize2;
+		LPVOID pMem1;
+		LPVOID pMem2;
+		DWORD dwSize1;
+		DWORD dwSize2;
 		HRESULT hrLock = pDirectSoundBuffer_->Lock(0, sizeWave, &pMem1, &dwSize1, &pMem2, &dwSize2, 0);
 		if (hrLock == DSERR_BUFFERLOST) {
 			hrLock = pDirectSoundBuffer_->Restore();
@@ -978,41 +937,38 @@ bool SoundPlayerWave::_CreateBuffer(gstd::ref_count_ptr<gstd::FileReader> reader
 }
 bool SoundPlayerWave::Play(PlayStyle& style)
 {
-	{
-		Lock lock(lock_);
-		if (bFadeDelete_)
-			SetVolumeRate(100);
-		bFadeDelete_ = false;
+	Lock lock(lock_);
+	if (bFadeDelete_)
+		SetVolumeRate(100);
+	bFadeDelete_ = false;
 
-		SetFade(0);
+	SetFade(0);
 
-		DWORD dwFlags = 0;
-		if (style.IsLoopEnable())
-			dwFlags = DSBPLAY_LOOPING;
+	DWORD dwFlags = 0;
+	if (style.IsLoopEnable())
+		dwFlags = DSBPLAY_LOOPING;
 
-		if (!(bPause_ && style.IsRestart())) {
-			this->Seek(style.GetStartTime());
-		}
-
-		HRESULT hr = pDirectSoundBuffer_->Play(0, 0, dwFlags);
-		if (hr == DSERR_BUFFERLOST) {
-			this->Restore();
-		}
-
-		bPause_ = false;
+	if (!(bPause_ && style.IsRestart())) {
+		this->Seek(style.GetStartTime());
 	}
+
+	HRESULT hr = pDirectSoundBuffer_->Play(0, 0, dwFlags);
+	if (hr == DSERR_BUFFERLOST) {
+		this->Restore();
+	}
+
+	bPause_ = false;
+
 	return true;
 }
 bool SoundPlayerWave::Stop()
 {
-	{
-		Lock lock(lock_);
-		if (IsPlaying())
-			bPause_ = true;
+	Lock lock(lock_);
+	if (IsPlaying())
+		bPause_ = true;
 
-		if (pDirectSoundBuffer_ != NULL)
-			pDirectSoundBuffer_->Stop();
-	}
+	if (pDirectSoundBuffer_ != nullptr)
+		pDirectSoundBuffer_->Stop();
 	return true;
 }
 bool SoundPlayerWave::IsPlaying() const
@@ -1023,11 +979,9 @@ bool SoundPlayerWave::IsPlaying() const
 }
 bool SoundPlayerWave::Seek(double time)
 {
-	{
-		Lock lock(lock_);
-		int pos = time * formatWave_.nAvgBytesPerSec;
-		pDirectSoundBuffer_->SetCurrentPosition(pos);
-	}
+	Lock lock(lock_);
+	int pos = time * formatWave_.nAvgBytesPerSec;
+	pDirectSoundBuffer_->SetCurrentPosition(pos);
 	return true;
 }
 /**********************************************************
@@ -1094,7 +1048,7 @@ bool SoundStreamingPlayerWave::_CreateBuffer(gstd::ref_count_ptr<gstd::FileReade
 	desc.dwFlags = DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLPAN | DSBCAPS_GETCURRENTPOSITION2 | DSBCAPS_GLOBALFOCUS | DSBCAPS_CTRLPOSITIONNOTIFY | DSBCAPS_LOCSOFTWARE;
 	desc.dwBufferBytes = 2 * formatWave_.nAvgBytesPerSec;
 	desc.lpwfxFormat = &formatWave_;
-	HRESULT hrBuffer = soundManager->GetDirectSound()->CreateSoundBuffer(&desc, (LPDIRECTSOUNDBUFFER*)&pDirectSoundBuffer_, NULL);
+	HRESULT hrBuffer = soundManager->GetDirectSound()->CreateSoundBuffer(&desc, (LPDIRECTSOUNDBUFFER*)&pDirectSoundBuffer_, nullptr);
 	if (FAILED(hrBuffer))
 		return false;
 
@@ -1138,21 +1092,17 @@ void SoundStreamingPlayerWave::_CopyBuffer(LPVOID pMem, DWORD dwSize)
 }
 bool SoundStreamingPlayerWave::Seek(double time)
 {
-	{
-		Lock lock(lock_);
-		int blockSize = formatWave_.nBlockAlign;
-		int pos = time * formatWave_.nAvgBytesPerSec;
-		pos = pos / blockSize * blockSize;
-		reader_->Seek(posWaveStart_ + pos);
-	}
+	Lock lock(lock_);
+	int blockSize = formatWave_.nBlockAlign;
+	int pos = time * formatWave_.nAvgBytesPerSec;
+	pos = pos / blockSize * blockSize;
+	reader_->Seek(posWaveStart_ + pos);
 	return true;
 }
 /**********************************************************
 //SoundStreamingPlayerOgg
 **********************************************************/
-SoundStreamingPlayerOgg::SoundStreamingPlayerOgg()
-{
-}
+SoundStreamingPlayerOgg::SoundStreamingPlayerOgg() = default;
 SoundStreamingPlayerOgg::~SoundStreamingPlayerOgg()
 {
 	this->Stop();
@@ -1174,7 +1124,7 @@ bool SoundStreamingPlayerOgg::_CreateBuffer(gstd::ref_count_ptr<gstd::FileReader
 	oggCallBacks_.tell_func = SoundStreamingPlayerOgg::_TellOgg;
 	ov_open_callbacks((void*)this, &fileOgg_, NULL, 0, oggCallBacks_);
 	vorbis_info* vi = ov_info(&fileOgg_, -1);
-	if (vi == NULL) {
+	if (vi == nullptr) {
 		ov_clear(&fileOgg_);
 		return false;
 	}
@@ -1212,7 +1162,7 @@ bool SoundStreamingPlayerOgg::_CreateBuffer(gstd::ref_count_ptr<gstd::FileReader
 	desc.dwFlags = DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLPAN | DSBCAPS_GETCURRENTPOSITION2 | DSBCAPS_GLOBALFOCUS | DSBCAPS_CTRLPOSITIONNOTIFY | DSBCAPS_LOCSOFTWARE;
 	desc.dwBufferBytes = sizeBuffer;
 	desc.lpwfxFormat = &formatWave_;
-	HRESULT hrBuffer = soundManager->GetDirectSound()->CreateSoundBuffer(&desc, (LPDIRECTSOUNDBUFFER*)&pDirectSoundBuffer_, NULL);
+	HRESULT hrBuffer = soundManager->GetDirectSound()->CreateSoundBuffer(&desc, (LPDIRECTSOUNDBUFFER*)&pDirectSoundBuffer_, nullptr);
 	if (FAILED(hrBuffer))
 		return false;
 
@@ -1285,16 +1235,14 @@ void SoundStreamingPlayerOgg::_CopyBuffer(LPVOID pMem, DWORD dwSize)
 }
 bool SoundStreamingPlayerOgg::Seek(double time)
 {
-	{
-		Lock lock(lock_);
-		ov_time_seek(&fileOgg_, time);
-	}
+	Lock lock(lock_);
+	ov_time_seek(&fileOgg_, time);
 	return true;
 }
 
 size_t SoundStreamingPlayerOgg::_ReadOgg(void* ptr, size_t size, size_t nmemb, void* source)
 {
-	SoundStreamingPlayerOgg* player = (SoundStreamingPlayerOgg*)source;
+	auto* player = (SoundStreamingPlayerOgg*)source;
 
 	int sizeCopy = size * nmemb;
 	sizeCopy = player->reader_->Read(ptr, sizeCopy);
@@ -1303,7 +1251,7 @@ size_t SoundStreamingPlayerOgg::_ReadOgg(void* ptr, size_t size, size_t nmemb, v
 int SoundStreamingPlayerOgg::_SeekOgg(void* source, ogg_int64_t offset, int whence)
 {
 	//現在の位置情報などをセットするコールバック関数です。
-	SoundStreamingPlayerOgg* player = (SoundStreamingPlayerOgg*)source;
+	auto* player = (SoundStreamingPlayerOgg*)source;
 	LONG high = (LONG)((offset & 0xFFFFFFFF00000000) >> 32);
 	LONG low = (LONG)((offset & 0x00000000FFFFFFFF) >> 0);
 
@@ -1333,7 +1281,7 @@ int SoundStreamingPlayerOgg::_CloseOgg(void* source)
 long SoundStreamingPlayerOgg::_TellOgg(void* source)
 {
 	//ファイルの現在の位置を返す関数です。
-	SoundStreamingPlayerOgg* player = (SoundStreamingPlayerOgg*)source;
+	auto* player = (SoundStreamingPlayerOgg*)source;
 	return player->reader_->GetFilePointer();
 }
 
@@ -1342,13 +1290,13 @@ long SoundStreamingPlayerOgg::_TellOgg(void* source)
 **********************************************************/
 SoundStreamingPlayerMp3::SoundStreamingPlayerMp3()
 {
-	hAcmStream_ = NULL;
+	hAcmStream_ = nullptr;
 	posMp3DataStart_ = 0;
 	posMp3DataEnd_ = 0;
 }
 SoundStreamingPlayerMp3::~SoundStreamingPlayerMp3()
 {
-	if (hAcmStream_ != NULL) {
+	if (hAcmStream_ != nullptr) {
 		acmStreamUnprepareHeader(hAcmStream_, &acmStreamHeader_, 0);
 		acmStreamClose(hAcmStream_, 0);
 
@@ -1509,7 +1457,7 @@ bool SoundStreamingPlayerMp3::_CreateBuffer(gstd::ref_count_ptr<gstd::FileReader
 	desc.dwFlags = DSBCAPS_CTRLVOLUME | DSBCAPS_CTRLPAN | DSBCAPS_GETCURRENTPOSITION2 | DSBCAPS_GLOBALFOCUS | DSBCAPS_CTRLPOSITIONNOTIFY | DSBCAPS_LOCSOFTWARE;
 	desc.dwBufferBytes = sizeBuffer;
 	desc.lpwfxFormat = &formatWave_;
-	HRESULT hrBuffer = soundManager->GetDirectSound()->CreateSoundBuffer(&desc, (LPDIRECTSOUNDBUFFER*)&pDirectSoundBuffer_, NULL);
+	HRESULT hrBuffer = soundManager->GetDirectSound()->CreateSoundBuffer(&desc, (LPDIRECTSOUNDBUFFER*)&pDirectSoundBuffer_, nullptr);
 	if (FAILED(hrBuffer))
 		return false;
 
@@ -1583,7 +1531,7 @@ void SoundStreamingPlayerMp3::_CopyBuffer(LPVOID pMem, DWORD dwSize)
 int SoundStreamingPlayerMp3::_ReadAcmStream(char* pBuffer, int size)
 {
 	int sizeWrite = 0;
-	if (bufDecode_ != NULL) {
+	if (bufDecode_ != nullptr) {
 		//前回デコード分を書き込み
 		int bufSize = bufDecode_->GetSize();
 		int copySize = min(size, bufSize);
@@ -1600,7 +1548,7 @@ int SoundStreamingPlayerMp3::_ReadAcmStream(char* pBuffer, int size)
 			return sizeWrite;
 		}
 
-		bufDecode_ = NULL;
+		bufDecode_ = nullptr;
 		pBuffer += sizeWrite;
 	}
 
@@ -1639,14 +1587,12 @@ bool SoundStreamingPlayerMp3::Seek(double time)
 
 	double waveBlockIndex = posSeekWave / waveBlockSize;
 	int mp3BlockIndex = (int)floor(waveBlockIndex + 0.5); //(waveBlockIndex * mp3BlockSize / waveBlockSize);
-	{
-		Lock lock(lock_);
-		double posSeekMp3 = mp3BlockSize * mp3BlockIndex;
-		reader_->Seek(posMp3DataStart_ + posSeekMp3);
+	Lock lock(lock_);
+	double posSeekMp3 = mp3BlockSize * mp3BlockIndex;
+	reader_->Seek(posMp3DataStart_ + posSeekMp3);
 
-		bufDecode_ = NULL;
-		timeCurrent_ = mp3BlockIndex * mp3BlockSize / formatMp3_.wfx.nAvgBytesPerSec;
-	}
+	bufDecode_ = nullptr;
+	timeCurrent_ = mp3BlockIndex * mp3BlockSize / formatMp3_.wfx.nAvgBytesPerSec;
 
 	return true;
 }

--- a/source/GcLib/directx/DirectSound.hpp
+++ b/source/GcLib/directx/DirectSound.hpp
@@ -66,10 +66,10 @@ public:
 	IDirectSound8* GetDirectSound() { return pDirectSound_; }
 	gstd::CriticalSection& GetLock() { return lock_; }
 
-	gstd::ref_count_ptr<SoundPlayer> GetPlayer(std::wstring path, bool bCreateAlways = false);
+	gstd::ref_count_ptr<SoundPlayer> GetPlayer(const std::wstring& path, bool bCreateAlways = false);
 	gstd::ref_count_ptr<SoundDivision> CreateSoundDivision(int index);
 	gstd::ref_count_ptr<SoundDivision> GetSoundDivision(int index);
-	gstd::ref_count_ptr<SoundInfo> GetSoundInfo(std::wstring path);
+	gstd::ref_count_ptr<SoundInfo> GetSoundInfo(const std::wstring& path);
 
 	void SetInfoPanel(gstd::ref_count_ptr<SoundInfoPanel> panel)
 	{
@@ -77,7 +77,7 @@ public:
 		panelInfo_ = panel;
 	}
 
-	bool AddSoundInfoFromFile(std::wstring path);
+	bool AddSoundInfoFromFile(const std::wstring& path);
 	std::vector<gstd::ref_count_ptr<SoundInfo>> GetSoundInfoList();
 	void SetFadeDeleteAll();
 
@@ -91,7 +91,7 @@ protected:
 	std::map<std::wstring, gstd::ref_count_ptr<SoundInfo>> mapInfo_;
 	gstd::ref_count_ptr<SoundInfoPanel> panelInfo_;
 
-	gstd::ref_count_ptr<SoundPlayer> _GetPlayer(std::wstring path);
+	gstd::ref_count_ptr<SoundPlayer> _GetPlayer(const std::wstring& path);
 
 private:
 	static DirectSoundManager* thisBase_;
@@ -157,7 +157,7 @@ public:
 	SoundDivision();
 	virtual ~SoundDivision();
 	void SetVolumeRate(double rate) { rateVolume_ = rate; }
-	double GetVolumeRate() { return rateVolume_; }
+	double GetVolumeRate() const { return rateVolume_; }
 
 protected:
 	double rateVolume_; //音量割合(0-100)
@@ -176,10 +176,10 @@ public:
 		timeLoopEnd_ = 0;
 	}
 	virtual ~SoundInfo(){};
-	std::wstring GetName() { return name_; }
-	std::wstring GetTitle() { return title_; }
-	double GetLoopStartTime() { return timeLoopStart_; }
-	double GetLoopEndTime() { return timeLoopEnd_; }
+	std::wstring GetName() const { return name_; }
+	std::wstring GetTitle() const { return title_; }
+	double GetLoopStartTime() const { return timeLoopStart_; }
+	double GetLoopEndTime() const { return timeLoopEnd_; }
 
 private:
 	std::wstring name_;
@@ -204,7 +204,7 @@ public:
 public:
 	SoundPlayer();
 	virtual ~SoundPlayer();
-	std::wstring GetPath() { return path_; }
+	std::wstring GetPath() const { return path_; }
 	gstd::CriticalSection& GetLock() { return lock_; }
 	virtual void Restore() { pDirectSoundBuffer_->Restore(); }
 	void SetSoundDivision(gstd::ref_count_ptr<SoundDivision> div);
@@ -213,7 +213,7 @@ public:
 	virtual bool Play();
 	virtual bool Play(PlayStyle& style);
 	virtual bool Stop();
-	virtual bool IsPlaying();
+	virtual bool IsPlaying() const;
 	virtual bool Seek(double time) = 0;
 	virtual bool SetVolumeRate(double rateVolume);
 	bool SetPanRate(double ratePan);
@@ -223,7 +223,7 @@ public:
 	void SetAutoDelete(bool bAuto = true) { bAutoDelete_ = bAuto; }
 	double GetFadeVolumeRate();
 	void Delete() { bDelete_ = true; }
-	WAVEFORMATEX GetWaveFormat() { return formatWave_; }
+	WAVEFORMATEX GetWaveFormat() const { return formatWave_; }
 
 protected:
 	DirectSoundManager* manager_;
@@ -254,14 +254,14 @@ public:
 	PlayStyle();
 	virtual ~PlayStyle();
 	void SetLoopEnable(bool bLoop) { bLoop_ = bLoop; }
-	bool IsLoopEnable() { return bLoop_; }
+	bool IsLoopEnable() const { return bLoop_; }
 	void SetLoopStartTime(double time) { timeLoopStart_ = time; }
-	double GetLoopStartTime() { return timeLoopStart_; }
+	double GetLoopStartTime() const { return timeLoopStart_; }
 	void SetLoopEndTime(double time) { timeLoopEnd_ = time; }
-	double GetLoopEndTime() { return timeLoopEnd_; }
+	double GetLoopEndTime() const { return timeLoopEnd_; }
 	void SetStartTime(double time) { timeStart_ = time; }
-	double GetStartTime() { return timeStart_; }
-	bool IsRestart() { return bRestart_; }
+	double GetStartTime() const { return timeStart_; }
+	bool IsRestart() const { return bRestart_; }
 	void SetRestart(bool b) { bRestart_ = b; }
 
 private:
@@ -287,7 +287,7 @@ protected:
 	bool bStreaming_;
 	bool bRequestStop_; //ループ完了時のフラグ。すぐ停止すると最後のバッファが再生されないため。
 
-	void _CreateSoundEvent(WAVEFORMATEX& formatWave);
+	void _CreateSoundEvent(const WAVEFORMATEX& formatWave);
 	virtual void _CopyStream(int indexCopy);
 	virtual void _CopyBuffer(LPVOID pMem, DWORD dwSize) = 0;
 	void _RequestStop() { bRequestStop_ = true; }
@@ -298,7 +298,7 @@ public:
 
 	virtual bool Play(PlayStyle& style);
 	virtual bool Stop();
-	virtual bool IsPlaying();
+	virtual bool IsPlaying() const;
 
 };
 class SoundStreamingPlayer::StreamingThread : public gstd::Thread, public gstd::InnerClass<SoundStreamingPlayer> {
@@ -319,7 +319,7 @@ public:
 
 	virtual bool Play(PlayStyle& style);
 	virtual bool Stop();
-	virtual bool IsPlaying();
+	virtual bool IsPlaying() const;
 	virtual bool Seek(double time);
 
 protected:

--- a/source/GcLib/directx/DirectSound.hpp
+++ b/source/GcLib/directx/DirectSound.hpp
@@ -82,9 +82,9 @@ public:
 	void SetFadeDeleteAll();
 
 protected:
+	mutable gstd::CriticalSection lock_;
 	IDirectSound8* pDirectSound_;
 	IDirectSoundBuffer8* pDirectSoundBuffer_;
-	gstd::CriticalSection lock_;
 	SoundManageThread* threadManage_;
 	std::map<std::wstring, std::list<gstd::ref_count_ptr<SoundPlayer>>> mapPlayer_;
 	std::map<int, gstd::ref_count_ptr<SoundDivision>> mapDivision_;
@@ -119,7 +119,7 @@ class SoundInfoPanel : public gstd::WindowLogger::Panel {
 public:
 	SoundInfoPanel();
 	void SetUpdateInterval(int time) { timeUpdateInterval_ = time; }
-	virtual void LocateParts();
+	void LocateParts() override;
 	virtual void Update(DirectSoundManager* soundManager);
 
 protected:
@@ -138,7 +138,7 @@ protected:
 	int timeLastUpdate_;
 	int timeUpdateInterval_;
 
-	virtual bool _AddedLogger(HWND hTab);
+	bool _AddedLogger(HWND hTab) override;
 };
 
 /**********************************************************
@@ -175,7 +175,7 @@ public:
 		timeLoopStart_ = 0;
 		timeLoopEnd_ = 0;
 	}
-	virtual ~SoundInfo(){};
+	virtual ~SoundInfo() = default;
 	std::wstring GetName() const { return name_; }
 	std::wstring GetTitle() const { return title_; }
 	double GetLoopStartTime() const { return timeLoopStart_; }
@@ -221,14 +221,14 @@ public:
 	void SetFade(double rateVolumeFadePerSec);
 	void SetFadeDelete(double rateVolumeFadePerSec);
 	void SetAutoDelete(bool bAuto = true) { bAutoDelete_ = bAuto; }
-	double GetFadeVolumeRate();
+	double GetFadeVolumeRate() const;
 	void Delete() { bDelete_ = true; }
 	WAVEFORMATEX GetWaveFormat() const { return formatWave_; }
 
 protected:
+	mutable gstd::CriticalSection lock_;
 	DirectSoundManager* manager_;
 	std::wstring path_;
-	gstd::CriticalSection lock_;
 	IDirectSoundBuffer8* pDirectSoundBuffer_;
 	gstd::ref_count_ptr<gstd::FileReader> reader_;
 	gstd::ref_count_ptr<SoundDivision> division_;
@@ -294,16 +294,16 @@ protected:
 
 public:
 	SoundStreamingPlayer();
-	virtual ~SoundStreamingPlayer();
+	~SoundStreamingPlayer() override;
 
-	virtual bool Play(PlayStyle& style);
-	virtual bool Stop();
-	virtual bool IsPlaying() const;
+	bool Play(PlayStyle& style) override;
+	bool Stop() override;
+	bool IsPlaying() const override;
 
 };
 class SoundStreamingPlayer::StreamingThread : public gstd::Thread, public gstd::InnerClass<SoundStreamingPlayer> {
 protected:
-	virtual void _Run();
+	void _Run() override;
 
 public:
 	StreamingThread(SoundStreamingPlayer* player) { _SetOuter(player); }
@@ -315,15 +315,15 @@ public:
 class SoundPlayerWave : public SoundPlayer {
 public:
 	SoundPlayerWave();
-	virtual ~SoundPlayerWave();
+	~SoundPlayerWave() override;
 
-	virtual bool Play(PlayStyle& style);
-	virtual bool Stop();
-	virtual bool IsPlaying() const;
-	virtual bool Seek(double time);
+	bool Play(PlayStyle& style) override;
+	bool Stop() override;
+	bool IsPlaying() const override;
+	bool Seek(double time) override;
 
 protected:
-	virtual bool _CreateBuffer(gstd::ref_count_ptr<gstd::FileReader> reader);
+	bool _CreateBuffer(gstd::ref_count_ptr<gstd::FileReader> reader) override;
 };
 
 /**********************************************************
@@ -332,13 +332,13 @@ protected:
 class SoundStreamingPlayerWave : public SoundStreamingPlayer {
 public:
 	SoundStreamingPlayerWave();
-	virtual bool Seek(double time);
+	bool Seek(double time) override;
 
 protected:
 	int posWaveStart_;
 	int posWaveEnd_;
-	virtual bool _CreateBuffer(gstd::ref_count_ptr<gstd::FileReader> reader);
-	virtual void _CopyBuffer(LPVOID pMem, DWORD dwSize);
+	bool _CreateBuffer(gstd::ref_count_ptr<gstd::FileReader> reader) override;
+	void _CopyBuffer(LPVOID pMem, DWORD dwSize) override;
 };
 
 /**********************************************************
@@ -347,15 +347,15 @@ protected:
 class SoundStreamingPlayerOgg : public SoundStreamingPlayer {
 public:
 	SoundStreamingPlayerOgg();
-	~SoundStreamingPlayerOgg();
-	virtual bool Seek(double time);
+	~SoundStreamingPlayerOgg() override;
+	bool Seek(double time) override;
 
 protected:
 	OggVorbis_File fileOgg_;
 	ov_callbacks oggCallBacks_;
 
-	virtual bool _CreateBuffer(gstd::ref_count_ptr<gstd::FileReader> reader);
-	virtual void _CopyBuffer(LPVOID pMem, DWORD dwSize);
+	bool _CreateBuffer(gstd::ref_count_ptr<gstd::FileReader> reader) override;
+	void _CopyBuffer(LPVOID pMem, DWORD dwSize) override;
 
 	static size_t _ReadOgg(void* ptr, size_t size, size_t nmemb, void* source);
 	static int _SeekOgg(void* source, ogg_int64_t offset, int whence);
@@ -369,8 +369,8 @@ protected:
 class SoundStreamingPlayerMp3 : public SoundStreamingPlayer {
 public:
 	SoundStreamingPlayerMp3();
-	~SoundStreamingPlayerMp3();
-	virtual bool Seek(double time);
+	~SoundStreamingPlayerMp3() override;
+	bool Seek(double time) override;
 
 protected:
 	MPEGLAYER3WAVEFORMAT formatMp3_;
@@ -383,8 +383,8 @@ protected:
 	double timeCurrent_;
 	gstd::ref_count_ptr<gstd::ByteBuffer> bufDecode_;
 
-	virtual bool _CreateBuffer(gstd::ref_count_ptr<gstd::FileReader> reader);
-	virtual void _CopyBuffer(LPVOID pMem, DWORD dwSize);
+	bool _CreateBuffer(gstd::ref_count_ptr<gstd::FileReader> reader) override;
+	void _CopyBuffer(LPVOID pMem, DWORD dwSize) override;
 	int _ReadAcmStream(char* pBuffer, int size);
 };
 

--- a/source/GcLib/directx/DxScript.cpp
+++ b/source/GcLib/directx/DxScript.cpp
@@ -17,14 +17,14 @@ DxScriptObjectBase::DxScriptObjectBase()
 	priRender_ = 0.5;
 	bDeleted_ = false;
 	bActive_ = false;
-	manager_ = NULL;
+	manager_ = nullptr;
 	idObject_ = DxScript::ID_INVALID;
 	idScript_ = ScriptClientBase::ID_SCRIPT_FREE;
 	typeObject_ = DxScript::OBJ_INVALID;
 }
 DxScriptObjectBase::~DxScriptObjectBase()
 {
-	if (manager_ != NULL && idObject_ != DxScript::ID_INVALID)
+	if (manager_ != nullptr && idObject_ != DxScript::ID_INVALID)
 		manager_->listUnusedIndex_.push_back(idObject_);
 }
 int DxScriptObjectBase::GetRenderPriorityI() const
@@ -42,9 +42,9 @@ DxScriptRenderObject::DxScriptRenderObject()
 	bFogEnable_ = false;
 	typeBlend_ = DirectGraphics::MODE_BLEND_ALPHA;
 	modeCulling_ = D3DCULL_NONE;
-	position_ = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
-	angle_ = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
-	scale_ = D3DXVECTOR3(1.0f, 1.0f, 1.0f);
+	position_ = D3DXVECTOR3(0.0F, 0.0F, 0.0F);
+	angle_ = D3DXVECTOR3(0.0F, 0.0F, 0.0F);
+	scale_ = D3DXVECTOR3(1.0F, 1.0F, 1.0F);
 }
 
 /**********************************************************
@@ -209,7 +209,7 @@ D3DXVECTOR3 DxScriptPrimitiveObject2D::GetVertexPosition(int index)
 	RenderObjectTLX* obj = GetObjectPointer();
 	VERTEX_TLX* vert = obj->GetVertex(index);
 
-	float bias = 0.5f;
+	float bias = 0.5F;
 	res.x = vert->position.x + bias;
 	res.y = vert->position.y + bias;
 	res.z = 0;
@@ -238,8 +238,8 @@ void DxScriptSpriteObject2D::Copy(DxScriptSpriteObject2D* src)
 	scale_ = src->scale_;
 	typeBlend_ = src->typeBlend_;
 
-	Sprite2D* destSprite2D = (Sprite2D*)objRender_.GetPointer();
-	Sprite2D* srcSprite2D = (Sprite2D*)src->objRender_.GetPointer();
+	auto* destSprite2D = (Sprite2D*)objRender_.GetPointer();
+	auto* srcSprite2D = (Sprite2D*)src->objRender_.GetPointer();
 	destSprite2D->Copy(srcSprite2D);
 }
 
@@ -278,9 +278,9 @@ void DxScriptSpriteListObject2D::CloseVertex()
 	SpriteList2D* obj = GetSpritePointer();
 	obj->CloseVertex();
 
-	position_ = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
-	angle_ = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
-	scale_ = D3DXVECTOR3(1.0f, 1.0f, 1.0f);
+	position_ = D3DXVECTOR3(0.0F, 0.0F, 0.0F);
+	angle_ = D3DXVECTOR3(0.0F, 0.0F, 0.0F);
+	scale_ = D3DXVECTOR3(1.0F, 1.0F, 1.0F);
 }
 
 /**********************************************************
@@ -310,10 +310,10 @@ void DxScriptPrimitiveObject3D::SetRenderState()
 {
 	if (idRelative_ >= 0) {
 		ref_count_ptr<DxScriptObjectBase>::unsync objRelative = manager_->GetObject(idRelative_);
-		if (objRelative != NULL) {
+		if (objRelative != nullptr) {
 			objRelative->SetRenderState();
-			DxScriptMeshObject* objMesh = dynamic_cast<DxScriptMeshObject*>(objRelative.GetPointer());
-			if (objMesh != NULL) {
+			auto* objMesh = dynamic_cast<DxScriptMeshObject*>(objRelative.GetPointer());
+			if (objMesh != nullptr) {
 				int frameAnime = objMesh->GetAnimeFrame();
 				std::wstring nameAnime = objMesh->GetAnimeName();
 				ref_count_ptr<DxMesh> mesh = objMesh->GetMesh();
@@ -440,10 +440,10 @@ void DxScriptTrajectoryObject3D::Work()
 {
 	if (idRelative_ >= 0) {
 		ref_count_ptr<DxScriptObjectBase>::unsync objRelative = manager_->GetObject(idRelative_);
-		if (objRelative != NULL) {
+		if (objRelative != nullptr) {
 			objRelative->SetRenderState();
-			DxScriptMeshObject* objMesh = dynamic_cast<DxScriptMeshObject*>(objRelative.GetPointer());
-			if (objMesh != NULL) {
+			auto* objMesh = dynamic_cast<DxScriptMeshObject*>(objRelative.GetPointer());
+			if (objMesh != nullptr) {
 				int frameAnime = objMesh->GetAnimeFrame();
 				std::wstring nameAnime = objMesh->GetAnimeName();
 				ref_count_ptr<DxMesh> mesh = objMesh->GetMesh();
@@ -497,7 +497,7 @@ DxScriptMeshObject::DxScriptMeshObject()
 
 void DxScriptMeshObject::Render()
 {
-	if (mesh_ == NULL)
+	if (mesh_ == nullptr)
 		return;
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	bool bEnvFogEnable = graphics->IsFogEnable();
@@ -539,7 +539,7 @@ void DxScriptMeshObject::SetAlpha(int alpha)
 }
 void DxScriptMeshObject::_UpdateMeshState()
 {
-	if (mesh_ == NULL)
+	if (mesh_ == nullptr)
 		return;
 	mesh_->SetPosition(position_);
 	mesh_->SetAngle(angle_);
@@ -548,7 +548,7 @@ void DxScriptMeshObject::_UpdateMeshState()
 }
 void DxScriptMeshObject::SetShader(gstd::ref_count_ptr<Shader> shader)
 {
-	if (mesh_ == NULL)
+	if (mesh_ == nullptr)
 		return;
 	mesh_->SetShader(shader);
 }
@@ -645,14 +645,12 @@ void DxScriptTextObject::SetColor(int r, int g, int b)
 int DxScriptTextObject::GetTotalWidth()
 {
 	_UpdateRenderer();
-	int res = textInfo_->GetTotalWidth();
-	return res;
+	return textInfo_->GetTotalWidth();
 }
 int DxScriptTextObject::GetTotalHeight()
 {
 	_UpdateRenderer();
-	int res = textInfo_->GetTotalHeight();
-	return res;
+	return textInfo_->GetTotalHeight();
 }
 void DxScriptTextObject::SetShader(gstd::ref_count_ptr<Shader> shader)
 {
@@ -669,40 +667,34 @@ DxSoundObject::DxSoundObject()
 }
 DxSoundObject::~DxSoundObject()
 {
-	if (player_ == NULL)
+	if (player_ == nullptr)
 		return;
 	player_->Delete();
 }
-bool DxSoundObject::Load(std::wstring path)
+bool DxSoundObject::Load(const std::wstring& path)
 {
 	DirectSoundManager* manager = DirectSoundManager::GetBase();
 	player_ = manager->GetPlayer(path);
-	if (player_ == NULL)
-		return false;
-
-	return true;
+	return player_ != NULL;
 }
 void DxSoundObject::Play()
 {
-	if (player_ != NULL)
+	if (player_ != nullptr)
 		player_->Play(style_);
 }
 
 /**********************************************************
 //DxFileObject
 **********************************************************/
-DxFileObject::DxFileObject()
-{
-}
-DxFileObject::~DxFileObject()
-{
-}
+DxFileObject::DxFileObject() = default;
+DxFileObject::~DxFileObject() = default;
+
 bool DxFileObject::OpenR(const std::wstring& path)
 {
 	file_ = new File(path);
 	bool res = file_->Open();
 	if (!res)
-		file_ = NULL;
+		file_ = nullptr;
 	return res;
 }
 bool DxFileObject::OpenW(const std::wstring& path)
@@ -723,12 +715,12 @@ bool DxFileObject::OpenW(const std::wstring& path)
 	file_ = new File(formattedPath);
 	bool res = file_->Create();
 	if (!res)
-		file_ = NULL;
+		file_ = nullptr;
 	return res;
 }
 void DxFileObject::Close()
 {
-	if (file_ == NULL)
+	if (file_ == nullptr)
 		return;
 	file_->Close();
 }
@@ -740,9 +732,7 @@ DxTextFileObject::DxTextFileObject()
 {
 	typeObject_ = DxScript::OBJ_FILE_TEXT;
 }
-DxTextFileObject::~DxTextFileObject()
-{
-}
+DxTextFileObject::~DxTextFileObject() = default;
 bool DxTextFileObject::OpenR(const std::wstring& path)
 {
 	listLine_.clear();
@@ -819,9 +809,9 @@ bool DxTextFileObject::OpenW(const std::wstring& path)
 }
 bool DxTextFileObject::Store()
 {
-	if (file_ == NULL)
+	if (file_ == nullptr)
 		return false;
-	for (int iLine = 0; iLine < listLine_.size(); iLine++) {
+	for (int iLine = 0; iLine < listLine_.size(); ++iLine) {
 		std::string str = listLine_[iLine];
 		if (iLine < listLine_.size() - 1)
 			str += "\r\n";
@@ -851,9 +841,8 @@ DxBinaryFileObject::DxBinaryFileObject()
 	byteOrder_ = ByteOrder::ENDIAN_LITTLE;
 	codePage_ = CP_ACP;
 }
-DxBinaryFileObject::~DxBinaryFileObject()
-{
-}
+DxBinaryFileObject::~DxBinaryFileObject() = default;
+
 bool DxBinaryFileObject::OpenR(const std::wstring& path)
 {
 	bool res = DxFileObject::OpenR(path);
@@ -897,9 +886,7 @@ DxScriptObjectManager::DxScriptObjectManager()
 	fogStart_ = 0;
 	fogEnd_ = 0;
 }
-DxScriptObjectManager::~DxScriptObjectManager()
-{
-}
+DxScriptObjectManager::~DxScriptObjectManager() = default;
 void DxScriptObjectManager::SetMaxObject(int max)
 {
 	if (obj_.size() == max)
@@ -908,7 +895,7 @@ void DxScriptObjectManager::SetMaxObject(int max)
 	if (obj_.size() < max) {
 		listUnusedIndex_.clear();
 		for (int iObj = 0; iObj < obj_.size(); iObj++) {
-			if (obj_[iObj] != NULL)
+			if (obj_[iObj] != nullptr)
 				continue;
 			listUnusedIndex_.push_back(iObj);
 		}
@@ -925,13 +912,12 @@ void DxScriptObjectManager::SetRenderBucketCapacity(int capacity)
 }
 void DxScriptObjectManager::_ArrangeActiveObjectList()
 {
-	std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>::iterator itr;
-	for (itr = listActiveObject_.begin(); itr != listActiveObject_.end();) {
-		gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj = (*itr);
-		if (obj == NULL || obj->IsDeleted() || !obj->IsActive())
+	for (auto itr = listActiveObject_.begin(); itr != listActiveObject_.end();) {
+		gstd::ref_count_ptr<DxScriptObjectBase>::unsync object = (*itr);
+		if (object == nullptr || object->IsDeleted() || !object->IsActive())
 			itr = listActiveObject_.erase(itr);
 		else
-			itr++;
+			++itr;
 	}
 }
 int DxScriptObjectManager::AddObject(gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj, bool bActivate)
@@ -945,7 +931,7 @@ int DxScriptObjectManager::AddObject(gstd::ref_count_ptr<DxScriptObjectBase>::un
 		Logger::WriteTop(StringUtility::Format(L"DxScriptObjectManagerサイズ拡張[%d->%d]", oldSize, newSize));
 	}
 
-	if (listUnusedIndex_.size() != 0) {
+	if (!listUnusedIndex_.empty()) {
 		res = listUnusedIndex_.front();
 		listUnusedIndex_.pop_front();
 
@@ -971,8 +957,7 @@ void DxScriptObjectManager::AddObject(int id, gstd::ref_count_ptr<DxScriptObject
 		listActiveObject_.push_back(obj);
 	}
 
-	std::list<int>::iterator itr = listUnusedIndex_.begin();
-	for (; itr != listUnusedIndex_.end(); itr++) {
+	for (auto itr = listUnusedIndex_.begin(); itr != listUnusedIndex_.end(); ++itr) {
 		if ((*itr) == id) {
 			listUnusedIndex_.erase(itr);
 			totalObjectCreateCount_++;
@@ -983,7 +968,7 @@ void DxScriptObjectManager::AddObject(int id, gstd::ref_count_ptr<DxScriptObject
 void DxScriptObjectManager::ActivateObject(int id, bool bActivate)
 {
 	gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj = GetObject(id);
-	if (obj == NULL || obj->IsDeleted())
+	if (obj == nullptr || obj->IsDeleted())
 		return;
 
 	if (bActivate && !obj->IsActive()) {
@@ -996,28 +981,28 @@ void DxScriptObjectManager::ActivateObject(int id, bool bActivate)
 std::vector<int> DxScriptObjectManager::GetValidObjectIdentifier()
 {
 	std::vector<int> res;
-	for (int iObj = 0; iObj < obj_.size(); iObj++) {
-		if (obj_[iObj] == NULL)
+	for (const auto& obj : obj_) {
+		if (obj == nullptr)
 			continue;
-		res.push_back(obj_[iObj]->idObject_);
+		res.push_back(obj->idObject_);
 	}
 	return res;
 }
 DxScriptObjectBase* DxScriptObjectManager::GetObjectPointer(int id)
 {
 	if (id < 0 || id >= obj_.size())
-		return NULL;
+		return nullptr;
 	return obj_[id].GetPointer();
 }
 void DxScriptObjectManager::DeleteObject(int id)
 {
 	if (id < 0 || id >= obj_.size())
 		return;
-	if (obj_[id] == NULL)
+	if (obj_[id] == nullptr)
 		return;
 
 	obj_[id]->bDeleted_ = true;
-	obj_[id] = NULL;
+	obj_[id] = nullptr;
 	//listUnusedIndex_.push_back(id);
 }
 void DxScriptObjectManager::ClearObject()
@@ -1035,21 +1020,20 @@ void DxScriptObjectManager::ClearObject()
 gstd::ref_count_ptr<Shader> DxScriptObjectManager::GetShader(int index)
 {
 	if (index < 0 || index >= listShader_.size())
-		return NULL;
-	ref_count_ptr<Shader> shader = listShader_[index];
-	return shader;
+		return nullptr;
+	return listShader_[index];
 }
-void DxScriptObjectManager::DeleteObjectByScriptID(_int64 idScript)
+void DxScriptObjectManager::DeleteObjectByScriptID(int64_t idScript)
 {
 	if (idScript == ScriptClientBase::ID_SCRIPT_FREE)
 		return;
 
-	for (int iObj = 0; iObj < obj_.size(); iObj++) {
-		if (obj_[iObj] == NULL)
+	for (auto& iObj : obj_) {
+		if (iObj == nullptr)
 			continue;
-		if (obj_[iObj]->GetScriptID() != idScript)
+		if (iObj->GetScriptID() != idScript)
 			continue;
-		DeleteObject(obj_[iObj]->GetObjectID());
+		DeleteObject(iObj->GetObjectID());
 	}
 }
 void DxScriptObjectManager::AddRenderObject(gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj)
@@ -1067,19 +1051,16 @@ void DxScriptObjectManager::AddRenderObject(gstd::ref_count_ptr<DxScriptObjectBa
 void DxScriptObjectManager::WorkObject()
 {
 	_ArrangeActiveObjectList();
-	std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>::iterator itr;
-	for (itr = listActiveObject_.begin(); itr != listActiveObject_.end(); itr++) {
-		gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj = (*itr);
-		if (obj == NULL || obj->IsDeleted())
+	for (auto& object : listActiveObject_) {
+		if (object == nullptr || object->IsDeleted())
 			continue;
-		obj->Work();
+		object->Work();
 	}
 
 	//音声再生
 	DirectSoundManager* soundManager = DirectSoundManager::GetBase();
-	std::map<std::wstring, ref_count_ptr<SoundInfo>>::iterator itrSound = mapReservedSound_.begin();
-	for (; itrSound != mapReservedSound_.end(); itrSound++) {
-		gstd::ref_count_ptr<SoundInfo> info = itrSound->second;
+	for (auto& itrSound : mapReservedSound_) {
+		gstd::ref_count_ptr<SoundInfo> info = itrSound.second;
 		gstd::ref_count_ptr<SoundPlayer> player = info->player_;
 		SoundPlayer::PlayStyle style = info->style_;
 		player->Play(style);
@@ -1095,44 +1076,41 @@ void DxScriptObjectManager::RenderObject()
 
 	for (int iPri = 0; iPri < objRender_.size(); iPri++) {
 		ref_count_ptr<Shader> shader = listShader_[iPri];
-		if (shader != NULL) {
+		if (shader != nullptr) {
 			shader->Begin();
 		}
 
-		std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>::iterator itr;
-		for (itr = objRender_[iPri].begin(); itr != objRender_[iPri].end(); itr++) {
-			(*itr)->Render();
+		for (auto& object : objRender_[iPri]) {
+			object->Render();
 		}
 		objRender_[iPri].clear();
 
-		if (shader != NULL) {
+		if (shader != nullptr) {
 			shader->End();
 		}
 	}
 }
 void DxScriptObjectManager::PrepareRenderObject()
 {
-	std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>::iterator itr;
-	for (itr = listActiveObject_.begin(); itr != listActiveObject_.end(); itr++) {
-		gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj = (*itr);
-		if (obj == NULL || obj->IsDeleted())
+	for (auto& object : listActiveObject_) {
+		if (object == nullptr || object->IsDeleted())
 			continue;
-		if (!obj->IsVisible())
+		if (!object->IsVisible())
 			continue;
-		AddRenderObject(obj);
+		AddRenderObject(object);
 	}
 }
 void DxScriptObjectManager::ClearRenderObject()
 {
-	for (int iPri = 0; iPri < objRender_.size(); iPri++) {
-		objRender_[iPri].clear();
+	for (auto& iPri : objRender_) {
+		iPri.clear();
 	}
 }
 void DxScriptObjectManager::SetShader(gstd::ref_count_ptr<Shader> shader, double min, double max)
 {
 	int tPriMin = (int)(min * (listShader_.size() - 1) + 0.5);
 	int tPriMax = (int)(max * (listShader_.size() - 1) + 0.5);
-	for (int iPri = tPriMin; iPri <= tPriMax; iPri++) {
+	for (int iPri = tPriMin; iPri <= tPriMax; ++iPri) {
 		if (iPri < 0 || iPri >= listShader_.size())
 			break;
 		listShader_[iPri] = shader;
@@ -1144,7 +1122,7 @@ void DxScriptObjectManager::ResetShader()
 }
 void DxScriptObjectManager::ResetShader(double min, double max)
 {
-	SetShader(NULL, min, max);
+	SetShader(nullptr, min, max);
 }
 
 void DxScriptObjectManager::ReserveSound(ref_count_ptr<SoundPlayer> player, const SoundPlayer::PlayStyle& style)
@@ -1641,9 +1619,8 @@ void DxScript::_ClearResource()
 	mapTexture_.clear();
 	mapMesh_.clear();
 
-	std::map<std::wstring, gstd::ref_count_ptr<SoundPlayer>>::iterator itrSound;
-	for (itrSound = mapSoundPlayer_.begin(); itrSound != mapSoundPlayer_.end(); itrSound++) {
-		SoundPlayer* player = (itrSound->second).GetPointer();
+	for (auto& itrSound : mapSoundPlayer_) {
+		SoundPlayer* player = (itrSound.second).GetPointer();
 		player->Delete();
 	}
 	mapSoundPlayer_.clear();
@@ -1655,17 +1632,17 @@ int DxScript::AddObject(gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj, boo
 }
 gstd::ref_count_ptr<Texture> DxScript::_GetTexture(const std::wstring& name)
 {
-	gstd::ref_count_ptr<Texture> res;
-	if (mapTexture_.find(name) != mapTexture_.end()) {
-		res = mapTexture_[name];
+	auto mapItr = mapTexture_.find(name);
+	if (mapItr != mapTexture_.end()) {
+		return mapItr->second;
 	}
-	return res;
+	return nullptr;
 }
 
 //Dx関数：システム系系
 gstd::value DxScript::Func_InstallFont(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	DirectSoundManager* manager = DirectSoundManager::GetBase();
 
 	std::wstring path = argv[0].as_string();
@@ -1683,7 +1660,7 @@ gstd::value DxScript::Func_InstallFont(gstd::script_machine* machine, int argc, 
 //Dx関数：音声系
 value DxScript::Func_LoadSound(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	DirectSoundManager* manager = DirectSoundManager::GetBase();
 
 	std::wstring path = argv[0].as_string();
@@ -1692,14 +1669,14 @@ value DxScript::Func_LoadSound(script_machine* machine, int argc, value const* a
 		return value(machine->get_engine()->get_boolean_type(), true);
 
 	ref_count_ptr<SoundPlayer> player = manager->GetPlayer(path, true);
-	if (player != NULL) {
+	if (player != nullptr) {
 		script->mapSoundPlayer_[path] = player;
 	}
-	return value(machine->get_engine()->get_boolean_type(), player != NULL);
+	return value(machine->get_engine()->get_boolean_type(), player != nullptr);
 }
 value DxScript::Func_RemoveSound(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	DirectSoundManager* manager = DirectSoundManager::GetBase();
 
 	std::wstring path = argv[0].as_string();
@@ -1714,7 +1691,7 @@ value DxScript::Func_RemoveSound(script_machine* machine, int argc, value const*
 }
 value DxScript::Func_PlayBGM(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	DirectSoundManager* manager = DirectSoundManager::GetBase();
 
 	std::wstring path = argv[0].as_string();
@@ -1738,7 +1715,7 @@ value DxScript::Func_PlayBGM(script_machine* machine, int argc, value const* arg
 }
 gstd::value DxScript::Func_PlaySE(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	DirectSoundManager* manager = DirectSoundManager::GetBase();
 
 	std::wstring path = argv[0].as_string();
@@ -1758,7 +1735,7 @@ gstd::value DxScript::Func_PlaySE(gstd::script_machine* machine, int argc, gstd:
 
 value DxScript::Func_StopSound(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	DirectSoundManager* manager = DirectSoundManager::GetBase();
 
 	std::wstring path = argv[0].as_string();
@@ -1807,8 +1784,8 @@ gstd::value DxScript::Func_GetMouseState(gstd::script_machine* machine, int argc
 gstd::value DxScript::Func_GetVirtualKeyState(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	long double res = KEY_FREE;
-	VirtualKeyManager* input = dynamic_cast<VirtualKeyManager*>(DirectInput::GetBase());
-	if (input != NULL) {
+	auto* input = dynamic_cast<VirtualKeyManager*>(DirectInput::GetBase());
+	if (input != nullptr) {
 		int id = (int)(argv[0].as_real());
 		res = input->GetVirtualKeyState(id);
 	}
@@ -1816,12 +1793,12 @@ gstd::value DxScript::Func_GetVirtualKeyState(gstd::script_machine* machine, int
 }
 gstd::value DxScript::Func_SetVirtualKeyState(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	VirtualKeyManager* input = dynamic_cast<VirtualKeyManager*>(DirectInput::GetBase());
-	if (input != NULL) {
+	auto* input = dynamic_cast<VirtualKeyManager*>(DirectInput::GetBase());
+	if (input != nullptr) {
 		int id = (int)(argv[0].as_real());
 		int state = (int)(argv[1].as_real());
 		ref_count_ptr<VirtualKey> vkey = input->GetVirtualKey(id);
-		if (vkey != NULL) {
+		if (vkey != nullptr) {
 			vkey->SetKeyState(state);
 		}
 	}
@@ -1842,7 +1819,7 @@ gstd::value DxScript::Func_GetScreenHeight(gstd::script_machine* machine, int ar
 }
 value DxScript::Func_LoadTexture(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	bool res = true;
 	std::wstring path = argv[0].as_string();
 	path = PathProperty::GetUnique(path);
@@ -1859,7 +1836,7 @@ value DxScript::Func_LoadTexture(script_machine* machine, int argc, value const*
 }
 value DxScript::Func_LoadTextureInLoadThread(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	bool res = true;
 	std::wstring path = argv[0].as_string();
 	path = PathProperty::GetUnique(path);
@@ -1876,7 +1853,7 @@ value DxScript::Func_LoadTextureInLoadThread(script_machine* machine, int argc, 
 }
 value DxScript::Func_RemoveTexture(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	std::wstring path = argv[0].as_string();
 	path = PathProperty::GetUnique(path);
 	{
@@ -1888,13 +1865,13 @@ value DxScript::Func_RemoveTexture(script_machine* machine, int argc, value cons
 value DxScript::Func_GetTextureWidth(script_machine* machine, int argc, value const* argv)
 {
 	long double res = 0;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	std::wstring path = argv[0].as_string();
 	path = PathProperty::GetUnique(path);
 	TextureManager* textureManager = TextureManager::GetBase();
 
 	gstd::ref_count_ptr<TextureData> textureData = textureManager->GetTextureData(path);
-	if (textureData != NULL) {
+	if (textureData != nullptr) {
 		D3DXIMAGE_INFO imageInfo = textureData->GetImageInfo();
 		res = imageInfo.Width;
 	}
@@ -1903,13 +1880,13 @@ value DxScript::Func_GetTextureWidth(script_machine* machine, int argc, value co
 value DxScript::Func_GetTextureHeight(script_machine* machine, int argc, value const* argv)
 {
 	long double res = 0;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	std::wstring path = argv[0].as_string();
 	path = PathProperty::GetUnique(path);
 	TextureManager* textureManager = TextureManager::GetBase();
 
 	gstd::ref_count_ptr<TextureData> textureData = textureManager->GetTextureData(path);
-	if (textureData != NULL) {
+	if (textureData != nullptr) {
 		D3DXIMAGE_INFO imageInfo = textureData->GetImageInfo();
 		res = imageInfo.Height;
 	}
@@ -1917,14 +1894,14 @@ value DxScript::Func_GetTextureHeight(script_machine* machine, int argc, value c
 }
 gstd::value DxScript::Func_SetFogEnable(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	bool bEnable = argv[0].as_boolean();
 	script->GetObjectManager()->SetFogParam(bEnable, 0, 0, 0);
 	return value();
 }
 gstd::value DxScript::Func_SetFogParam(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	double start = argv[0].as_real();
 	double end = argv[1].as_real();
 	int r = (int)argv[2].as_real();
@@ -1936,7 +1913,7 @@ gstd::value DxScript::Func_SetFogParam(gstd::script_machine* machine, int argc, 
 }
 gstd::value DxScript::Func_CreateRenderTarget(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	bool res = true;
 	std::wstring name = argv[0].as_string();
 
@@ -1952,14 +1929,14 @@ gstd::value DxScript::Func_CreateRenderTarget(gstd::script_machine* machine, int
 }
 gstd::value DxScript::Func_SetRenderTarget(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	TextureManager* textureManager = TextureManager::GetBase();
 
 	std::wstring name = argv[0].as_string();
 	ref_count_ptr<Texture> texture = script->_GetTexture(name);
-	if (texture == NULL)
+	if (texture == nullptr)
 		texture = textureManager->GetTexture(name);
-	if (texture == NULL)
+	if (texture == nullptr)
 		return value();
 
 	DirectGraphics* graphics = DirectGraphics::GetBase();
@@ -1976,7 +1953,7 @@ gstd::value DxScript::Func_GetTransitionRenderTargetName(gstd::script_machine* m
 }
 gstd::value DxScript::Func_SaveRenderedTextureA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	std::wstring nameTexture = argv[0].as_string();
 	std::wstring path = argv[1].as_string();
 	path = PathProperty::GetUnique(path);
@@ -1985,10 +1962,10 @@ gstd::value DxScript::Func_SaveRenderedTextureA1(gstd::script_machine* machine, 
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 
 	ref_count_ptr<Texture> texture = script->_GetTexture(nameTexture);
-	if (texture == NULL)
+	if (texture == nullptr)
 		texture = textureManager->GetTexture(nameTexture);
 
-	if (texture != NULL) {
+	if (texture != nullptr) {
 		//フォルダ生成
 		std::wstring dir = PathProperty::GetFileDirectory(path);
 		File fDir(dir);
@@ -1998,13 +1975,13 @@ gstd::value DxScript::Func_SaveRenderedTextureA1(gstd::script_machine* machine, 
 		IDirect3DSurface9* pSurface = texture->GetD3DSurface();
 		RECT rect = { 0, 0, graphics->GetScreenWidth(), graphics->GetScreenHeight() };
 		D3DXSaveSurfaceToFile(path.c_str(), D3DXIFF_BMP,
-			pSurface, NULL, &rect);
+			pSurface, nullptr, &rect);
 	}
 	return value();
 }
 gstd::value DxScript::Func_SaveRenderedTextureA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 
 	std::wstring nameTexture = argv[0].as_string();
 	std::wstring path = argv[1].as_string();
@@ -2019,9 +1996,9 @@ gstd::value DxScript::Func_SaveRenderedTextureA2(gstd::script_machine* machine, 
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 
 	ref_count_ptr<Texture> texture = script->_GetTexture(nameTexture);
-	if (texture == NULL)
+	if (texture == nullptr)
 		texture = textureManager->GetTexture(nameTexture);
-	if (texture != NULL) {
+	if (texture != nullptr) {
 		//フォルダ生成
 		std::wstring dir = PathProperty::GetFileDirectory(path);
 		File fDir(dir);
@@ -2031,14 +2008,14 @@ gstd::value DxScript::Func_SaveRenderedTextureA2(gstd::script_machine* machine, 
 		IDirect3DSurface9* pSurface = texture->GetD3DSurface();
 		RECT rect = { rcLeft, rcTop, rcRight, rcBottom };
 		D3DXSaveSurfaceToFile(path.c_str(), D3DXIFF_BMP,
-			pSurface, NULL, &rect);
+			pSurface, nullptr, &rect);
 	}
 	return value();
 }
 gstd::value DxScript::Func_IsPixelShaderSupported(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
-	ref_count_ptr<Shader> shader = NULL;
+	auto* script = (DxScript*)machine->data;
+	ref_count_ptr<Shader> shader = nullptr;
 
 	int major = (int)(argv[0].as_real() + 0.5);
 	int minor = (int)(argv[1].as_real() + 0.5);
@@ -2050,26 +2027,26 @@ gstd::value DxScript::Func_IsPixelShaderSupported(gstd::script_machine* machine,
 
 gstd::value DxScript::Func_SetShader(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	ref_count_ptr<Shader> shader = obj->GetShader();
 
-	double min = (double)argv[1].as_real();
-	double max = (double)argv[2].as_real();
+	auto min = (double)argv[1].as_real();
+	auto max = (double)argv[2].as_real();
 	gstd::ref_count_ptr<DxScriptObjectManager> objectManager = script->GetObjectManager();
 	objectManager->SetShader(shader, min, max);
 	return value();
 }
 gstd::value DxScript::Func_SetShaderI(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	ref_count_ptr<Shader> shader = obj->GetShader();
@@ -2087,11 +2064,11 @@ gstd::value DxScript::Func_SetShaderI(gstd::script_machine* machine, int argc, g
 }
 gstd::value DxScript::Func_ResetShader(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
-	ref_count_ptr<Shader> shader = NULL;
+	auto* script = (DxScript*)machine->data;
+	ref_count_ptr<Shader> shader = nullptr;
 
-	double min = (double)argv[0].as_real();
-	double max = (double)argv[1].as_real();
+	auto min = (double)argv[0].as_real();
+	auto max = (double)argv[1].as_real();
 
 	gstd::ref_count_ptr<DxScriptObjectManager> objectManager = script->GetObjectManager();
 	objectManager->SetShader(shader, min, max);
@@ -2099,8 +2076,8 @@ gstd::value DxScript::Func_ResetShader(gstd::script_machine* machine, int argc, 
 }
 gstd::value DxScript::Func_ResetShaderI(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
-	ref_count_ptr<Shader> shader = NULL;
+	auto* script = (DxScript*)machine->data;
+	ref_count_ptr<Shader> shader = nullptr;
 
 	int size = script->GetObjectManager()->GetRenderBucketCapacity();
 	int min = (int)(argv[0].as_real() + 0.5);
@@ -2362,16 +2339,16 @@ gstd::value DxScript::Func_Get2DCameraRatioY(gstd::script_machine* machine, int 
 //Dx関数：その他
 gstd::value DxScript::Func_GetObjectDistance(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id1 = (int)argv[0].as_real();
 	int id2 = (int)argv[1].as_real();
 
-	DxScriptRenderObject* obj1 = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id1));
-	if (obj1 == NULL)
+	auto* obj1 = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id1));
+	if (obj1 == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)-1);
 
-	DxScriptRenderObject* obj2 = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id2));
-	if (obj2 == NULL)
+	auto* obj2 = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id2));
+	if (obj2 == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)-1);
 
 	int tx = obj1->GetPosition().x - obj2->GetPosition().x;
@@ -2383,11 +2360,11 @@ gstd::value DxScript::Func_GetObjectDistance(gstd::script_machine* machine, int 
 }
 gstd::value DxScript::Func_GetObject2dPosition(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		script->RaiseError(L"error invalid object");
 
 	DirectGraphics* graphics = DirectGraphics::GetBase();
@@ -2404,7 +2381,7 @@ gstd::value DxScript::Func_GetObject2dPosition(gstd::script_machine* machine, in
 }
 gstd::value DxScript::Func_Get2dPosition(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	double px = argv[0].as_real();
 	double py = argv[1].as_real();
 	double pz = argv[2].as_real();
@@ -2425,7 +2402,7 @@ gstd::value DxScript::Func_Get2dPosition(gstd::script_machine* machine, int argc
 //Dx関数：オブジェクト操作(共通)
 value DxScript::Func_Obj_Delete(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	script->CheckRunInMainThread();
 	int id = (int)argv[0].as_real();
 	script->DeleteObject(id);
@@ -2433,38 +2410,38 @@ value DxScript::Func_Obj_Delete(script_machine* machine, int argc, value const* 
 }
 value DxScript::Func_Obj_IsDeleted(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	DxScriptObjectBase* obj = script->GetObjectPointer(id);
-	bool res = obj == NULL;
+	bool res = obj == nullptr;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
 value DxScript::Func_Obj_SetVisible(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	DxScriptObjectBase* obj = script->GetObjectPointer(id);
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 	obj->bVisible_ = argv[1].as_boolean();
 	return value();
 }
 value DxScript::Func_Obj_IsVisible(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	DxScriptObjectBase* obj = script->GetObjectPointer(id);
 	bool res = false;
-	if (obj != NULL)
+	if (obj != nullptr)
 		res = obj->bVisible_;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
 value DxScript::Func_Obj_SetRenderPriority(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	DxScriptObjectBase* obj = script->GetObjectPointer(id);
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 	double pri = argv[1].as_real();
 	if (pri < 0)
@@ -2476,10 +2453,10 @@ value DxScript::Func_Obj_SetRenderPriority(script_machine* machine, int argc, va
 }
 value DxScript::Func_Obj_SetRenderPriorityI(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	DxScriptObjectBase* obj = script->GetObjectPointer(id);
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	int pos = (int)(argv[1].as_real() + 0.5);
@@ -2497,10 +2474,10 @@ gstd::value DxScript::Func_Obj_GetRenderPriority(gstd::script_machine* machine, 
 {
 	long double res = 0;
 
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	DxScriptObjectBase* obj = script->GetObjectPointer(id);
-	if (obj != NULL)
+	if (obj != nullptr)
 		res = obj->GetRenderPriority();
 	return value(machine->get_engine()->get_real_type(), res);
 }
@@ -2508,22 +2485,22 @@ gstd::value DxScript::Func_Obj_GetRenderPriorityI(gstd::script_machine* machine,
 {
 	long double res = 0;
 
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	DxScriptObjectBase* obj = script->GetObjectPointer(id);
-	if (obj != NULL)
+	if (obj != nullptr)
 		res = obj->GetRenderPriorityI();
 	return value(machine->get_engine()->get_real_type(), res);
 }
 
 gstd::value DxScript::Func_Obj_GetValue(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	std::wstring key = argv[1].as_string();
 
 	DxScriptObjectBase* obj = script->GetObjectPointer(id);
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	gstd::value res = obj->GetObjectValue(key);
@@ -2531,13 +2508,13 @@ gstd::value DxScript::Func_Obj_GetValue(gstd::script_machine* machine, int argc,
 }
 gstd::value DxScript::Func_Obj_GetValueD(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	std::wstring key = argv[1].as_string();
 	gstd::value def = argv[2];
 
 	DxScriptObjectBase* obj = script->GetObjectPointer(id);
-	if (obj == NULL)
+	if (obj == nullptr)
 		return def;
 
 	gstd::value res = def;
@@ -2548,13 +2525,13 @@ gstd::value DxScript::Func_Obj_GetValueD(gstd::script_machine* machine, int argc
 }
 gstd::value DxScript::Func_Obj_SetValue(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	std::wstring key = argv[1].as_string();
 	gstd::value val = argv[2];
 
 	DxScriptObjectBase* obj = script->GetObjectPointer(id);
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	obj->SetObjectValue(key, val);
@@ -2562,12 +2539,12 @@ gstd::value DxScript::Func_Obj_SetValue(gstd::script_machine* machine, int argc,
 }
 gstd::value DxScript::Func_Obj_DeleteValue(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	std::wstring key = argv[1].as_string();
 
 	DxScriptObjectBase* obj = script->GetObjectPointer(id);
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	obj->DeleteObjectValue(key);
@@ -2575,12 +2552,12 @@ gstd::value DxScript::Func_Obj_DeleteValue(gstd::script_machine* machine, int ar
 }
 gstd::value DxScript::Func_Obj_IsValueExists(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	std::wstring key = argv[1].as_string();
 
 	DxScriptObjectBase* obj = script->GetObjectPointer(id);
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	bool res = obj->IsObjectValueExists(key);
@@ -2589,10 +2566,10 @@ gstd::value DxScript::Func_Obj_IsValueExists(gstd::script_machine* machine, int 
 value DxScript::Func_Obj_GetType(script_machine* machine, int argc, value const* argv)
 {
 	long double res = DxScript::OBJ_INVALID;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptObjectBase* obj = dynamic_cast<DxScriptObjectBase*>(script->GetObjectPointer(id));
-	if (obj != NULL)
+	auto* obj = dynamic_cast<DxScriptObjectBase*>(script->GetObjectPointer(id));
+	if (obj != nullptr)
 		res = obj->GetObjectType();
 	return value(machine->get_engine()->get_real_type(), res);
 }
@@ -2600,40 +2577,40 @@ value DxScript::Func_Obj_GetType(script_machine* machine, int argc, value const*
 //Dx関数：オブジェクト操作(RenderObject)
 value DxScript::Func_ObjRender_SetX(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetX(argv[1].as_real());
 	return value();
 }
 value DxScript::Func_ObjRender_SetY(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetY(argv[1].as_real());
 	return value();
 }
 value DxScript::Func_ObjRender_SetZ(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetZ(argv[1].as_real());
 	return value();
 }
 value DxScript::Func_ObjRender_SetPosition(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetX(argv[1].as_real());
 	obj->SetY(argv[2].as_real());
@@ -2642,40 +2619,40 @@ value DxScript::Func_ObjRender_SetPosition(script_machine* machine, int argc, va
 }
 value DxScript::Func_ObjRender_SetAngleX(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetAngleX(argv[1].as_real());
 	return value();
 }
 value DxScript::Func_ObjRender_SetAngleY(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetAngleY(argv[1].as_real());
 	return value();
 }
 value DxScript::Func_ObjRender_SetAngleZ(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetAngleZ(argv[1].as_real());
 	return value();
 }
 value DxScript::Func_ObjRender_SetAngleXYZ(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetAngleX(argv[1].as_real());
 	obj->SetAngleY(argv[2].as_real());
@@ -2684,40 +2661,40 @@ value DxScript::Func_ObjRender_SetAngleXYZ(script_machine* machine, int argc, va
 }
 value DxScript::Func_ObjRender_SetScaleX(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetScaleX(argv[1].as_real());
 	return value();
 }
 value DxScript::Func_ObjRender_SetScaleY(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetScaleY(argv[1].as_real());
 	return value();
 }
 value DxScript::Func_ObjRender_SetScaleZ(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetScaleZ(argv[1].as_real());
 	return value();
 }
 value DxScript::Func_ObjRender_SetScaleXYZ(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetScaleX(argv[1].as_real());
 	obj->SetScaleY(argv[2].as_real());
@@ -2726,20 +2703,20 @@ value DxScript::Func_ObjRender_SetScaleXYZ(script_machine* machine, int argc, va
 }
 value DxScript::Func_ObjRender_SetColor(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetColor((int)argv[1].as_real(), (int)argv[2].as_real(), (int)argv[3].as_real());
 	return value();
 }
 value DxScript::Func_ObjRender_SetColorHSV(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int hue = (int)argv[1].as_real();
@@ -2758,20 +2735,20 @@ value DxScript::Func_ObjRender_SetColorHSV(script_machine* machine, int argc, va
 }
 value DxScript::Func_ObjRender_SetAlpha(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetAlpha((int)argv[1].as_real());
 	return value();
 }
 value DxScript::Func_ObjRender_SetBlendType(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->typeBlend_ = (int)argv[1].as_real();
 	return value();
@@ -2779,161 +2756,161 @@ value DxScript::Func_ObjRender_SetBlendType(script_machine* machine, int argc, v
 value DxScript::Func_ObjRender_GetX(script_machine* machine, int argc, value const* argv)
 {
 	long double res = 0;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj != NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj != nullptr)
 		res = obj->position_.x;
 	return value(machine->get_engine()->get_real_type(), res);
 }
 value DxScript::Func_ObjRender_GetY(script_machine* machine, int argc, value const* argv)
 {
 	long double res = 0;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj != NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj != nullptr)
 		res = obj->position_.y;
 	return value(machine->get_engine()->get_real_type(), res);
 }
 value DxScript::Func_ObjRender_GetZ(script_machine* machine, int argc, value const* argv)
 {
 	long double res = 0;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj != NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj != nullptr)
 		res = obj->position_.z;
 	return value(machine->get_engine()->get_real_type(), res);
 }
 gstd::value DxScript::Func_ObjRender_GetAngleX(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	long double res = 0;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj != NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj != nullptr)
 		res = obj->angle_.x;
 	return value(machine->get_engine()->get_real_type(), res);
 }
 gstd::value DxScript::Func_ObjRender_GetAngleY(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	long double res = 0;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj != NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj != nullptr)
 		res = obj->angle_.y;
 	return value(machine->get_engine()->get_real_type(), res);
 }
 gstd::value DxScript::Func_ObjRender_GetAngleZ(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	long double res = 0;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj != NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj != nullptr)
 		res = obj->angle_.z;
 	return value(machine->get_engine()->get_real_type(), res);
 }
 gstd::value DxScript::Func_ObjRender_GetScaleX(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	long double res = 0;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj != NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj != nullptr)
 		res = obj->scale_.x;
 	return value(machine->get_engine()->get_real_type(), res);
 }
 gstd::value DxScript::Func_ObjRender_GetScaleY(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	long double res = 0;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj != NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj != nullptr)
 		res = obj->scale_.y;
 	return value(machine->get_engine()->get_real_type(), res);
 }
 gstd::value DxScript::Func_ObjRender_GetScaleZ(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	long double res = 0;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj != NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj != nullptr)
 		res = obj->scale_.z;
 	return value(machine->get_engine()->get_real_type(), res);
 }
 
 value DxScript::Func_ObjRender_SetZWrite(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->bZWrite_ = argv[1].as_boolean();
 	return value();
 }
 value DxScript::Func_ObjRender_SetZTest(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->bZTest_ = argv[1].as_boolean();
 	return value();
 }
 value DxScript::Func_ObjRender_SetFogEnable(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->bFogEnable_ = argv[1].as_boolean();
 	return value();
 }
 value DxScript::Func_ObjRender_SetCullingMode(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->modeCulling_ = (int)argv[1].as_boolean();
 	return value();
 }
 value DxScript::Func_ObjRender_SetRalativeObject(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int idRelative = (int)argv[1].as_real();
 	std::wstring nameBone = argv[2].as_string();
 	obj->SetRelativeObject(idRelative, nameBone);
-	DxScriptObjectBase* objRelative = dynamic_cast<DxScriptObjectBase*>(script->GetObjectPointer(idRelative));
-	if (objRelative == NULL)
+	auto* objRelative = dynamic_cast<DxScriptObjectBase*>(script->GetObjectPointer(idRelative));
+	if (objRelative == nullptr)
 		return value();
 	return value();
 }
 value DxScript::Func_ObjRender_SetPermitCamera(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	bool bEnable = argv[1].as_boolean();
 
-	DxScriptPrimitiveObject2D* obj2D = dynamic_cast<DxScriptPrimitiveObject2D*>(script->GetObjectPointer(id));
-	DxScriptTextObject* objText = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj2D != NULL)
+	auto* obj2D = dynamic_cast<DxScriptPrimitiveObject2D*>(script->GetObjectPointer(id));
+	auto* objText = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj2D != nullptr)
 		obj2D->SetPermitCamera(bEnable);
-	else if (objText != NULL)
+	else if (objText != nullptr)
 		objText->SetPermitCamera(bEnable);
 	return value();
 }
@@ -2941,10 +2918,10 @@ value DxScript::Func_ObjRender_SetPermitCamera(gstd::script_machine* machine, in
 gstd::value DxScript::Func_ObjRender_GetBlendType(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
 	int res = 0;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj != NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj != nullptr)
 		res = obj->GetBlendType();
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
@@ -2952,13 +2929,13 @@ gstd::value DxScript::Func_ObjRender_GetBlendType(gstd::script_machine* machine,
 //Dx関数：オブジェクト操作(ShaderObject)
 gstd::value DxScript::Func_ObjShader_Create(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	script->CheckRunInMainThread();
 	int type = (int)argv[0].as_real();
 	ref_count_ptr<DxScriptShaderObject>::unsync obj = new DxScriptShaderObject();
 
 	int id = ID_INVALID;
-	if (obj != NULL) {
+	if (obj != nullptr) {
 		obj->Initialize();
 		obj->manager_ = script->objManager_.GetPointer();
 		id = script->AddObject(obj);
@@ -2967,10 +2944,10 @@ gstd::value DxScript::Func_ObjShader_Create(gstd::script_machine* machine, int a
 }
 gstd::value DxScript::Func_ObjShader_SetShaderF(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	bool res = false;
@@ -2992,43 +2969,43 @@ gstd::value DxScript::Func_ObjShader_SetShaderF(gstd::script_machine* machine, i
 }
 gstd::value DxScript::Func_ObjShader_SetShaderO(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id1 = (int)argv[0].as_real();
-	DxScriptRenderObject* obj1 = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id1));
-	if (obj1 == NULL)
+	auto* obj1 = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id1));
+	if (obj1 == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	int id2 = (int)argv[1].as_real();
-	DxScriptRenderObject* obj2 = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id2));
-	if (obj2 == NULL)
+	auto* obj2 = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id2));
+	if (obj2 == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	ref_count_ptr<Shader> shader = obj2->GetShader();
-	if (shader == NULL)
+	if (shader == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 	obj1->SetShader(shader);
 	return value(machine->get_engine()->get_boolean_type(), true);
 }
 gstd::value DxScript::Func_ObjShader_ResetShader(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
-	obj->SetShader(NULL);
+	obj->SetShader(nullptr);
 	return value();
 }
 gstd::value DxScript::Func_ObjShader_SetTechnique(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	ref_count_ptr<Shader> shader = obj->GetShader();
-	if (shader == NULL)
+	if (shader == nullptr)
 		return value();
 
 	std::string aPath = StringUtility::ConvertWideToMulti(argv[1].as_string());
@@ -3037,14 +3014,14 @@ gstd::value DxScript::Func_ObjShader_SetTechnique(gstd::script_machine* machine,
 }
 gstd::value DxScript::Func_ObjShader_SetMatrix(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	ref_count_ptr<Shader> shader = obj->GetShader();
-	if (shader == NULL)
+	if (shader == nullptr)
 		return value();
 
 	std::string name = StringUtility::ConvertWideToMulti(argv[1].as_string());
@@ -3061,7 +3038,7 @@ gstd::value DxScript::Func_ObjShader_SetMatrix(gstd::script_machine* machine, in
 		for (int iCol = 0; iCol < 4; iCol++) {
 			int index = iRow * 4 + iCol;
 			value& arrayValue = sMatrix.index_as_array(index);
-			float fValue = (float)arrayValue.as_real();
+			auto fValue = (float)arrayValue.as_real();
 			matrix.m[iRow][iCol] = fValue;
 		}
 	}
@@ -3070,14 +3047,14 @@ gstd::value DxScript::Func_ObjShader_SetMatrix(gstd::script_machine* machine, in
 }
 gstd::value DxScript::Func_ObjShader_SetMatrixArray(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	ref_count_ptr<Shader> shader = obj->GetShader();
-	if (shader == NULL)
+	if (shader == nullptr)
 		return value();
 
 	std::string name = StringUtility::ConvertWideToMulti(argv[1].as_string());
@@ -3102,7 +3079,7 @@ gstd::value DxScript::Func_ObjShader_SetMatrixArray(gstd::script_machine* machin
 			for (int iCol = 0; iCol < 4; iCol++) {
 				int index = iRow * 4 + iCol;
 				value& arrayValue = sMatrix.index_as_array(index);
-				float fValue = (float)arrayValue.as_real();
+				auto fValue = (float)arrayValue.as_real();
 				matrix.m[iRow][iCol] = fValue;
 			}
 		}
@@ -3113,14 +3090,14 @@ gstd::value DxScript::Func_ObjShader_SetMatrixArray(gstd::script_machine* machin
 }
 gstd::value DxScript::Func_ObjShader_SetVector(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	ref_count_ptr<Shader> shader = obj->GetShader();
-	if (shader == NULL)
+	if (shader == nullptr)
 		return value();
 
 	std::string name = StringUtility::ConvertWideToMulti(argv[1].as_string());
@@ -3134,31 +3111,31 @@ gstd::value DxScript::Func_ObjShader_SetVector(gstd::script_machine* machine, in
 }
 gstd::value DxScript::Func_ObjShader_SetFloat(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	ref_count_ptr<Shader> shader = obj->GetShader();
-	if (shader == NULL)
+	if (shader == nullptr)
 		return value();
 
 	std::string name = StringUtility::ConvertWideToMulti(argv[1].as_string());
-	float vValue = (float)argv[2].as_real();
+	auto vValue = (float)argv[2].as_real();
 	shader->SetFloat(name, vValue);
 	return value();
 }
 gstd::value DxScript::Func_ObjShader_SetFloatArray(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	ref_count_ptr<Shader> shader = obj->GetShader();
-	if (shader == NULL)
+	if (shader == nullptr)
 		return value();
 
 	std::string name = StringUtility::ConvertWideToMulti(argv[1].as_string());
@@ -3171,7 +3148,7 @@ gstd::value DxScript::Func_ObjShader_SetFloatArray(gstd::script_machine* machine
 	std::vector<float> listFloat;
 	for (int iArray = 0; iArray < dataLength; iArray++) {
 		value& aValue = array.index_as_array(iArray);
-		float fValue = (float)aValue.as_real();
+		auto fValue = (float)aValue.as_real();
 		listFloat.push_back(fValue);
 	}
 	shader->SetFloatArray(name, listFloat);
@@ -3179,14 +3156,14 @@ gstd::value DxScript::Func_ObjShader_SetFloatArray(gstd::script_machine* machine
 }
 gstd::value DxScript::Func_ObjShader_SetTexture(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	ref_count_ptr<Shader> shader = obj->GetShader();
-	if (shader == NULL)
+	if (shader == nullptr)
 		return value();
 
 	std::string name = StringUtility::ConvertWideToMulti(argv[1].as_string());
@@ -3206,7 +3183,7 @@ gstd::value DxScript::Func_ObjShader_SetTexture(gstd::script_machine* machine, i
 //Dx関数：オブジェクト操作(PrimitiveObject)
 value DxScript::Func_ObjPrimitive_Create(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	script->CheckRunInMainThread();
 	int type = (int)argv[0].as_real();
 	ref_count_ptr<DxScriptPrimitiveObject>::unsync obj;
@@ -3225,7 +3202,7 @@ value DxScript::Func_ObjPrimitive_Create(script_machine* machine, int argc, valu
 	}
 
 	int id = ID_INVALID;
-	if (obj != NULL) {
+	if (obj != nullptr) {
 		obj->Initialize();
 		obj->manager_ = script->objManager_.GetPointer();
 		id = script->AddObject(obj);
@@ -3234,30 +3211,30 @@ value DxScript::Func_ObjPrimitive_Create(script_machine* machine, int argc, valu
 }
 value DxScript::Func_ObjPrimitive_SetPrimitiveType(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptPrimitiveObject* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetPrimitiveType((D3DPRIMITIVETYPE)(int)argv[1].as_real());
 	return value();
 }
 value DxScript::Func_ObjPrimitive_SetVertexCount(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptPrimitiveObject* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetVertexCount((int)argv[1].as_real());
 	return value();
 }
 value DxScript::Func_ObjPrimitive_SetTexture(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptPrimitiveObject* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	std::wstring path = argv[1].as_string();
@@ -3274,43 +3251,43 @@ value DxScript::Func_ObjPrimitive_SetTexture(script_machine* machine, int argc, 
 value DxScript::Func_ObjPrimitive_GetVertexCount(script_machine* machine, int argc, value const* argv)
 {
 	long double res = 0;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptPrimitiveObject* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
-	if (obj != NULL)
+	auto* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
+	if (obj != nullptr)
 		res = obj->GetVertexCount();
 	return value(machine->get_engine()->get_real_type(), res);
 }
 value DxScript::Func_ObjPrimitive_SetVertexPosition(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptPrimitiveObject* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetVertexPosition((int)argv[1].as_real(), argv[2].as_real(), argv[3].as_real(), argv[4].as_real());
 	return value();
 }
 value DxScript::Func_ObjPrimitive_SetVertexUV(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptPrimitiveObject* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetVertexUV((int)argv[1].as_real(), argv[2].as_real(), argv[3].as_real());
 	return value();
 }
 gstd::value DxScript::Func_ObjPrimitive_SetVertexUVT(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptPrimitiveObject* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	ref_count_ptr<Texture> texture = obj->GetTexture();
-	if (texture == NULL)
+	if (texture == nullptr)
 		return value();
 
 	int width = texture->GetWidth();
@@ -3321,33 +3298,33 @@ gstd::value DxScript::Func_ObjPrimitive_SetVertexUVT(gstd::script_machine* machi
 }
 value DxScript::Func_ObjPrimitive_SetVertexColor(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptPrimitiveObject* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetVertexColor((int)argv[1].as_real(), (int)argv[2].as_real(), (int)argv[3].as_real(), (int)argv[4].as_real());
 	return value();
 }
 value DxScript::Func_ObjPrimitive_SetVertexAlpha(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptPrimitiveObject* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetVertexAlpha((int)argv[1].as_real(), (int)argv[2].as_real());
 	return value();
 }
 value DxScript::Func_ObjPrimitive_GetVertexPosition(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	int index = (int)argv[1].as_real();
 
 	D3DXVECTOR3 pos = D3DXVECTOR3(0, 0, 0);
-	DxScriptPrimitiveObject* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
-	if (obj != NULL)
+	auto* obj = dynamic_cast<DxScriptPrimitiveObject*>(script->GetObjectPointer(id));
+	if (obj != nullptr)
 		pos = obj->GetVertexPosition(index);
 
 	std::vector<long double> listPos;
@@ -3363,10 +3340,10 @@ value DxScript::Func_ObjPrimitive_GetVertexPosition(script_machine* machine, int
 //Dx関数：オブジェクト操作(Sprite2D)
 value DxScript::Func_ObjSprite2D_SetSourceRect(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptSpriteObject2D* obj = dynamic_cast<DxScriptSpriteObject2D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptSpriteObject2D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	RECT_D rcDest = {
@@ -3380,10 +3357,10 @@ value DxScript::Func_ObjSprite2D_SetSourceRect(script_machine* machine, int argc
 }
 value DxScript::Func_ObjSprite2D_SetDestRect(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptSpriteObject2D* obj = dynamic_cast<DxScriptSpriteObject2D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptSpriteObject2D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	RECT_D rcDest = {
@@ -3397,10 +3374,10 @@ value DxScript::Func_ObjSprite2D_SetDestRect(script_machine* machine, int argc, 
 }
 value DxScript::Func_ObjSprite2D_SetDestCenter(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptSpriteObject2D* obj = dynamic_cast<DxScriptSpriteObject2D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptSpriteObject2D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	obj->GetSpritePointer()->SetDestinationCenter();
@@ -3410,10 +3387,10 @@ value DxScript::Func_ObjSprite2D_SetDestCenter(gstd::script_machine* machine, in
 //Dx関数：オブジェクト操作(SpriteList2D)
 gstd::value DxScript::Func_ObjSpriteList2D_SetSourceRect(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptSpriteListObject2D* obj = dynamic_cast<DxScriptSpriteListObject2D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptSpriteListObject2D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	RECT_D rcDest = {
@@ -3427,10 +3404,10 @@ gstd::value DxScript::Func_ObjSpriteList2D_SetSourceRect(gstd::script_machine* m
 }
 gstd::value DxScript::Func_ObjSpriteList2D_SetDestRect(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptSpriteListObject2D* obj = dynamic_cast<DxScriptSpriteListObject2D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptSpriteListObject2D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	RECT_D rcDest = {
@@ -3444,10 +3421,10 @@ gstd::value DxScript::Func_ObjSpriteList2D_SetDestRect(gstd::script_machine* mac
 }
 gstd::value DxScript::Func_ObjSpriteList2D_SetDestCenter(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptSpriteListObject2D* obj = dynamic_cast<DxScriptSpriteListObject2D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptSpriteListObject2D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	obj->GetSpritePointer()->SetDestinationCenter();
@@ -3455,10 +3432,10 @@ gstd::value DxScript::Func_ObjSpriteList2D_SetDestCenter(gstd::script_machine* m
 }
 gstd::value DxScript::Func_ObjSpriteList2D_AddVertex(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptSpriteListObject2D* obj = dynamic_cast<DxScriptSpriteListObject2D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptSpriteListObject2D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	obj->AddVertex();
@@ -3466,10 +3443,10 @@ gstd::value DxScript::Func_ObjSpriteList2D_AddVertex(gstd::script_machine* machi
 }
 gstd::value DxScript::Func_ObjSpriteList2D_CloseVertex(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptSpriteListObject2D* obj = dynamic_cast<DxScriptSpriteListObject2D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptSpriteListObject2D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	obj->CloseVertex();
@@ -3477,10 +3454,10 @@ gstd::value DxScript::Func_ObjSpriteList2D_CloseVertex(gstd::script_machine* mac
 }
 gstd::value DxScript::Func_ObjSpriteList2D_ClearVertexCount(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptSpriteListObject2D* obj = dynamic_cast<DxScriptSpriteListObject2D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptSpriteListObject2D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	obj->GetSpritePointer()->ClearVertexCount();
@@ -3490,10 +3467,10 @@ gstd::value DxScript::Func_ObjSpriteList2D_ClearVertexCount(gstd::script_machine
 //Dx関数：オブジェクト操作(Sprite3D)
 value DxScript::Func_ObjSprite3D_SetSourceRect(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptSpriteObject3D* obj = dynamic_cast<DxScriptSpriteObject3D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptSpriteObject3D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	RECT_D rcSrc = {
@@ -3507,10 +3484,10 @@ value DxScript::Func_ObjSprite3D_SetSourceRect(script_machine* machine, int argc
 }
 value DxScript::Func_ObjSprite3D_SetDestRect(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptSpriteObject3D* obj = dynamic_cast<DxScriptSpriteObject3D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptSpriteObject3D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	RECT_D rcDest = {
@@ -3524,10 +3501,10 @@ value DxScript::Func_ObjSprite3D_SetDestRect(script_machine* machine, int argc, 
 }
 value DxScript::Func_ObjSprite3D_SetSourceDestRect(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptSpriteObject3D* obj = dynamic_cast<DxScriptSpriteObject3D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptSpriteObject3D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	RECT_D rcSrc = {
@@ -3541,10 +3518,10 @@ value DxScript::Func_ObjSprite3D_SetSourceDestRect(script_machine* machine, int 
 }
 value DxScript::Func_ObjSprite3D_SetBillboard(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptSpriteObject3D* obj = dynamic_cast<DxScriptSpriteObject3D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptSpriteObject3D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	bool bEnable = argv[1].as_boolean();
@@ -3554,10 +3531,10 @@ value DxScript::Func_ObjSprite3D_SetBillboard(script_machine* machine, int argc,
 //Dx関数：オブジェクト操作(TrajectoryObject3D)
 value DxScript::Func_ObjTrajectory3D_SetInitialPoint(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTrajectoryObject3D* obj = dynamic_cast<DxScriptTrajectoryObject3D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTrajectoryObject3D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	D3DXVECTOR3 pos1(argv[1].as_real(), argv[2].as_real(), argv[3].as_real());
@@ -3567,10 +3544,10 @@ value DxScript::Func_ObjTrajectory3D_SetInitialPoint(script_machine* machine, in
 }
 value DxScript::Func_ObjTrajectory3D_SetAlphaVariation(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTrajectoryObject3D* obj = dynamic_cast<DxScriptTrajectoryObject3D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTrajectoryObject3D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	obj->GetObjectPointer()->SetAlphaVariation(argv[1].as_real());
@@ -3578,10 +3555,10 @@ value DxScript::Func_ObjTrajectory3D_SetAlphaVariation(script_machine* machine, 
 }
 value DxScript::Func_ObjTrajectory3D_SetComplementCount(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTrajectoryObject3D* obj = dynamic_cast<DxScriptTrajectoryObject3D*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTrajectoryObject3D*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	obj->GetObjectPointer()->SetComplementCount((int)argv[1].as_real());
@@ -3591,19 +3568,19 @@ value DxScript::Func_ObjTrajectory3D_SetComplementCount(script_machine* machine,
 //Dx関数：オブジェクト操作(DxMesh)
 value DxScript::Func_ObjMesh_Create(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	ref_count_ptr<DxScriptMeshObject>::unsync obj = new DxScriptMeshObject();
 	int id = ID_INVALID;
-	if (obj != NULL)
+	if (obj != nullptr)
 		id = script->AddObject(obj);
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
 value DxScript::Func_ObjMesh_Load(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptMeshObject* obj = dynamic_cast<DxScriptMeshObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptMeshObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	ref_count_ptr<DxMesh> mesh;
@@ -3627,30 +3604,30 @@ value DxScript::Func_ObjMesh_Load(script_machine* machine, int argc, value const
 }
 value DxScript::Func_ObjMesh_SetColor(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptMeshObject* obj = dynamic_cast<DxScriptMeshObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptMeshObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetColor((int)argv[1].as_real(), (int)argv[2].as_real(), (int)argv[3].as_real());
 	return value();
 }
 value DxScript::Func_ObjMesh_SetAlpha(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptMeshObject* obj = dynamic_cast<DxScriptMeshObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptMeshObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	obj->SetAlpha((int)argv[1].as_real());
 	return value();
 }
 value DxScript::Func_ObjMesh_SetAnimation(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptMeshObject* obj = dynamic_cast<DxScriptMeshObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptMeshObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	std::wstring anime = argv[1].as_string();
@@ -3664,10 +3641,10 @@ value DxScript::Func_ObjMesh_SetAnimation(script_machine* machine, int argc, val
 }
 gstd::value DxScript::Func_ObjMesh_SetCoordinate2D(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptMeshObject* obj = dynamic_cast<DxScriptMeshObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptMeshObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	bool bEnable = argv[1].as_boolean();
@@ -3677,13 +3654,13 @@ gstd::value DxScript::Func_ObjMesh_SetCoordinate2D(gstd::script_machine* machine
 value DxScript::Func_ObjMesh_GetPath(script_machine* machine, int argc, value const* argv)
 {
 	std::wstring res;
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptMeshObject* obj = dynamic_cast<DxScriptMeshObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptMeshObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_string_type(), res);
 	DxMesh* mesh = obj->mesh_.GetPointer();
-	if (mesh == NULL)
+	if (mesh == nullptr)
 		return value(machine->get_engine()->get_string_type(), res);
 	res = mesh->GetPath();
 	return value(machine->get_engine()->get_string_type(), res);
@@ -3692,19 +3669,19 @@ value DxScript::Func_ObjMesh_GetPath(script_machine* machine, int argc, value co
 //Dx関数：オブジェクト操作(DxText)
 value DxScript::Func_ObjText_Create(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	ref_count_ptr<DxScriptTextObject>::unsync obj = new DxScriptTextObject();
 	int id = ID_INVALID;
-	if (obj != NULL)
+	if (obj != nullptr)
 		id = script->AddObject(obj);
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
 value DxScript::Func_ObjText_SetText(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	std::wstring wstr = argv[1].as_string();
 	obj->SetText(wstr);
@@ -3712,10 +3689,10 @@ value DxScript::Func_ObjText_SetText(script_machine* machine, int argc, value co
 }
 value DxScript::Func_ObjText_SetFontType(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	std::wstring wstr = argv[1].as_string();
 	obj->SetFontType(wstr);
@@ -3723,10 +3700,10 @@ value DxScript::Func_ObjText_SetFontType(script_machine* machine, int argc, valu
 }
 value DxScript::Func_ObjText_SetFontSize(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	int size = (int)argv[1].as_real();
 	obj->SetFontSize(size);
@@ -3734,10 +3711,10 @@ value DxScript::Func_ObjText_SetFontSize(script_machine* machine, int argc, valu
 }
 value DxScript::Func_ObjText_SetFontBold(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	bool bBold = argv[1].as_boolean();
 	obj->SetFontBold(bBold);
@@ -3745,10 +3722,10 @@ value DxScript::Func_ObjText_SetFontBold(script_machine* machine, int argc, valu
 }
 value DxScript::Func_ObjText_SetFontColorTop(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	int r = (int)argv[1].as_real();
 	int g = (int)argv[2].as_real();
@@ -3758,10 +3735,10 @@ value DxScript::Func_ObjText_SetFontColorTop(script_machine* machine, int argc, 
 }
 value DxScript::Func_ObjText_SetFontColorBottom(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	int r = (int)argv[1].as_real();
 	int g = (int)argv[2].as_real();
@@ -3771,10 +3748,10 @@ value DxScript::Func_ObjText_SetFontColorBottom(script_machine* machine, int arg
 }
 value DxScript::Func_ObjText_SetFontBorderWidth(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	int width = (int)argv[1].as_real();
 	obj->SetFontBorderWidth(width);
@@ -3782,10 +3759,10 @@ value DxScript::Func_ObjText_SetFontBorderWidth(script_machine* machine, int arg
 }
 value DxScript::Func_ObjText_SetFontBorderType(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	int type = (int)argv[1].as_real();
 	obj->SetFontBorderType(type);
@@ -3793,10 +3770,10 @@ value DxScript::Func_ObjText_SetFontBorderType(script_machine* machine, int argc
 }
 value DxScript::Func_ObjText_SetFontBorderColor(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	int r = (int)argv[1].as_real();
 	int g = (int)argv[2].as_real();
@@ -3806,10 +3783,10 @@ value DxScript::Func_ObjText_SetFontBorderColor(script_machine* machine, int arg
 }
 value DxScript::Func_ObjText_SetMaxWidth(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	int width = (int)argv[1].as_real();
 	obj->SetMaxWidth(width);
@@ -3817,10 +3794,10 @@ value DxScript::Func_ObjText_SetMaxWidth(script_machine* machine, int argc, valu
 }
 value DxScript::Func_ObjText_SetMaxHeight(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	int height = (int)argv[1].as_real();
 	obj->SetMaxHeight(height);
@@ -3828,10 +3805,10 @@ value DxScript::Func_ObjText_SetMaxHeight(script_machine* machine, int argc, val
 }
 value DxScript::Func_ObjText_SetLinePitch(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	int pitch = (int)argv[1].as_real();
 	obj->SetLinePitch(pitch);
@@ -3839,10 +3816,10 @@ value DxScript::Func_ObjText_SetLinePitch(script_machine* machine, int argc, val
 }
 value DxScript::Func_ObjText_SetSidePitch(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	int pitch = (int)argv[1].as_real();
 	obj->SetSidePitch(pitch);
@@ -3850,10 +3827,10 @@ value DxScript::Func_ObjText_SetSidePitch(script_machine* machine, int argc, val
 }
 value DxScript::Func_ObjText_SetVertexColor(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	int a = (int)argv[1].as_real();
 	int r = (int)argv[2].as_real();
@@ -3864,10 +3841,10 @@ value DxScript::Func_ObjText_SetVertexColor(script_machine* machine, int argc, v
 }
 gstd::value DxScript::Func_ObjText_SetTransCenter(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	double centerX = argv[1].as_real();
 	double centerY = argv[2].as_real();
@@ -3877,10 +3854,10 @@ gstd::value DxScript::Func_ObjText_SetTransCenter(gstd::script_machine* machine,
 }
 gstd::value DxScript::Func_ObjText_SetAutoTransCenter(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	bool bAutoCenter = argv[1].as_boolean();
 
@@ -3889,10 +3866,10 @@ gstd::value DxScript::Func_ObjText_SetAutoTransCenter(gstd::script_machine* mach
 }
 gstd::value DxScript::Func_ObjText_SetHorizontalAlignment(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	int align = (int)argv[1].as_real();
 
@@ -3901,10 +3878,10 @@ gstd::value DxScript::Func_ObjText_SetHorizontalAlignment(gstd::script_machine* 
 }
 gstd::value DxScript::Func_ObjText_SetSyntacticAnalysis(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	bool bEnable = argv[1].as_boolean();
 
@@ -3913,10 +3890,10 @@ gstd::value DxScript::Func_ObjText_SetSyntacticAnalysis(gstd::script_machine* ma
 }
 value DxScript::Func_ObjText_GetTextLength(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	std::wstring text = obj->GetText();
 	int res = StringUtility::CountAsciiSizeCharacter(text);
@@ -3924,30 +3901,28 @@ value DxScript::Func_ObjText_GetTextLength(script_machine* machine, int argc, va
 }
 value DxScript::Func_ObjText_GetTextLengthCU(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	std::vector<int> listCount = obj->GetTextCountCU();
 	int res = 0;
-	for (int iLine = 0; iLine < listCount.size(); iLine++) {
-		int count = listCount[iLine];
+	for (int count : listCount) {
 		res += count;
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 value DxScript::Func_ObjText_GetTextLengthCUL(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	std::vector<int> listCount = obj->GetTextCountCU();
 	std::vector<long double> listCountD;
-	for (int iLine = 0; iLine < listCount.size(); iLine++) {
-		int count = listCount[iLine];
+	for (int count : listCount) {
 		listCountD.push_back(count);
 	}
 
@@ -3956,10 +3931,10 @@ value DxScript::Func_ObjText_GetTextLengthCUL(script_machine* machine, int argc,
 }
 value DxScript::Func_ObjText_GetTotalWidth(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int res = obj->GetTotalWidth();
@@ -3967,10 +3942,10 @@ value DxScript::Func_ObjText_GetTotalWidth(script_machine* machine, int argc, va
 }
 value DxScript::Func_ObjText_GetTotalHeight(script_machine* machine, int argc, value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptTextObject* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptTextObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int res = obj->GetTotalHeight();
@@ -3980,7 +3955,7 @@ value DxScript::Func_ObjText_GetTotalHeight(script_machine* machine, int argc, v
 //Dx関数：音声操作(DxSoundObject)
 gstd::value DxScript::Func_ObjSound_Create(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	DirectSoundManager* manager = DirectSoundManager::GetBase();
 
 	ref_count_ptr<DxSoundObject>::unsync obj = new DxSoundObject();
@@ -3989,10 +3964,10 @@ gstd::value DxScript::Func_ObjSound_Create(gstd::script_machine* machine, int ar
 }
 gstd::value DxScript::Func_ObjSound_Load(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxSoundObject* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	;
 
@@ -4004,13 +3979,13 @@ gstd::value DxScript::Func_ObjSound_Load(gstd::script_machine* machine, int argc
 }
 gstd::value DxScript::Func_ObjSound_Play(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxSoundObject* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<SoundPlayer> player = obj->GetPlayer();
-	if (player == NULL)
+	if (player == nullptr)
 		return value();
 
 	//obj->Play();
@@ -4019,13 +3994,13 @@ gstd::value DxScript::Func_ObjSound_Play(gstd::script_machine* machine, int argc
 }
 gstd::value DxScript::Func_ObjSound_Stop(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxSoundObject* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<SoundPlayer> player = obj->GetPlayer();
-	if (player == NULL)
+	if (player == nullptr)
 		return value();
 
 	player->Stop();
@@ -4034,13 +4009,13 @@ gstd::value DxScript::Func_ObjSound_Stop(gstd::script_machine* machine, int argc
 }
 gstd::value DxScript::Func_ObjSound_SetVolumeRate(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxSoundObject* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<SoundPlayer> player = obj->GetPlayer();
-	if (player == NULL)
+	if (player == nullptr)
 		return value();
 
 	double rate = argv[1].as_real();
@@ -4049,13 +4024,13 @@ gstd::value DxScript::Func_ObjSound_SetVolumeRate(gstd::script_machine* machine,
 }
 gstd::value DxScript::Func_ObjSound_SetPanRate(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxSoundObject* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<SoundPlayer> player = obj->GetPlayer();
-	if (player == NULL)
+	if (player == nullptr)
 		return value();
 
 	double rate = argv[1].as_real();
@@ -4064,13 +4039,13 @@ gstd::value DxScript::Func_ObjSound_SetPanRate(gstd::script_machine* machine, in
 }
 gstd::value DxScript::Func_ObjSound_SetFade(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxSoundObject* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<SoundPlayer> player = obj->GetPlayer();
-	if (player == NULL)
+	if (player == nullptr)
 		return value();
 
 	double fade = argv[1].as_real();
@@ -4079,13 +4054,13 @@ gstd::value DxScript::Func_ObjSound_SetFade(gstd::script_machine* machine, int a
 }
 gstd::value DxScript::Func_ObjSound_SetLoopEnable(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxSoundObject* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<SoundPlayer> player = obj->GetPlayer();
-	if (player == NULL)
+	if (player == nullptr)
 		return value();
 
 	bool bLoop = (bool)argv[1].as_boolean();
@@ -4095,13 +4070,13 @@ gstd::value DxScript::Func_ObjSound_SetLoopEnable(gstd::script_machine* machine,
 }
 gstd::value DxScript::Func_ObjSound_SetLoopTime(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxSoundObject* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<SoundPlayer> player = obj->GetPlayer();
-	if (player == NULL)
+	if (player == nullptr)
 		return value();
 
 	double startTime = argv[1].as_real();
@@ -4114,13 +4089,13 @@ gstd::value DxScript::Func_ObjSound_SetLoopTime(gstd::script_machine* machine, i
 }
 gstd::value DxScript::Func_ObjSound_SetLoopSampleCount(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxSoundObject* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<SoundPlayer> player = obj->GetPlayer();
-	if (player == NULL)
+	if (player == nullptr)
 		return value();
 
 	double startSample = argv[1].as_real();
@@ -4138,13 +4113,13 @@ gstd::value DxScript::Func_ObjSound_SetLoopSampleCount(gstd::script_machine* mac
 }
 gstd::value DxScript::Func_ObjSound_SetRestartEnable(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxSoundObject* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<SoundPlayer> player = obj->GetPlayer();
-	if (player == NULL)
+	if (player == nullptr)
 		return value();
 
 	bool bRestart = (bool)argv[1].as_boolean();
@@ -4155,13 +4130,13 @@ gstd::value DxScript::Func_ObjSound_SetRestartEnable(gstd::script_machine* machi
 }
 gstd::value DxScript::Func_ObjSound_SetSoundDivision(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxSoundObject* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<SoundPlayer> player = obj->GetPlayer();
-	if (player == NULL)
+	if (player == nullptr)
 		return value();
 
 	int div = (int)argv[1].as_real();
@@ -4171,13 +4146,13 @@ gstd::value DxScript::Func_ObjSound_SetSoundDivision(gstd::script_machine* machi
 }
 gstd::value DxScript::Func_ObjSound_IsPlaying(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxSoundObject* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<SoundPlayer> player = obj->GetPlayer();
-	if (player == NULL)
+	if (player == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	bool bPlay = player->IsPlaying();
@@ -4186,13 +4161,13 @@ gstd::value DxScript::Func_ObjSound_IsPlaying(gstd::script_machine* machine, int
 }
 gstd::value DxScript::Func_ObjSound_GetVolumeRate(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxSoundObject* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxSoundObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<SoundPlayer> player = obj->GetPlayer();
-	if (player == NULL)
+	if (player == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)0);
 
 	double rate = player->GetVolumeRate();
@@ -4203,7 +4178,7 @@ gstd::value DxScript::Func_ObjSound_GetVolumeRate(gstd::script_machine* machine,
 //Dx関数：ファイル操作(DxFileObject)
 gstd::value DxScript::Func_ObjFile_Create(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	//	script->CheckRunInMainThread();
 	int type = (int)argv[0].as_real();
 	ref_count_ptr<DxFileObject>::unsync obj;
@@ -4214,7 +4189,7 @@ gstd::value DxScript::Func_ObjFile_Create(gstd::script_machine* machine, int arg
 	}
 
 	int id = ID_INVALID;
-	if (obj != NULL) {
+	if (obj != nullptr) {
 		obj->Initialize();
 		obj->manager_ = script->objManager_.GetPointer();
 		id = script->AddObject(obj);
@@ -4223,10 +4198,10 @@ gstd::value DxScript::Func_ObjFile_Create(gstd::script_machine* machine, int arg
 }
 gstd::value DxScript::Func_ObjFile_Open(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxFileObject* obj = dynamic_cast<DxFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	std::wstring path = argv[1].as_string();
@@ -4236,10 +4211,10 @@ gstd::value DxScript::Func_ObjFile_Open(gstd::script_machine* machine, int argc,
 }
 gstd::value DxScript::Func_ObjFile_OpenNW(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxFileObject* obj = dynamic_cast<DxFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	std::wstring path = argv[1].as_string();
@@ -4249,10 +4224,10 @@ gstd::value DxScript::Func_ObjFile_OpenNW(gstd::script_machine* machine, int arg
 }
 gstd::value DxScript::Func_ObjFile_Store(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxFileObject* obj = dynamic_cast<DxFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	bool res = obj->Store();
@@ -4260,24 +4235,24 @@ gstd::value DxScript::Func_ObjFile_Store(gstd::script_machine* machine, int argc
 }
 gstd::value DxScript::Func_ObjFile_GetSize(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxFileObject* obj = dynamic_cast<DxFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)0);
 
 	gstd::ref_count_ptr<File> file = obj->GetFile();
-	int res = file != NULL ? file->GetSize() : 0;
+	int res = file != nullptr ? file->GetSize() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 
 //Dx関数：ファイル操作(DxTextFileObject)
 gstd::value DxScript::Func_ObjFileT_GetLineCount(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxTextFileObject* obj = dynamic_cast<DxTextFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxTextFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)0);
 
 	int res = obj->GetLineCount();
@@ -4285,10 +4260,10 @@ gstd::value DxScript::Func_ObjFileT_GetLineCount(gstd::script_machine* machine, 
 }
 gstd::value DxScript::Func_ObjFileT_GetLineText(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxTextFileObject* obj = dynamic_cast<DxTextFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxTextFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_string_type(), std::wstring());
 
 	int pos = (int)argv[1].as_real();
@@ -4298,10 +4273,10 @@ gstd::value DxScript::Func_ObjFileT_GetLineText(gstd::script_machine* machine, i
 }
 gstd::value DxScript::Func_ObjFileT_SplitLineText(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxTextFileObject* obj = dynamic_cast<DxTextFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxTextFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_string_type(), std::wstring());
 
 	int pos = (int)argv[1].as_real();
@@ -4314,10 +4289,10 @@ gstd::value DxScript::Func_ObjFileT_SplitLineText(gstd::script_machine* machine,
 }
 gstd::value DxScript::Func_ObjFileT_AddLine(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxTextFileObject* obj = dynamic_cast<DxTextFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxTextFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	std::string str = to_mbcs(argv[1].as_string());
@@ -4326,10 +4301,10 @@ gstd::value DxScript::Func_ObjFileT_AddLine(gstd::script_machine* machine, int a
 }
 gstd::value DxScript::Func_ObjFileT_ClearLine(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxTextFileObject* obj = dynamic_cast<DxTextFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxTextFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	obj->ClearLine();
@@ -4339,10 +4314,10 @@ gstd::value DxScript::Func_ObjFileT_ClearLine(gstd::script_machine* machine, int
 //Dx関数：ファイル操作(DxBinalyFileObject)
 gstd::value DxScript::Func_ObjFileB_SetByteOrder(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxBinaryFileObject* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return gstd::value();
 
 	int order = (int)argv[1].as_real();
@@ -4351,22 +4326,22 @@ gstd::value DxScript::Func_ObjFileB_SetByteOrder(gstd::script_machine* machine, 
 }
 gstd::value DxScript::Func_ObjFileB_SetCharacterCode(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxBinaryFileObject* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return gstd::value();
 
-	unsigned int code = (unsigned int)argv[1].as_real();
+	auto code = (unsigned int)argv[1].as_real();
 	obj->SetCodePage(code);
 	return gstd::value();
 }
 gstd::value DxScript::Func_ObjFileB_GetPointer(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxBinaryFileObject* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)-1);
 
 	gstd::ref_count_ptr<gstd::ByteBuffer> buffer = obj->GetBuffer();
@@ -4375,10 +4350,10 @@ gstd::value DxScript::Func_ObjFileB_GetPointer(gstd::script_machine* machine, in
 }
 gstd::value DxScript::Func_ObjFileB_Seek(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxBinaryFileObject* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return gstd::value();
 
 	int pos = (int)argv[1].as_real();
@@ -4388,10 +4363,10 @@ gstd::value DxScript::Func_ObjFileB_Seek(gstd::script_machine* machine, int argc
 }
 gstd::value DxScript::Func_ObjFileB_ReadBoolean(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxBinaryFileObject* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)-1);
 	if (!obj->IsReadableSize(1))
 		script->RaiseError(gstd::ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_END_OF_FILE));
@@ -4402,10 +4377,10 @@ gstd::value DxScript::Func_ObjFileB_ReadBoolean(gstd::script_machine* machine, i
 }
 gstd::value DxScript::Func_ObjFileB_ReadByte(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxBinaryFileObject* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)-1);
 	if (!obj->IsReadableSize(1))
 		script->RaiseError(gstd::ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_END_OF_FILE));
@@ -4416,10 +4391,10 @@ gstd::value DxScript::Func_ObjFileB_ReadByte(gstd::script_machine* machine, int 
 }
 gstd::value DxScript::Func_ObjFileB_ReadShort(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxBinaryFileObject* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)0);
 	if (!obj->IsReadableSize(2))
 		script->RaiseError(gstd::ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_END_OF_FILE));
@@ -4434,10 +4409,10 @@ gstd::value DxScript::Func_ObjFileB_ReadShort(gstd::script_machine* machine, int
 }
 gstd::value DxScript::Func_ObjFileB_ReadInteger(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxBinaryFileObject* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)-1);
 	if (!obj->IsReadableSize(4))
 		script->RaiseError(gstd::ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_END_OF_FILE));
@@ -4452,16 +4427,16 @@ gstd::value DxScript::Func_ObjFileB_ReadInteger(gstd::script_machine* machine, i
 }
 gstd::value DxScript::Func_ObjFileB_ReadLong(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxBinaryFileObject* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)-1);
 	if (!obj->IsReadableSize(8))
 		script->RaiseError(gstd::ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_END_OF_FILE));
 
 	gstd::ref_count_ptr<gstd::ByteBuffer> buffer = obj->GetBuffer();
-	_int64 bv = buffer->ReadInteger64();
+	int64_t bv = buffer->ReadInteger64();
 	if (obj->GetByteOrder() == ByteOrder::ENDIAN_BIG)
 		ByteOrder::Reverse(&bv, sizeof(bv));
 	long double res = bv;
@@ -4469,10 +4444,10 @@ gstd::value DxScript::Func_ObjFileB_ReadLong(gstd::script_machine* machine, int 
 }
 gstd::value DxScript::Func_ObjFileB_ReadFloat(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxBinaryFileObject* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)-1);
 	if (!obj->IsReadableSize(4))
 		script->RaiseError(gstd::ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_END_OF_FILE));
@@ -4489,10 +4464,10 @@ gstd::value DxScript::Func_ObjFileB_ReadFloat(gstd::script_machine* machine, int
 }
 gstd::value DxScript::Func_ObjFileB_ReadDouble(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxBinaryFileObject* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)-1);
 	if (!obj->IsReadableSize(8))
 		script->RaiseError(gstd::ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_END_OF_FILE));
@@ -4500,7 +4475,7 @@ gstd::value DxScript::Func_ObjFileB_ReadDouble(gstd::script_machine* machine, in
 	gstd::ref_count_ptr<gstd::ByteBuffer> buffer = obj->GetBuffer();
 	long double res = 0;
 	if (obj->GetByteOrder() == ByteOrder::ENDIAN_BIG) {
-		_int64 bv = buffer->ReadInteger64();
+		int64_t bv = buffer->ReadInteger64();
 		ByteOrder::Reverse(&bv, sizeof(bv));
 		res = (double&)bv;
 	} else
@@ -4509,10 +4484,10 @@ gstd::value DxScript::Func_ObjFileB_ReadDouble(gstd::script_machine* machine, in
 }
 gstd::value DxScript::Func_ObjFileB_ReadString(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxBinaryFileObject* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxBinaryFileObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_string_type(), std::wstring());
 
 	int readSize = (int)argv[1].as_real();

--- a/source/GcLib/directx/DxScript.cpp
+++ b/source/GcLib/directx/DxScript.cpp
@@ -27,10 +27,9 @@ DxScriptObjectBase::~DxScriptObjectBase()
 	if (manager_ != NULL && idObject_ != DxScript::ID_INVALID)
 		manager_->listUnusedIndex_.push_back(idObject_);
 }
-int DxScriptObjectBase::GetRenderPriorityI()
+int DxScriptObjectBase::GetRenderPriorityI() const
 {
-	int res = (int)(priRender_ * (manager_->GetRenderBucketCapacity() - 1) + 0.5);
-	return res;
+	return (int)(priRender_ * (manager_->GetRenderBucketCapacity() - 1) + 0.5);
 }
 
 /**********************************************************
@@ -71,7 +70,7 @@ void DxScriptPrimitiveObject::SetVertexCount(int count)
 {
 	objRender_->SetVertexCount(count);
 }
-int DxScriptPrimitiveObject::GetVertexCount()
+int DxScriptPrimitiveObject::GetVertexCount() const
 {
 	return objRender_->GetVertexCount();
 }
@@ -133,9 +132,9 @@ void DxScriptPrimitiveObject2D::SetRenderState()
 	graphics->SetBlendMode(typeBlend_);
 	graphics->SetCullingMode(D3DCULL_NONE);
 }
-bool DxScriptPrimitiveObject2D::IsValidVertexIndex(int index)
+bool DxScriptPrimitiveObject2D::IsValidVertexIndex(int index) const
 {
-	RenderObjectTLX* obj = GetObjectPointer();
+	const RenderObjectTLX* obj = GetObjectPointer();
 	int count = obj->GetVertexCount();
 	return index >= 0 && index < count;
 }
@@ -339,9 +338,9 @@ void DxScriptPrimitiveObject3D::SetRenderState()
 	graphics->SetBlendMode(typeBlend_);
 	graphics->SetCullingMode(modeCulling_);
 }
-bool DxScriptPrimitiveObject3D::IsValidVertexIndex(int index)
+bool DxScriptPrimitiveObject3D::IsValidVertexIndex(int index) const
 {
-	RenderObjectLX* obj = GetObjectPointer();
+	const RenderObjectLX* obj = GetObjectPointer();
 	int count = obj->GetVertexCount();
 	return index >= 0 && index < count;
 }
@@ -698,7 +697,7 @@ DxFileObject::DxFileObject()
 DxFileObject::~DxFileObject()
 {
 }
-bool DxFileObject::OpenR(std::wstring path)
+bool DxFileObject::OpenR(const std::wstring& path)
 {
 	file_ = new File(path);
 	bool res = file_->Open();
@@ -706,22 +705,22 @@ bool DxFileObject::OpenR(std::wstring path)
 		file_ = NULL;
 	return res;
 }
-bool DxFileObject::OpenW(std::wstring path)
+bool DxFileObject::OpenW(const std::wstring& path)
 {
-	path = PathProperty::Canonicalize(path);
-	path = PathProperty::ReplaceYenToSlash(path);
+	auto formattedPath = PathProperty::Canonicalize(path);
+	formattedPath = PathProperty::ReplaceYenToSlash(formattedPath);
 
-	std::wstring dir = PathProperty::GetFileDirectory(path);
+	std::wstring dir = PathProperty::GetFileDirectory(formattedPath);
 	File fDir(dir);
 	bool bDir = fDir.CreateDirectory();
 	if (!bDir)
 		return false;
 
-	std::wstring dirModule = PathProperty::GetFileDirectory(path);
+	std::wstring dirModule = PathProperty::GetFileDirectory(formattedPath);
 	if (dir.find(dirModule) == std::wstring::npos)
 		return false;
 
-	file_ = new File(path);
+	file_ = new File(formattedPath);
 	bool res = file_->Create();
 	if (!res)
 		file_ = NULL;
@@ -744,7 +743,7 @@ DxTextFileObject::DxTextFileObject()
 DxTextFileObject::~DxTextFileObject()
 {
 }
-bool DxTextFileObject::OpenR(std::wstring path)
+bool DxTextFileObject::OpenR(const std::wstring& path)
 {
 	listLine_.clear();
 	bool res = DxFileObject::OpenR(path);
@@ -771,8 +770,8 @@ bool DxTextFileObject::OpenR(std::wstring path)
 			text_ = text;
 			pos_ = 0;
 		}
-		int GetPosition() { return pos_; }
-		char GetCurrentCharactor() { return (*text_)[pos_]; }
+		int GetPosition() const { return pos_; }
+		char GetCurrentCharactor() const { return (*text_)[pos_]; }
 		void Advance()
 		{
 			pos_++;
@@ -814,10 +813,9 @@ bool DxTextFileObject::OpenR(std::wstring path)
 	}
 	return true;
 }
-bool DxTextFileObject::OpenW(std::wstring path)
+bool DxTextFileObject::OpenW(const std::wstring& path)
 {
-	bool res = DxFileObject::OpenW(path);
-	return res;
+	return DxFileObject::OpenW(path);
 }
 bool DxTextFileObject::Store()
 {
@@ -834,7 +832,7 @@ bool DxTextFileObject::Store()
 	}
 	return true;
 }
-std::string DxTextFileObject::GetLine(int line)
+std::string DxTextFileObject::GetLine(int line) const
 {
 	line--; //行数は1開始
 	if (line >= listLine_.size())
@@ -856,7 +854,7 @@ DxBinaryFileObject::DxBinaryFileObject()
 DxBinaryFileObject::~DxBinaryFileObject()
 {
 }
-bool DxBinaryFileObject::OpenR(std::wstring path)
+bool DxBinaryFileObject::OpenR(const std::wstring& path)
 {
 	bool res = DxFileObject::OpenR(path);
 	if (!res)
@@ -870,7 +868,7 @@ bool DxBinaryFileObject::OpenR(std::wstring path)
 
 	return true;
 }
-bool DxBinaryFileObject::OpenW(std::wstring path)
+bool DxBinaryFileObject::OpenW(const std::wstring& path)
 {
 	return false;
 }
@@ -1149,7 +1147,7 @@ void DxScriptObjectManager::ResetShader(double min, double max)
 	SetShader(NULL, min, max);
 }
 
-void DxScriptObjectManager::ReserveSound(ref_count_ptr<SoundPlayer> player, SoundPlayer::PlayStyle& style)
+void DxScriptObjectManager::ReserveSound(ref_count_ptr<SoundPlayer> player, const SoundPlayer::PlayStyle& style)
 {
 	ref_count_ptr<SoundInfo> info = new SoundInfo();
 	info->player_ = player;
@@ -1655,7 +1653,7 @@ int DxScript::AddObject(gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj, boo
 	obj->idScript_ = idScript_;
 	return objManager_->AddObject(obj, bActivate);
 }
-gstd::ref_count_ptr<Texture> DxScript::_GetTexture(std::wstring name)
+gstd::ref_count_ptr<Texture> DxScript::_GetTexture(const std::wstring& name)
 {
 	gstd::ref_count_ptr<Texture> res;
 	if (mapTexture_.find(name) != mapTexture_.end()) {

--- a/source/GcLib/directx/DxScript.hpp
+++ b/source/GcLib/directx/DxScript.hpp
@@ -28,23 +28,23 @@ public:
 	virtual void Render() = 0;
 	virtual void SetRenderState() = 0;
 
-	int GetObjectID() { return idObject_; }
-	int GetObjectType() { return typeObject_; }
-	_int64 GetScriptID() { return idScript_; }
-	bool IsDeleted() { return bDeleted_; }
-	bool IsActive() { return bActive_; }
+	int GetObjectID() const { return idObject_; }
+	int GetObjectType() const { return typeObject_; }
+	_int64 GetScriptID() const { return idScript_; }
+	bool IsDeleted() const { return bDeleted_; }
+	bool IsActive() const { return bActive_; }
 	void SetActive(bool bActive) { bActive_ = bActive; }
-	bool IsVisible() { return bVisible_; }
+	bool IsVisible() const { return bVisible_; }
 
-	double GetRenderPriority() { return priRender_; }
-	int GetRenderPriorityI();
+	double GetRenderPriority() const { return priRender_; }
+	int GetRenderPriorityI() const;
 	void SetRenderPriority(double pri) { priRender_ = pri; }
 	void SetRenderPriorityI(int pri);
 
-	bool IsObjectValueExists(std::wstring key) { return mapObjectValue_.find(key) != mapObjectValue_.end(); }
-	gstd::value GetObjectValue(std::wstring key) { return mapObjectValue_[key]; }
-	void SetObjectValue(std::wstring key, gstd::value val) { mapObjectValue_[key] = val; }
-	void DeleteObjectValue(std::wstring key) { mapObjectValue_.erase(key); }
+	bool IsObjectValueExists(const std::wstring& key) const { return mapObjectValue_.find(key) != mapObjectValue_.end(); }
+	gstd::value GetObjectValue(const std::wstring& key) { return mapObjectValue_[key]; }
+	void SetObjectValue(const std::wstring& key, const gstd::value& val) { mapObjectValue_[key] = val; }
+	void DeleteObjectValue(const std::wstring& key) { mapObjectValue_.erase(key); }
 
 protected:
 	int idObject_;
@@ -79,15 +79,15 @@ public:
 	virtual void SetColor(int r, int g, int b) = 0;
 	virtual void SetAlpha(int alpha) = 0;
 
-	D3DXVECTOR3 GetPosition() { return position_; }
-	D3DXVECTOR3 GetAngle() { return angle_; }
-	D3DXVECTOR3 GetScale() { return scale_; }
+	D3DXVECTOR3 GetPosition() const { return position_; }
+	D3DXVECTOR3 GetAngle() const { return angle_; }
+	D3DXVECTOR3 GetScale() const { return scale_; }
 	void SetPosition(D3DXVECTOR3 pos) { position_ = pos; }
 	void SetAngle(D3DXVECTOR3 angle) { angle_ = angle; }
 	void SetScale(D3DXVECTOR3 scale) { scale_ = scale; }
 
-	int GetBlendType() { return typeBlend_; }
-	void SetRelativeObject(int id, std::wstring bone)
+	int GetBlendType() const { return typeBlend_; }
+	void SetRelativeObject(int id, const std::wstring& bone)
 	{
 		idRelative_ = id;
 		nameRelativeBone_ = bone;
@@ -139,11 +139,11 @@ public:
 	DxScriptPrimitiveObject();
 	void SetPrimitiveType(D3DPRIMITIVETYPE type);
 	void SetVertexCount(int count);
-	int GetVertexCount();
+	int GetVertexCount() const;
 	gstd::ref_count_ptr<Texture> GetTexture();
 	virtual void SetTexture(gstd::ref_count_ptr<Texture> texture);
 
-	virtual bool IsValidVertexIndex(int index) = 0;
+	virtual bool IsValidVertexIndex(int index) const = 0;
 	virtual void SetVertexPosition(int index, float x, float y, float z) = 0;
 	virtual void SetVertexUV(int index, float u, float v) = 0;
 	virtual void SetVertexAlpha(int index, int alpha) = 0;
@@ -166,7 +166,9 @@ public:
 	virtual void Render();
 	virtual void SetRenderState();
 	RenderObjectTLX* GetObjectPointer() { return (RenderObjectTLX*)objRender_.GetPointer(); }
-	virtual bool IsValidVertexIndex(int index);
+	const RenderObjectTLX* GetObjectPointer() const { return (RenderObjectTLX*)objRender_.GetPointer(); }
+
+	virtual bool IsValidVertexIndex(int index) const;
 	virtual void SetColor(int r, int g, int b);
 	virtual void SetAlpha(int alpha);
 	virtual void SetVertexPosition(int index, float x, float y, float z);
@@ -211,7 +213,9 @@ public:
 	virtual void Render();
 	virtual void SetRenderState();
 	RenderObjectLX* GetObjectPointer() { return (RenderObjectLX*)objRender_.GetPointer(); }
-	virtual bool IsValidVertexIndex(int index);
+	const RenderObjectLX* GetObjectPointer() const { return (RenderObjectLX*)objRender_.GetPointer(); }
+
+	virtual bool IsValidVertexIndex(int index) const;
 	virtual void SetColor(int r, int g, int b);
 	virtual void SetAlpha(int alpha);
 	virtual void SetVertexPosition(int index, float x, float y, float z);
@@ -239,8 +243,9 @@ public:
 	virtual void Render();
 	virtual void SetRenderState();
 	TrajectoryObject3D* GetObjectPointer() { return (TrajectoryObject3D*)objRender_.GetPointer(); }
+	const TrajectoryObject3D* GetObjectPointer() const { return (TrajectoryObject3D*)objRender_.GetPointer(); }
 
-	virtual bool IsValidVertexIndex(int index) { return false; }
+	virtual bool IsValidVertexIndex(int index) const { return false; }
 	virtual void SetColor(int r, int g, int b);
 	virtual void SetAlpha(int alpha){};
 	virtual void SetVertexPosition(int index, float x, float y, float z){};
@@ -264,8 +269,8 @@ public:
 	virtual void SetAlpha(int alpha);
 	void SetMesh(gstd::ref_count_ptr<DxMesh> mesh) { mesh_ = mesh; }
 	gstd::ref_count_ptr<DxMesh> GetMesh() { return mesh_; }
-	int GetAnimeFrame() { return time_; }
-	std::wstring GetAnimeName() { return anime_; }
+	int GetAnimeFrame() const { return time_; }
+	std::wstring GetAnimeName() const { return anime_; }
 
 	virtual void SetX(float x)
 	{
@@ -334,7 +339,7 @@ public:
 	virtual void Render();
 	virtual void SetRenderState();
 
-	void SetText(std::wstring text)
+	void SetText(const std::wstring& text)
 	{
 		text_.SetText(text);
 		bChange_ = true;
@@ -344,7 +349,7 @@ public:
 	int GetTotalWidth();
 	int GetTotalHeight();
 
-	void SetFontType(std::wstring type)
+	void SetFontType(const std::wstring& type)
 	{
 		text_.SetFontType(type.c_str());
 		bChange_ = true;
@@ -478,8 +483,8 @@ public:
 	virtual void Render() {}
 	virtual void SetRenderState() {}
 
-	virtual bool OpenR(std::wstring path);
-	virtual bool OpenW(std::wstring path);
+	virtual bool OpenR(const std::wstring& path);
+	virtual bool OpenW(const std::wstring& path);
 	virtual bool Store() = 0;
 	virtual void Close();
 
@@ -494,11 +499,11 @@ class DxTextFileObject : public DxFileObject {
 public:
 	DxTextFileObject();
 	virtual ~DxTextFileObject();
-	virtual bool OpenR(std::wstring path);
-	virtual bool OpenW(std::wstring path);
+	virtual bool OpenR(const std::wstring& path);
+	virtual bool OpenW(const std::wstring& path);
 	virtual bool Store();
-	int GetLineCount() { return listLine_.size(); }
-	std::string GetLine(int line);
+	int GetLineCount() const { return listLine_.size(); }
+	std::string GetLine(int line) const;
 
 	void AddLine(std::string line) { listLine_.push_back(line); }
 	void ClearLine() { listLine_.clear(); }
@@ -514,18 +519,18 @@ class DxBinaryFileObject : public DxFileObject {
 public:
 	DxBinaryFileObject();
 	virtual ~DxBinaryFileObject();
-	virtual bool OpenR(std::wstring path);
-	virtual bool OpenW(std::wstring path);
+	virtual bool OpenR(const std::wstring& path);
+	virtual bool OpenW(const std::wstring& path);
 	virtual bool Store();
 
 	gstd::ref_count_ptr<gstd::ByteBuffer> GetBuffer() { return buffer_; }
 	bool IsReadableSize(int size);
 
-	unsigned int GetCodePage() { return codePage_; }
+	unsigned int GetCodePage() const { return codePage_; }
 	void SetCodePage(unsigned int page) { codePage_ = page; }
 
 	void SetByteOrder(int order) { byteOrder_ = order; }
-	int GetByteOrder() { return byteOrder_; }
+	int GetByteOrder() const { return byteOrder_; }
 
 protected:
 	int byteOrder_;
@@ -534,8 +539,8 @@ protected:
 };
 
 /**********************************************************
-	//DxScriptObjectManager
-	**********************************************************/
+//DxScriptObjectManager
+**********************************************************/
 class DxScriptObjectManager {
 	friend DxScriptObjectBase;
 
@@ -549,15 +554,15 @@ public:
 public:
 	DxScriptObjectManager();
 	virtual ~DxScriptObjectManager();
-	int GetMaxObject() { return obj_.size(); }
+	int GetMaxObject() const { return obj_.size(); }
 	void SetMaxObject(int max);
-	int GetAliveObjectCount() { return obj_.size() - listUnusedIndex_.size(); }
-	int GetRenderBucketCapacity() { return objRender_.size(); }
+	int GetAliveObjectCount() const { return obj_.size() - listUnusedIndex_.size(); }
+	int GetRenderBucketCapacity() const { return objRender_.size(); }
 	void SetRenderBucketCapacity(int capacity);
 	virtual int AddObject(gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj, bool bActivate = true);
 	void AddObject(int id, gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj, bool bActivate = true);
 	void ActivateObject(int id, bool bActivate);
-	gstd::ref_count_ptr<DxScriptObjectBase>::unsync GetObject(int id) { return obj_[id]; }
+	gstd::ref_count_ptr<DxScriptObjectBase>::unsync GetObject(int id) const { return obj_[id]; }
 	std::vector<int> GetValidObjectIdentifier();
 	DxScriptObjectBase* GetObjectPointer(int id);
 	virtual void DeleteObject(int id);
@@ -576,15 +581,15 @@ public:
 	void ResetShader(double min, double max);
 	gstd::ref_count_ptr<Shader> GetShader(int index);
 
-	void ReserveSound(gstd::ref_count_ptr<SoundPlayer> player, SoundPlayer::PlayStyle& style);
+	void ReserveSound(gstd::ref_count_ptr<SoundPlayer> player, const SoundPlayer::PlayStyle& style);
 	void DeleteReservedSound(gstd::ref_count_ptr<SoundPlayer> player);
 	void SetFogParam(bool bEnable, D3DCOLOR fogColor, float start, float end);
-	_int64 GetTotalObjectCreateCount() { return totalObjectCreateCount_; }
+	_int64 GetTotalObjectCreateCount() const { return totalObjectCreateCount_; }
 
-	bool IsFogEneble() { return bFogEnable_; }
-	D3DCOLOR GetFogColor() { return fogColor_; }
-	float GetFogStart() { return fogStart_; }
-	float GetFogEnd() { return fogEnd_; }
+	bool IsFogEneble() const { return bFogEnable_; }
+	D3DCOLOR GetFogColor() const { return fogColor_; }
+	float GetFogStart() const { return fogStart_; }
+	float GetFogEnd() const { return fogEnd_; }
 
 protected:
 	_int64 totalObjectCreateCount_;
@@ -656,7 +661,7 @@ public:
 	virtual void WorkObject() { objManager_->WorkObject(); }
 	virtual void RenderObject() { objManager_->RenderObject(); }
 
-	void AddMeshResource(std::wstring name, gstd::ref_count_ptr<DxMesh> mesh) { mapMesh_[name] = mesh; }
+	void AddMeshResource(const std::wstring& name, gstd::ref_count_ptr<DxMesh> mesh) { mapMesh_[name] = mesh; }
 
 	//Dx関数：システム系
 	static gstd::value Func_InstallFont(gstd::script_machine* machine, int argc, gstd::value const* argv);
@@ -933,7 +938,7 @@ protected:
 	std::map<std::wstring, gstd::ref_count_ptr<DxMesh>> mapMesh_;
 
 	void _ClearResource();
-	gstd::ref_count_ptr<Texture> _GetTexture(std::wstring name);
+	gstd::ref_count_ptr<Texture> _GetTexture(const std::wstring& name);
 };
 
 } // namespace directx

--- a/source/GcLib/directx/DxScript.hpp
+++ b/source/GcLib/directx/DxScript.hpp
@@ -30,7 +30,7 @@ public:
 
 	int GetObjectID() const { return idObject_; }
 	int GetObjectType() const { return typeObject_; }
-	_int64 GetScriptID() const { return idScript_; }
+	int64_t GetScriptID() const { return idScript_; }
 	bool IsDeleted() const { return bDeleted_; }
 	bool IsActive() const { return bActive_; }
 	void SetActive(bool bActive) { bActive_ = bActive; }
@@ -49,7 +49,7 @@ public:
 protected:
 	int idObject_;
 	int typeObject_;
-	_int64 idScript_;
+	int64_t idScript_;
 	DxScriptObjectManager* manager_;
 	double priRender_;
 	bool bVisible_;
@@ -93,10 +93,10 @@ public:
 		nameRelativeBone_ = bone;
 	}
 
-	virtual gstd::ref_count_ptr<Shader> GetShader() { return NULL; }
+	virtual gstd::ref_count_ptr<Shader> GetShader() { return nullptr; }
 	virtual void SetShader(gstd::ref_count_ptr<Shader> shader) {}
-	virtual void Render() {}
-	virtual void SetRenderState() {}
+	void Render() override {}
+	void SetRenderState() override {}
 
 protected:
 	bool bZWrite_;
@@ -119,11 +119,11 @@ protected:
 class DxScriptShaderObject : public DxScriptRenderObject {
 public:
 	DxScriptShaderObject();
-	virtual gstd::ref_count_ptr<Shader> GetShader() { return shader_; }
-	virtual void SetShader(gstd::ref_count_ptr<Shader> shader) { shader_ = shader; }
+	gstd::ref_count_ptr<Shader> GetShader() override { return shader_; }
+	void SetShader(gstd::ref_count_ptr<Shader> shader) override { shader_ = shader; }
 
-	virtual void SetColor(int r, int g, int b) {}
-	virtual void SetAlpha(int alpha) {}
+	void SetColor(int r, int g, int b) override {}
+	void SetAlpha(int alpha) override {}
 
 private:
 	gstd::ref_count_ptr<Shader> shader_;
@@ -150,8 +150,8 @@ public:
 	virtual void SetVertexColor(int index, int r, int g, int b) = 0;
 	virtual D3DXVECTOR3 GetVertexPosition(int index) = 0;
 
-	virtual gstd::ref_count_ptr<Shader> GetShader();
-	virtual void SetShader(gstd::ref_count_ptr<Shader> shader);
+	gstd::ref_count_ptr<Shader> GetShader() override;
+	void SetShader(gstd::ref_count_ptr<Shader> shader) override;
 
 protected:
 	gstd::ref_count_ptr<RenderObject> objRender_;
@@ -163,20 +163,20 @@ protected:
 class DxScriptPrimitiveObject2D : public DxScriptPrimitiveObject {
 public:
 	DxScriptPrimitiveObject2D();
-	virtual void Render();
-	virtual void SetRenderState();
+	void Render() override;
+	void SetRenderState() override;
 	RenderObjectTLX* GetObjectPointer() { return (RenderObjectTLX*)objRender_.GetPointer(); }
 	const RenderObjectTLX* GetObjectPointer() const { return (RenderObjectTLX*)objRender_.GetPointer(); }
 
-	virtual bool IsValidVertexIndex(int index) const;
-	virtual void SetColor(int r, int g, int b);
-	virtual void SetAlpha(int alpha);
-	virtual void SetVertexPosition(int index, float x, float y, float z);
-	virtual void SetVertexUV(int index, float u, float v);
-	virtual void SetVertexAlpha(int index, int alpha);
-	virtual void SetVertexColor(int index, int r, int g, int b);
+	bool IsValidVertexIndex(int index) const override;
+	void SetColor(int r, int g, int b) override;
+	void SetAlpha(int alpha) override;
+	void SetVertexPosition(int index, float x, float y, float z) override;
+	void SetVertexUV(int index, float u, float v) override;
+	void SetVertexAlpha(int index, int alpha) override;
+	void SetVertexColor(int index, int r, int g, int b) override;
 	void SetPermitCamera(bool bPermit);
-	virtual D3DXVECTOR3 GetVertexPosition(int index);
+	D3DXVECTOR3 GetVertexPosition(int index) override;
 };
 
 /**********************************************************
@@ -195,8 +195,8 @@ public:
 class DxScriptSpriteListObject2D : public DxScriptPrimitiveObject2D {
 public:
 	DxScriptSpriteListObject2D();
-	virtual void SetColor(int r, int g, int b);
-	virtual void SetAlpha(int alpha);
+	void SetColor(int r, int g, int b) override;
+	void SetAlpha(int alpha) override;
 	void AddVertex();
 	void CloseVertex();
 	SpriteList2D* GetSpritePointer() { return (SpriteList2D*)objRender_.GetPointer(); }
@@ -210,19 +210,19 @@ class DxScriptPrimitiveObject3D : public DxScriptPrimitiveObject {
 
 public:
 	DxScriptPrimitiveObject3D();
-	virtual void Render();
-	virtual void SetRenderState();
+	void Render() override;
+	void SetRenderState() override;
 	RenderObjectLX* GetObjectPointer() { return (RenderObjectLX*)objRender_.GetPointer(); }
 	const RenderObjectLX* GetObjectPointer() const { return (RenderObjectLX*)objRender_.GetPointer(); }
 
-	virtual bool IsValidVertexIndex(int index) const;
-	virtual void SetColor(int r, int g, int b);
-	virtual void SetAlpha(int alpha);
-	virtual void SetVertexPosition(int index, float x, float y, float z);
-	virtual void SetVertexUV(int index, float u, float v);
-	virtual void SetVertexAlpha(int index, int alpha);
-	virtual void SetVertexColor(int index, int r, int g, int b);
-	virtual D3DXVECTOR3 GetVertexPosition(int index);
+	bool IsValidVertexIndex(int index) const override;
+	void SetColor(int r, int g, int b) override;
+	void SetAlpha(int alpha) override;
+	void SetVertexPosition(int index, float x, float y, float z) override;
+	void SetVertexUV(int index, float u, float v) override;
+	void SetVertexAlpha(int index, int alpha) override;
+	void SetVertexColor(int index, int r, int g, int b) override;
+	D3DXVECTOR3 GetVertexPosition(int index) override;
 };
 /**********************************************************
 //DxScriptSpriteObject3D
@@ -239,20 +239,20 @@ public:
 class DxScriptTrajectoryObject3D : public DxScriptPrimitiveObject {
 public:
 	DxScriptTrajectoryObject3D();
-	virtual void Work();
-	virtual void Render();
-	virtual void SetRenderState();
+	void Work() override;
+	void Render() override;
+	void SetRenderState() override;
 	TrajectoryObject3D* GetObjectPointer() { return (TrajectoryObject3D*)objRender_.GetPointer(); }
 	const TrajectoryObject3D* GetObjectPointer() const { return (TrajectoryObject3D*)objRender_.GetPointer(); }
 
-	virtual bool IsValidVertexIndex(int index) const { return false; }
-	virtual void SetColor(int r, int g, int b);
-	virtual void SetAlpha(int alpha){};
-	virtual void SetVertexPosition(int index, float x, float y, float z){};
-	virtual void SetVertexUV(int index, float u, float v){};
-	virtual void SetVertexAlpha(int index, int alpha){};
-	virtual void SetVertexColor(int index, int r, int g, int b){};
-	virtual D3DXVECTOR3 GetVertexPosition(int index) { return D3DXVECTOR3(0, 0, 0); }
+	bool IsValidVertexIndex(int index) const override { return false; }
+	void SetColor(int r, int g, int b) override;
+	void SetAlpha(int alpha) override{};
+	void SetVertexPosition(int index, float x, float y, float z) override{};
+	void SetVertexUV(int index, float u, float v) override{};
+	void SetVertexAlpha(int index, int alpha) override{};
+	void SetVertexColor(int index, int r, int g, int b) override{};
+	D3DXVECTOR3 GetVertexPosition(int index) override { return {0, 0, 0}; }
 };
 
 /**********************************************************
@@ -263,10 +263,10 @@ class DxScriptMeshObject : public DxScriptRenderObject {
 
 public:
 	DxScriptMeshObject();
-	virtual void Render();
-	virtual void SetRenderState();
-	virtual void SetColor(int r, int g, int b);
-	virtual void SetAlpha(int alpha);
+	void Render() override;
+	void SetRenderState() override;
+	void SetColor(int r, int g, int b) override;
+	void SetAlpha(int alpha) override;
 	void SetMesh(gstd::ref_count_ptr<DxMesh> mesh) { mesh_ = mesh; }
 	gstd::ref_count_ptr<DxMesh> GetMesh() { return mesh_; }
 	int GetAnimeFrame() const { return time_; }
@@ -317,7 +317,7 @@ public:
 		scale_.z = z;
 		_UpdateMeshState();
 	}
-	virtual void SetShader(gstd::ref_count_ptr<Shader> shader);
+	void SetShader(gstd::ref_count_ptr<Shader> shader) override;
 
 protected:
 	gstd::ref_count_ptr<DxMesh> mesh_;
@@ -336,8 +336,8 @@ class DxScriptTextObject : public DxScriptRenderObject {
 
 public:
 	DxScriptTextObject();
-	virtual void Render();
-	virtual void SetRenderState();
+	void Render() override;
+	void SetRenderState() override;
 
 	void SetText(const std::wstring& text)
 	{
@@ -430,10 +430,10 @@ public:
 	void SetPermitCamera(bool bPermit) { text_.SetPermitCamera(bPermit); }
 	void SetSyntacticAnalysis(bool bEnable) { text_.SetSyntacticAnalysis(bEnable); }
 
-	virtual void SetAlpha(int alpha);
-	virtual void SetColor(int r, int g, int b);
+	void SetAlpha(int alpha) override;
+	void SetColor(int r, int g, int b) override;
 	void SetVertexColor(D3DCOLOR color) { text_.SetVertexColor(color); }
-	virtual void SetShader(gstd::ref_count_ptr<Shader> shader);
+	void SetShader(gstd::ref_count_ptr<Shader> shader) override;
 
 protected:
 	bool bChange_;
@@ -454,11 +454,11 @@ class DxSoundObject : public DxScriptObjectBase {
 
 public:
 	DxSoundObject();
-	~DxSoundObject();
-	virtual void Render() {}
-	virtual void SetRenderState() {}
+	~DxSoundObject() override;
+	void Render() override {}
+	void SetRenderState() override {}
 
-	bool Load(std::wstring path);
+	bool Load(const std::wstring& path);
 	void Play();
 
 	gstd::ref_count_ptr<SoundPlayer> GetPlayer() { return player_; }
@@ -477,11 +477,11 @@ class DxFileObject : public DxScriptObjectBase {
 
 public:
 	DxFileObject();
-	~DxFileObject();
+	~DxFileObject() override;
 	gstd::ref_count_ptr<gstd::File> GetFile() { return file_; }
 
-	virtual void Render() {}
-	virtual void SetRenderState() {}
+	void Render() override {}
+	void SetRenderState() override {}
 
 	virtual bool OpenR(const std::wstring& path);
 	virtual bool OpenW(const std::wstring& path);
@@ -498,10 +498,10 @@ protected:
 class DxTextFileObject : public DxFileObject {
 public:
 	DxTextFileObject();
-	virtual ~DxTextFileObject();
-	virtual bool OpenR(const std::wstring& path);
-	virtual bool OpenW(const std::wstring& path);
-	virtual bool Store();
+	~DxTextFileObject() override;
+	bool OpenR(const std::wstring& path) override;
+	bool OpenW(const std::wstring& path) override;
+	bool Store() override;
 	int GetLineCount() const { return listLine_.size(); }
 	std::string GetLine(int line) const;
 
@@ -518,10 +518,10 @@ protected:
 class DxBinaryFileObject : public DxFileObject {
 public:
 	DxBinaryFileObject();
-	virtual ~DxBinaryFileObject();
-	virtual bool OpenR(const std::wstring& path);
-	virtual bool OpenW(const std::wstring& path);
-	virtual bool Store();
+	~DxBinaryFileObject() override;
+	bool OpenR(const std::wstring& path) override;
+	bool OpenW(const std::wstring& path) override;
+	bool Store() override;
 
 	gstd::ref_count_ptr<gstd::ByteBuffer> GetBuffer() { return buffer_; }
 	bool IsReadableSize(int size);
@@ -548,7 +548,7 @@ public:
 	struct SoundInfo {
 		gstd::ref_count_ptr<SoundPlayer> player_;
 		SoundPlayer::PlayStyle style_;
-		virtual ~SoundInfo() {}
+		virtual ~SoundInfo() = default;
 	};
 
 public:
@@ -567,7 +567,7 @@ public:
 	DxScriptObjectBase* GetObjectPointer(int id);
 	virtual void DeleteObject(int id);
 	void ClearObject();
-	void DeleteObjectByScriptID(_int64 idScript);
+	void DeleteObjectByScriptID(int64_t idScript);
 	void AddRenderObject(gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj); //要フレームごとに登録
 	void WorkObject();
 	void RenderObject();
@@ -584,7 +584,7 @@ public:
 	void ReserveSound(gstd::ref_count_ptr<SoundPlayer> player, const SoundPlayer::PlayStyle& style);
 	void DeleteReservedSound(gstd::ref_count_ptr<SoundPlayer> player);
 	void SetFogParam(bool bEnable, D3DCOLOR fogColor, float start, float end);
-	_int64 GetTotalObjectCreateCount() const { return totalObjectCreateCount_; }
+	int64_t GetTotalObjectCreateCount() const { return totalObjectCreateCount_; }
 
 	bool IsFogEneble() const { return bFogEnable_; }
 	D3DCOLOR GetFogColor() const { return fogColor_; }
@@ -592,7 +592,7 @@ public:
 	float GetFogEnd() const { return fogEnd_; }
 
 protected:
-	_int64 totalObjectCreateCount_;
+	int64_t totalObjectCreateCount_;
 	std::list<int> listUnusedIndex_;
 	std::vector<gstd::ref_count_ptr<DxScriptObjectBase>::unsync> obj_; //オブジェクト
 	std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync> listActiveObject_;
@@ -646,7 +646,7 @@ public:
 
 public:
 	DxScript();
-	virtual ~DxScript();
+	~DxScript() override;
 
 	void SetObjectManager(gstd::ref_count_ptr<DxScriptObjectManager> manager) { objManager_ = manager; }
 	gstd::ref_count_ptr<DxScriptObjectManager> GetObjectManager() { return objManager_; }

--- a/source/GcLib/directx/DxText.cpp
+++ b/source/GcLib/directx/DxText.cpp
@@ -18,19 +18,13 @@ DxFont::DxFont()
 	widthBorder_ = 2;
 	colorBorder_ = D3DCOLOR_ARGB(128, 255, 255, 255);
 }
-DxFont::~DxFont()
-{
-}
+DxFont::~DxFont() = default;
 
 /**********************************************************
 //DxChar
 **********************************************************/
-DxChar::DxChar()
-{
-}
-DxChar::~DxChar()
-{
-}
+DxChar::DxChar() = default;
+DxChar::~DxChar() = default;
 
 bool DxChar::Create(int code, Font& winFont, DxFont& dxFont)
 {
@@ -43,8 +37,8 @@ bool DxChar::Create(int code, Font& winFont, DxFont& dxFont)
 	D3DCOLOR colorBorder = font_.GetBorderColor();
 	int widthBorder = typeBorder != DxFont::BORDER_NONE ? font_.GetBorderWidth() : 0;
 
-	HDC hDC = ::GetDC(NULL);
-	HFONT oldFont = (HFONT)SelectObject(hDC, winFont.GetHandle());
+	HDC hDC = ::GetDC(nullptr);
+	auto oldFont = (HFONT)SelectObject(hDC, winFont.GetHandle());
 
 	// フォントビットマップ取得
 	TEXTMETRIC tm;
@@ -54,13 +48,13 @@ bool DxChar::Create(int code, Font& winFont, DxFont& dxFont)
 	int uFormat = GGO_GRAY2_BITMAP; //typeBorder == DxFont::BORDER_FULL ? GGO_BITMAP : GGO_GRAY2_BITMAP;
 	if (dxFont.GetLogFont().lfHeight <= 12)
 		uFormat = GGO_BITMAP;
-	DWORD size = ::GetGlyphOutline(hDC, code, uFormat, &gm, 0, NULL, &mat);
+	DWORD size = ::GetGlyphOutline(hDC, code, uFormat, &gm, 0, nullptr, &mat);
 	ref_count_ptr<BYTE> ptr = new BYTE[size];
 	::GetGlyphOutline(hDC, code, uFormat, &gm, size, ptr.GetPointer(), &mat);
 
 	// デバイスコンテキストとフォントハンドルの解放
 	::SelectObject(hDC, oldFont);
-	::ReleaseDC(NULL, hDC);
+	::ReleaseDC(nullptr, hDC);
 
 	//テクスチャ作成
 	int tex_x = gm.gmCellIncX + widthBorder * 2;
@@ -71,29 +65,29 @@ bool DxChar::Create(int code, Font& winFont, DxFont& dxFont)
 	while (TRUE) {
 		tex_x /= 2;
 		if (tex_x == 0) {
-			widthTexture = pow(2., num_x);
+			widthTexture = pow(2.0, num_x);
 			break;
 		}
-		num_x++;
+		++num_x;
 	}
 	int num_y = 1;
 	while (TRUE) {
 		tex_y /= 2;
 		if (tex_y == 0) {
-			heightTexture = pow(2., num_y);
+			heightTexture = pow(2.0, num_y);
 			break;
 		}
-		num_y++;
+		++num_y;
 	}
-	IDirect3DTexture9* pTexture = NULL;
+	IDirect3DTexture9* pTexture = nullptr;
 	HRESULT hr = DirectGraphics::GetBase()->GetDevice()->CreateTexture(
 		widthTexture, heightTexture,
-		1, D3DPOOL_DEFAULT, D3DFMT_A8R8G8B8, D3DPOOL_MANAGED, &pTexture, NULL);
+		1, D3DPOOL_DEFAULT, D3DFMT_A8R8G8B8, D3DPOOL_MANAGED, &pTexture, nullptr);
 	if (FAILED(hr))
 		return false;
 
 	D3DLOCKED_RECT lock;
-	if (FAILED(pTexture->LockRect(0, &lock, NULL, D3DLOCK_DISCARD))) {
+	if (FAILED(pTexture->LockRect(0, &lock, nullptr, D3DLOCK_DISCARD))) {
 		return false;
 	}
 	int iOfs_x = gm.gmptGlyphOrigin.x;
@@ -110,13 +104,13 @@ bool DxChar::Create(int code, Font& winFont, DxFont& dxFont)
 
 	int xMax = iBmp_w + iOfs_x + widthBorder * 2;
 	int yMax = iBmp_h + iOfs_y + widthBorder * 2;
-	for (int iy = 0; iy < yMax && size > 0; iy++) {
+	for (int iy = 0; iy < yMax && size > 0; ++iy) {
 		int yBmp = iy - iOfs_y - widthBorder;
 		int colorR = ColorAccess::GetColorR(colorTop) - gapColorR * yBmp;
 		int colorG = ColorAccess::GetColorG(colorTop) - gapColorG * yBmp;
 		int colorB = ColorAccess::GetColorB(colorTop) - gapColorB * yBmp;
 
-		for (int ix = 0; ix < xMax; ix++) {
+		for (int ix = 0; ix < xMax; ++ix) {
 			int xBmp = ix - iOfs_x - widthBorder;
 
 			DWORD alpha = 255;
@@ -140,8 +134,8 @@ bool DxChar::Create(int code, Font& winFont, DxFont& dxFont)
 					int bx = typeBorder == DxFont::BORDER_FULL ? xBmp + widthBorder + antiDist : xBmp + 1;
 					int by = typeBorder == DxFont::BORDER_FULL ? yBmp + widthBorder + antiDist : yBmp + 1;
 					int minAlphaEnableDist = 255 * 255;
-					for (int ax = xBmp - widthBorder - antiDist; ax <= bx; ax++) {
-						for (int ay = yBmp - widthBorder - antiDist; ay <= by; ay++) {
+					for (int ax = xBmp - widthBorder - antiDist; ax <= bx; ++ax) {
+						for (int ay = yBmp - widthBorder - antiDist; ay <= by; ++ay) {
 							int dist = abs(ax - xBmp) + abs(ay - yBmp);
 							if (dist > widthBorder + antiDist || dist == 0)
 								continue;
@@ -188,8 +182,8 @@ bool DxChar::Create(int code, Font& winFont, DxFont& dxFont)
 					int cDist = 1;
 					int bx = typeBorder == DxFont::BORDER_FULL ? xBmp + cDist : xBmp + 1;
 					int by = typeBorder == DxFont::BORDER_FULL ? yBmp + cDist : yBmp + 1;
-					for (int ax = xBmp - cDist; ax <= bx; ax++) {
-						for (int ay = yBmp - cDist; ay <= by; ay++) {
+					for (int ax = xBmp - cDist; ax <= bx; ++ax) {
+						for (int ay = yBmp - cDist; ay <= by; ++ay) {
 							DWORD tAlpha = 255;
 							if (uFormat != GGO_BITMAP) {
 								tAlpha = tAlpha = ax >= 0 && ax < iBmp_w && ay >= 0 && ay < iBmp_h ? (255 * ptr[ax + iBmp_w * ay]) / (level - 1) : 0;
@@ -203,7 +197,7 @@ bool DxChar::Create(int code, Font& winFont, DxFont& dxFont)
 							}
 
 							if (tAlpha > 0)
-								count++;
+								++count;
 						}
 					}
 					if (count >= 2)
@@ -249,15 +243,15 @@ DxCharCache::~DxCharCache()
 {
 	Clear();
 }
+
 void DxCharCache::_arrange()
 {
 	countPri_ = 0;
 	std::map<int, DxCharCacheKey> mapPriKeyLast = mapPriKey_;
 	mapPriKey_.clear();
 	mapKeyPri_.clear();
-	std::map<int, DxCharCacheKey>::iterator itr;
-	for (itr = mapPriKeyLast.begin(); itr != mapPriKeyLast.end(); itr++) {
-		DxCharCacheKey key = itr->second;
+	for (auto& keyItr : mapPriKeyLast) {
+		DxCharCacheKey key = keyItr.second;
 		int pri = countPri_;
 
 		mapPriKey_[pri] = key;
@@ -266,6 +260,7 @@ void DxCharCache::_arrange()
 		countPri_++;
 	}
 }
+
 void DxCharCache::Clear()
 {
 	mapPriKey_.clear();
@@ -275,9 +270,9 @@ void DxCharCache::Clear()
 ref_count_ptr<DxChar> DxCharCache::GetChar(DxCharCacheKey& key)
 {
 	gstd::ref_count_ptr<DxChar> res;
-	bool bExist = mapCache_.find(key) != mapCache_.end();
-	if (bExist) {
-		res = mapCache_[key];
+	auto mapItr = mapCache_.find(key);
+	if (mapItr != mapCache_.end()) {
+		res = mapItr->second;
 		/*
 		//キーの優先順位をトップにする
 		int tPri = mapKeyPri_[key];
@@ -323,34 +318,34 @@ void DxCharCache::AddChar(DxCharCacheKey& key, ref_count_ptr<DxChar> value)
 /**********************************************************
 //DxTextScanner
 **********************************************************/
-const int DxTextScanner::TOKEN_TAG_START = DxTextToken::TK_OPENB;
-const int DxTextScanner::TOKEN_TAG_END = DxTextToken::TK_CLOSEB;
+constexpr int DxTextScanner::TOKEN_TAG_START = DxTextToken::TK_OPENB;
+constexpr int DxTextScanner::TOKEN_TAG_END = DxTextToken::TK_CLOSEB;
 const std::wstring DxTextScanner::TAG_START = L"[";
 const std::wstring DxTextScanner::TAG_END = L"]";
 const std::wstring DxTextScanner::TAG_NEW_LINE = L"r";
 const std::wstring DxTextScanner::TAG_RUBY = L"ruby";
 const std::wstring DxTextScanner::TAG_FONT = L"font";
-const wchar_t CHAR_TAG_START = L'[';
-const wchar_t CHAR_TAG_END = L']';
+constexpr wchar_t CHAR_TAG_START = L'[';
+constexpr wchar_t CHAR_TAG_END = L']';
 DxTextScanner::DxTextScanner(wchar_t* str, int charCount)
 {
 	std::vector<wchar_t> buf;
 	buf.resize(charCount);
-	if (buf.size() != 0) {
+	if (!buf.empty()) {
 		memcpy(&buf[0], str, charCount * sizeof(wchar_t));
 	}
 
 	buf.push_back(L'\0');
 	this->DxTextScanner::DxTextScanner(buf);
 }
-DxTextScanner::DxTextScanner(std::wstring str)
+DxTextScanner::DxTextScanner(const std::wstring& str)
 {
 	std::vector<wchar_t> buf;
 	buf.resize(str.size() + 1);
 	memcpy(&buf[0], str.c_str(), (str.size() + 1) * sizeof(wchar_t));
 	this->DxTextScanner::DxTextScanner(buf);
 }
-DxTextScanner::DxTextScanner(std::vector<wchar_t>& buf)
+DxTextScanner::DxTextScanner(const std::vector<wchar_t>& buf)
 {
 	buffer_ = buf;
 	pointer_ = buffer_.begin();
@@ -358,13 +353,10 @@ DxTextScanner::DxTextScanner(std::vector<wchar_t>& buf)
 	line_ = 1;
 	bTagScan_ = false;
 }
-DxTextScanner::~DxTextScanner()
-{
-}
-
+DxTextScanner::~DxTextScanner() = default;
 wchar_t DxTextScanner::_NextChar()
 {
-	if (HasNext() == false) {
+	if (!HasNext()) {
 		std::wstring source;
 		source.resize(buffer_.size());
 		memcpy(&source[0], &buffer_[0], source.size() * sizeof(wchar_t));
@@ -372,22 +364,22 @@ wchar_t DxTextScanner::_NextChar()
 		_RaiseError(log);
 	}
 
-	pointer_++;
+	++pointer_;
 
 	if (*pointer_ == L'\n')
-		line_++;
+		++line_;
 	return *pointer_;
 }
 void DxTextScanner::_SkipComment()
 {
 	while (true) {
-		std::vector<wchar_t>::iterator posStart = pointer_;
+		auto posStart = pointer_;
 		_SkipSpace();
 
 		wchar_t ch = *pointer_;
 
 		if (ch == L'/') { //コメントアウト処理
-			std::vector<wchar_t>::iterator tPos = pointer_;
+			auto tPos = pointer_;
 			ch = _NextChar();
 			if (ch == L'/') { // "//"
 				while (true) {
@@ -418,41 +410,22 @@ void DxTextScanner::_SkipComment()
 }
 void DxTextScanner::_SkipSpace()
 {
-	wchar_t ch = *pointer_;
-	while (true) {
-		if (ch != L' ' && ch != L'\t')
-			break;
-		ch = _NextChar();
+	while (*pointer_ == L' ' || *pointer_ == L'\t') {
+		_NextChar();
 	}
 }
-void DxTextScanner::_RaiseError(std::wstring str)
+void DxTextScanner::_RaiseError(const std::wstring& str)
 {
-	throw gstd::wexception(str.c_str());
+	throw gstd::wexception(str);
 }
 bool DxTextScanner::_IsTextStartSign()
 {
 	if (bTagScan_)
 		return false;
 
-	bool res = false;
 	wchar_t ch = *pointer_;
-
-	if (false && ch == L'\\') {
-		std::vector<wchar_t>::iterator pos = pointer_;
-		ch = _NextChar(); //次のタグまで進める
-		bool bLess = ch == CHAR_TAG_START;
-		if (!bLess) {
-			res = false;
-			SetCurrentPointer(pos);
-		} else {
-			res = !bLess;
-		}
-	} else {
-		bool bLess = ch == CHAR_TAG_START;
-		res = !bLess;
-	}
-
-	return res;
+	// Shortened version of original function. (see Git logs for orig. func.)
+	return !(ch == CHAR_TAG_START);
 }
 bool DxTextScanner::_IsTextScan()
 {
@@ -460,7 +433,8 @@ bool DxTextScanner::_IsTextScan()
 	wchar_t ch = _NextChar();
 	if (!HasNext()) {
 		return false;
-	} else if (ch == L'/') {
+	}
+	if (ch == L'/') {
 		ch = *(pointer_ + 1);
 		if (ch == L'/' || ch == L'*')
 			res = false;
@@ -500,7 +474,7 @@ DxTextToken& DxTextScanner::Next()
 	}
 
 	DxTextToken::Type type = DxTextToken::TK_UNKNOWN;
-	std::vector<wchar_t>::iterator posStart = pointer_; //先頭を保存
+	auto posStart = pointer_; //先頭を保存
 
 	if (_IsTextStartSign()) {
 		ch = *pointer_;
@@ -650,7 +624,7 @@ DxTextToken& DxTextScanner::Next()
 
 				if (ch == L'E' || ch == L'e') {
 					//1E-5みたいなケース
-					std::vector<wchar_t>::iterator pos = pointer_;
+					auto pos = pointer_;
 					ch = _NextChar();
 					while (iswdigit(ch) || ch == L'-')
 						ch = _NextChar(); //数字だけの間ポインタを進める
@@ -687,7 +661,9 @@ DxTextToken& DxTextScanner::Next()
 }
 bool DxTextScanner::HasNext()
 {
-	return pointer_ != buffer_.end() && *pointer_ != L'\0' && token_.GetType() != DxTextToken::TK_EOF;
+	return pointer_ != buffer_.end()
+		&& *pointer_ != L'\0'
+		&& token_.GetType() != DxTextToken::TK_EOF;
 }
 void DxTextScanner::CheckType(const DxTextToken& tok, int type)
 {
@@ -710,15 +686,12 @@ int DxTextScanner::GetCurrentLine() const
 int DxTextScanner::SearchCurrentLine()
 {
 	int line = 1;
-	wchar_t* pbuf = &(*buffer_.begin());
-	wchar_t* ebuf = &(*pointer_);
-	while (true) {
-		if (pbuf >= ebuf)
-			break;
-		else if (*pbuf == L'\n')
-			line++;
-
-		pbuf++;
+	const wchar_t* pbuf = &(*buffer_.begin());
+	const wchar_t* ebuf = &(*pointer_);
+	while (pbuf < ebuf) {
+		if (*pbuf == L'\n')
+			++line;
+		++pbuf;
 	}
 	return line;
 }
@@ -732,9 +705,9 @@ void DxTextScanner::SetCurrentPointer(std::vector<wchar_t>::iterator pos)
 }
 int DxTextScanner::GetCurrentPosition() const
 {
-	if (buffer_.size() == 0)
+	if (buffer_.empty())
 		return 0;
-	wchar_t* pos = (wchar_t*)&*pointer_;
+	auto* pos = (wchar_t*)&*pointer_;
 	return pos - &buffer_[0];
 }
 
@@ -758,27 +731,22 @@ int DxTextToken::GetInteger()
 	if (type_ != TK_INT) {
 		throw gstd::wexception(L"DxTextToken::GetInterger:データのタイプが違います");
 	}
-	int res = StringUtility::ToInteger(element_);
-	return res;
+	return StringUtility::ToInteger(element_);
 }
 double DxTextToken::GetReal()
 {
 	if (type_ != TK_REAL && type_ != TK_INT) {
 		throw gstd::wexception(L"DxTextToken::GetReal:データのタイプが違います");
 	}
-
-	double res = StringUtility::ToDouble(element_);
-	return res;
+	return StringUtility::ToDouble(element_);
 }
 bool DxTextToken::GetBoolean()
 {
-	bool res = false;
 	if (type_ == TK_REAL && type_ == TK_INT) {
-		res = GetReal() == 1;
+		return GetReal() == 1;
 	} else {
-		res = element_ == L"true";
+		return element_ == L"true";
 	}
-	return res;
 }
 
 /**********************************************************
@@ -795,9 +763,9 @@ DxTextRenderObject::DxTextRenderObject()
 	position_.x = 0;
 	position_.y = 0;
 
-	angle_ = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
-	scale_ = D3DXVECTOR3(1.0f, 1.0f, 1.0f);
-	center_ = D3DXVECTOR2(0.0f, 0.0f);
+	angle_ = D3DXVECTOR3(0.0F, 0.0F, 0.0F);
+	scale_ = D3DXVECTOR3(1.0F, 1.0F, 1.0F);
+	center_ = D3DXVECTOR2(0.0F, 0.0F);
 	bAutoCenter_ = true;
 	bPermitCamera_ = true;
 }
@@ -805,8 +773,8 @@ void DxTextRenderObject::Render()
 {
 	POINT pos = position_;
 
-	bool bAngle = angle_.x != 0.0f || angle_.y != 0.0f || angle_.z != 0.0f;
-	bool bScale = scale_.x != 1.0f || scale_.y != 1.0f || scale_.z != 1.0f;
+	bool bAngle = angle_.x != 0.0F || angle_.y != 0.0F || angle_.z != 0.0F;
+	bool bScale = scale_.x != 1.0F || scale_.y != 1.0F || scale_.z != 1.0F;
 	bool bMatrix = bAngle || bScale;
 	D3DXMATRIX mat;
 	D3DXMatrixIdentity(&mat);
@@ -825,9 +793,7 @@ void DxTextRenderObject::Render()
 	if (bMatrix && bAutoCenter_) {
 		RECT rect;
 		ZeroMemory(&rect, sizeof(RECT));
-		std::list<ObjectData>::iterator itr = listData_.begin();
-		for (; itr != listData_.end(); itr++) {
-			ObjectData obj = *itr;
+		for (auto& obj : listData_) {
 			gstd::ref_count_ptr<Sprite2D> sprite = obj.sprite;
 			RECT_D rcDest = sprite->GetDestinationRect();
 			rect.left = min(rect.left, rcDest.left);
@@ -839,19 +805,17 @@ void DxTextRenderObject::Render()
 		center.y = (rect.bottom + rect.top) / 2;
 	}
 
-	std::list<ObjectData>::iterator itr = listData_.begin();
-	for (; itr != listData_.end(); itr++) {
-		ObjectData obj = *itr;
-		POINT bias = obj.bias;
+	for (auto& obj : listData_) {
 		gstd::ref_count_ptr<Sprite2D> sprite = obj.sprite;
 		sprite->SetColorRGB(color_);
 		sprite->SetAlpha(ColorAccess::GetColorA(color_));
 		RECT_D rcDestCopy = sprite->GetDestinationRect();
+		POINT& bias = obj.bias;
 
 		//座標変換
 		if (bMatrix) {
 			int countVertex = sprite->GetVertexCount();
-			for (int iVert = 0; iVert < countVertex; iVert++) {
+			for (int iVert = 0; iVert < countVertex; ++iVert) {
 				VERTEX_TLX* vert = sprite->GetVertex(iVert);
 				vert->position.x -= center.x;
 				vert->position.y -= center.y;
@@ -890,17 +854,16 @@ void DxTextRenderObject::AddRenderObject(gstd::ref_count_ptr<DxTextRenderObject>
 }
 
 //DxTextRenderer
-DxTextRenderer* DxTextRenderer::thisBase_ = NULL;
+DxTextRenderer* DxTextRenderer::thisBase_ = nullptr;
 DxTextRenderer::DxTextRenderer()
 {
 	colorVertex_ = D3DCOLOR_ARGB(255, 255, 255, 255);
 }
-DxTextRenderer::~DxTextRenderer()
-{
-}
+DxTextRenderer::~DxTextRenderer() = default;
+
 bool DxTextRenderer::Initialize()
 {
-	if (thisBase_ != NULL)
+	if (thisBase_ != nullptr)
 		return false;
 
 	winFont_.CreateFont(Font::GOTHIC, 20, true);
@@ -947,7 +910,7 @@ ref_count_ptr<DxTextLine> DxTextRenderer::_GetTextInfoSub(const std::wstring& te
 		const wchar_t* pNextChar = pText + charCount;
 		if (pNextChar < eText) {
 			//次の文字
-			std::wstring strNext = L"";
+			std::wstring strNext;
 			strNext.resize(1);
 			memcpy(&strNext[0], pNextChar, strNext.size() * sizeof(wchar_t));
 
@@ -970,7 +933,7 @@ ref_count_ptr<DxTextLine> DxTextRenderer::_GetTextInfoSub(const std::wstring& te
 			continue;
 		}
 		if (totalHeight + size.cy > heightMax) {
-			textLine = NULL;
+			textLine = nullptr;
 			break;
 		}
 		textLine->width_ += lw;
@@ -994,8 +957,8 @@ gstd::ref_count_ptr<DxTextInfo> DxTextRenderer::GetTextInfo(DxText* dxText)
 
 	ref_count_ptr<Font> fontTemp;
 
-	HDC hDC = ::GetDC(NULL);
-	HFONT oldFont = (HFONT)SelectObject(hDC, winFont_.GetHandle());
+	HDC hDC = ::GetDC(nullptr);
+	auto oldFont = (HFONT)SelectObject(hDC, winFont_.GetHandle());
 
 	bool bEnd = false;
 	int totalWidth = 0;
@@ -1009,7 +972,7 @@ gstd::ref_count_ptr<DxTextInfo> DxTextRenderer::GetTextInfo(DxText* dxText)
 		while (!bEnd) {
 			if (!scan.HasNext()) {
 				//残りを加える
-				if (textLine->code_.size() > 0) {
+				if (!textLine->code_.empty()) {
 					totalWidth = max(totalWidth, textLine->width_);
 					totalHeight += textLine->height_;
 					res->AddTextLine(textLine);
@@ -1022,11 +985,11 @@ gstd::ref_count_ptr<DxTextInfo> DxTextRenderer::GetTextInfo(DxText* dxText)
 			if (typeToken == DxTextToken::TK_TEXT) {
 				std::wstring text = tok.GetElement();
 				text = _ReplaceRenderText(text);
-				if (text.size() == 0 || text == L"")
+				if (text.empty() || text.empty())
 					continue;
 
 				textLine = _GetTextInfoSub(text, dxText, res, textLine, hDC, totalWidth, totalHeight);
-				if (textLine == NULL)
+				if (textLine == nullptr)
 					bEnd = true;
 			} else if (typeToken == DxTextScanner::TOKEN_TAG_START) {
 				int indexTag = textLine->code_.size();
@@ -1039,7 +1002,7 @@ gstd::ref_count_ptr<DxTextInfo> DxTextRenderer::GetTextInfo(DxText* dxText)
 						textLine = _GetTextInfoSub(L" ", dxText, res, textLine, hDC, totalWidth, totalHeight);
 					}
 
-					if (textLine != NULL) {
+					if (textLine != nullptr) {
 						totalWidth = max(totalWidth, textLine->width_);
 						totalHeight += textLine->height_ + linePitch;
 						res->AddTextLine(textLine);
@@ -1100,14 +1063,14 @@ gstd::ref_count_ptr<DxTextInfo> DxTextRenderer::GetTextInfo(DxText* dxText)
 						if (codeCount == currentCodeCount) {
 							//タグが完全に次の行に回る場合
 							tag->SetTagIndex(0);
-							textLine->tag_.push_back(tag);
+							textLine->tag_.emplace_back(tag);
 						} else {
-							textLineRuby->tag_.push_back(tag);
+							textLineRuby->tag_.emplace_back(tag);
 						}
 					}
 
 				} else if (element == DxTextScanner::TAG_FONT) {
-					DxTextTag_Font* tag = new DxTextTag_Font();
+					auto* tag = new DxTextTag_Font();
 					DxFont font = dxText->GetFont();
 					LOGFONT logFont = font.GetLogFont();
 					tag->SetTagIndex(indexTag);
@@ -1129,7 +1092,7 @@ gstd::ref_count_ptr<DxTextInfo> DxTextRenderer::GetTextInfo(DxText* dxText)
 
 					if (bClear) {
 						widthBorder = dxFont.GetBorderType() != DxFont::BORDER_NONE ? dxFont.GetBorderWidth() : 0;
-						fontTemp = NULL;
+						fontTemp = nullptr;
 						oldFont = (HFONT)SelectObject(hDC, winFont_.GetHandle());
 					} else {
 						widthBorder = font.GetBorderType() != DxFont::BORDER_NONE ? font.GetBorderWidth() : 0;
@@ -1139,7 +1102,7 @@ gstd::ref_count_ptr<DxTextInfo> DxTextRenderer::GetTextInfo(DxText* dxText)
 						oldFont = (HFONT)SelectObject(hDC, fontTemp->GetHandle());
 					}
 					tag->SetFont(font);
-					textLine->tag_.push_back(tag);
+					textLine->tag_.emplace_back(tag);
 				} else {
 					std::wstring text = DxTextScanner::TAG_START;
 					text += tok.GetElement();
@@ -1150,11 +1113,11 @@ gstd::ref_count_ptr<DxTextInfo> DxTextRenderer::GetTextInfo(DxText* dxText)
 						text += tok.GetElement();
 					}
 					text = _ReplaceRenderText(text);
-					if (text.size() == 0 || text == L"")
+					if (text.empty() || text.empty())
 						continue;
 
 					textLine = _GetTextInfoSub(text, dxText, res, textLine, hDC, totalWidth, totalHeight);
-					if (textLine == NULL)
+					if (textLine == nullptr)
 						bEnd = true;
 				}
 			}
@@ -1162,7 +1125,7 @@ gstd::ref_count_ptr<DxTextInfo> DxTextRenderer::GetTextInfo(DxText* dxText)
 	} else {
 		std::wstring& text = dxText->GetText();
 		text = _ReplaceRenderText(text);
-		if (text.size() > 0) {
+		if (!text.empty()) {
 			textLine = _GetTextInfoSub(text, dxText, res, textLine, hDC, totalWidth, totalHeight);
 			res->AddTextLine(textLine);
 		}
@@ -1171,7 +1134,7 @@ gstd::ref_count_ptr<DxTextInfo> DxTextRenderer::GetTextInfo(DxText* dxText)
 	res->totalWidth_ = totalWidth + widthBorder;
 	res->totalHeight_ = totalHeight + widthBorder;
 	::SelectObject(hDC, oldFont);
-	::ReleaseDC(NULL, hDC);
+	::ReleaseDC(nullptr, hDC);
 	return res;
 }
 std::wstring DxTextRenderer::_ReplaceRenderText(std::wstring& text)
@@ -1196,24 +1159,23 @@ void DxTextRenderer::_CreateRenderObject(gstd::ref_count_ptr<DxTextRenderObject>
 	int xRender = pos.x;
 	int yRender = pos.y;
 
-	int countTag = textLine->GetTagCount();
 	int indexTag = 0;
+	int countTag = textLine->GetTagCount();
 	int countCode = textLine->code_.size();
-	for (int iCode = 0; iCode < countCode; iCode++) {
-		for (; indexTag < countTag;) {
+	for (int iCode = 0; iCode < countCode; ++iCode) {
+		for (; indexTag < countTag; ++indexTag) {
 			gstd::ref_count_ptr<DxTextTag> tag = textLine->GetTag(indexTag);
 			int tagNo = tag->GetTagIndex();
 			if (tagNo != iCode)
 				break;
 			int type = tag->GetTagType();
 			if (type == DxTextTag::TYPE_FONT) {
-				DxTextTag_Font* font = (DxTextTag_Font*)tag.GetPointer();
+				auto* font = (DxTextTag_Font*)tag.GetPointer();
 				dxFont = font->GetFont();
 				keyFont.font_ = dxFont;
 				winFont_.CreateFontIndirect(dxFont.GetLogFont());
-				indexTag++;
 			} else if (type == DxTextTag::TYPE_RUBY) {
-				DxTextTag_Ruby* ruby = (DxTextTag_Ruby*)tag.GetPointer();
+				auto* ruby = (DxTextTag_Ruby*)tag.GetPointer();
 				ref_count_ptr<DxText> textRuby = ruby->GetRenderText();
 
 				RECT margin;
@@ -1228,10 +1190,9 @@ void DxTextRenderer::_CreateRenderObject(gstd::ref_count_ptr<DxTextRenderObject>
 				objRender->AddRenderObject(textRuby->CreateRenderObject(), bias);
 
 				SetFont(dxFont.GetLogFont());
-
-				indexTag++;
-			} else
+			} else {
 				break;
+			}
 		}
 
 		//文字コード
@@ -1241,7 +1202,7 @@ void DxTextRenderer::_CreateRenderObject(gstd::ref_count_ptr<DxTextRenderObject>
 		keyFont.code_ = code;
 		keyFont.font_ = dxFont;
 		ref_count_ptr<DxChar> dxChar = cache_.GetChar(keyFont);
-		if (dxChar == NULL) {
+		if (dxChar == nullptr) {
 			//キャッシュにない場合、作成して追加
 			dxChar = new DxChar();
 			dxChar->Create(code, winFont_, dxFont);
@@ -1255,12 +1216,12 @@ void DxTextRenderer::_CreateRenderObject(gstd::ref_count_ptr<DxTextRenderObject>
 		ref_count_ptr<Texture> texture = dxChar->GetTexture();
 		spriteText->SetTexture(texture);
 
-		//		int objWidth = texture->GetWidth();//dxChar->GetWidth();
-		//		int objHeight = texture->GetHeight();//dxChar->GetHeight();
+		// int objWidth = texture->GetWidth();//dxChar->GetWidth();
+		// int objHeight = texture->GetHeight();//dxChar->GetHeight();
 		int objWidth = dxChar->GetWidth();
 		int objHeight = dxChar->GetHeight();
 		RECT_D rcDest = { (double)xRender, (double)yRender, (double)(objWidth + xRender), (double)(objHeight + yRender) };
-		RECT_D rcSrc = { 0., 0., (double)objWidth, (double)objHeight };
+		RECT_D rcSrc = { 0.0, 0.0, (double)objWidth, (double)objHeight };
 		spriteText->SetVertex(rcSrc, rcDest, colorVertex_);
 		objRender->AddRenderObject(spriteText);
 
@@ -1271,102 +1232,96 @@ void DxTextRenderer::_CreateRenderObject(gstd::ref_count_ptr<DxTextRenderObject>
 
 gstd::ref_count_ptr<DxTextRenderObject> DxTextRenderer::CreateRenderObject(DxText* dxText, ref_count_ptr<DxTextInfo> textInfo)
 {
-	{
-		Lock lock(lock_);
-		gstd::ref_count_ptr<DxTextRenderObject> objRender = new DxTextRenderObject();
-		objRender->SetPosition(dxText->GetPosition());
-		objRender->SetVertexColor(dxText->GetVertexColor());
-		objRender->SetPermitCamera(dxText->IsPermitCamera());
-		objRender->SetShader(dxText->GetShader());
+	Lock lock(lock_);
+	gstd::ref_count_ptr<DxTextRenderObject> objRender = new DxTextRenderObject();
+	objRender->SetPosition(dxText->GetPosition());
+	objRender->SetVertexColor(dxText->GetVertexColor());
+	objRender->SetPermitCamera(dxText->IsPermitCamera());
+	objRender->SetShader(dxText->GetShader());
 
-		DxFont& dxFont = dxText->GetFont();
-		int linePitch = dxText->GetLinePitch();
-		int widthMax = dxText->GetMaxWidth();
-		int heightMax = dxText->GetMaxHeight();
-		RECT margin = dxText->GetMargin();
-		int alignmentHorizontal = dxText->GetHorizontalAlignment();
-		int alignmentVertical = dxText->GetVerticalAlignment();
-		POINT pos;
-		ZeroMemory(&pos, sizeof(POINT));
-		bool bAutoIndent = textInfo->IsAutoIndent();
+	DxFont& dxFont = dxText->GetFont();
+	int linePitch = dxText->GetLinePitch();
+	int widthMax = dxText->GetMaxWidth();
+	int heightMax = dxText->GetMaxHeight();
+	RECT margin = dxText->GetMargin();
+	int alignmentHorizontal = dxText->GetHorizontalAlignment();
+	int alignmentVertical = dxText->GetVerticalAlignment();
+	POINT pos;
+	ZeroMemory(&pos, sizeof(POINT));
+	bool bAutoIndent = textInfo->IsAutoIndent();
 
-		switch (alignmentVertical) {
-		case ALIGNMENT_TOP:
+	switch (alignmentVertical) {
+	case ALIGNMENT_TOP:
+		break;
+	case ALIGNMENT_CENTER: {
+		int cy = pos.y + heightMax / 2;
+		pos.y = cy - textInfo->totalHeight_ / 2;
+		break;
+	}
+	case ALIGNMENT_BOTTOM: {
+		int by = pos.y + heightMax;
+		pos.y = by - textInfo->totalHeight_;
+		break;
+	}
+	}
+	pos.y += margin.top;
+
+	int heightTotal = 0;
+	int countLine = textInfo->textLine_.size();
+	int lineStart = textInfo->GetValidStartLine() - 1;
+	int lineEnd = textInfo->GetValidEndLine() - 1;
+	for (int iLine = lineStart; iLine <= lineEnd; ++iLine) {
+		gstd::ref_count_ptr<DxTextLine> textLine = textInfo->GetTextLine(iLine);
+		pos.x = 0; //dxText->GetPosition().x;
+		if (iLine == 0)
+			pos.x += margin.left;
+		switch (alignmentHorizontal) {
+		case ALIGNMENT_LEFT:
+			if (iLine >= 1 && bAutoIndent)
+				pos.x = dxText->GetFontSize();
 			break;
 		case ALIGNMENT_CENTER: {
-			int cy = pos.y + heightMax / 2;
-			pos.y = cy - textInfo->totalHeight_ / 2;
+			int cx = pos.x + widthMax / 2;
+			pos.x = cx - textLine->width_ / 2;
 			break;
 		}
-		case ALIGNMENT_BOTTOM: {
-			int by = pos.y + heightMax;
-			pos.y = by - textInfo->totalHeight_;
+		case ALIGNMENT_RIGHT: {
+			int rx = pos.x + widthMax;
+			pos.x = rx - textLine->width_;
 			break;
 		}
 		}
-		pos.y += margin.top;
 
-		int heightTotal = 0;
-		int countLine = textInfo->textLine_.size();
-		int lineStart = textInfo->GetValidStartLine() - 1;
-		int lineEnd = textInfo->GetValidEndLine() - 1;
-		for (int iLine = lineStart; iLine <= lineEnd; iLine++) {
-			gstd::ref_count_ptr<DxTextLine> textLine = textInfo->GetTextLine(iLine);
-			pos.x = 0; //dxText->GetPosition().x;
-			if (iLine == 0)
-				pos.x += margin.left;
-			switch (alignmentHorizontal) {
-			case ALIGNMENT_LEFT:
-				if (iLine >= 1 && bAutoIndent)
-					pos.x = dxText->GetFontSize();
-				break;
-			case ALIGNMENT_CENTER: {
-				int cx = pos.x + widthMax / 2;
-				pos.x = cx - textLine->width_ / 2;
-				break;
-			}
-			case ALIGNMENT_RIGHT: {
-				int rx = pos.x + widthMax;
-				pos.x = rx - textLine->width_;
-				break;
-			}
-			}
+		heightTotal += textLine->height_ + linePitch;
+		if (heightTotal > heightMax)
+			break;
 
-			heightTotal += textLine->height_ + linePitch;
-			if (heightTotal > heightMax)
-				break;
+		_CreateRenderObject(objRender, pos, dxFont, textLine);
 
-			_CreateRenderObject(objRender, pos, dxFont, textLine);
-
-			pos.y += textLine->height_ + linePitch;
-		}
-		return objRender;
+		pos.y += textLine->height_ + linePitch;
 	}
+	return objRender;
 }
 
 void DxTextRenderer::Render(DxText* dxText)
 {
-	{
-		Lock lock(lock_);
-		ref_count_ptr<DxTextInfo> textInfo = GetTextInfo(dxText);
-		Render(dxText, textInfo);
-	}
+	Lock lock(lock_);
+	ref_count_ptr<DxTextInfo> textInfo = GetTextInfo(dxText);
+	Render(dxText, textInfo);
 }
 void DxTextRenderer::Render(DxText* dxText, gstd::ref_count_ptr<DxTextInfo> textInfo)
 {
-	{
-		Lock lock(lock_);
-		ref_count_ptr<DxTextRenderObject> objRender = CreateRenderObject(dxText, textInfo);
-		objRender->Render();
-	}
+	Lock lock(lock_);
+	ref_count_ptr<DxTextRenderObject> objRender = CreateRenderObject(dxText, textInfo);
+	objRender->Render();
 }
 bool DxTextRenderer::AddFontFromFile(std::wstring path)
 {
 	ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-	if (reader == NULL)
-		throw gstd::wexception(StringUtility::Format(L"フォントファイルが見つかりません(%s)", path.c_str()).c_str());
+	if (reader == nullptr)
+		throw gstd::wexception(StringUtility::Format(L"フォントファイルが見つかりません(%s)", path.c_str()));
 	if (!reader->Open())
-		throw gstd::wexception(StringUtility::Format(L"フォントファイルを開けません(%s)", path.c_str()).c_str());
+		throw gstd::wexception(StringUtility::Format(L"フォントファイルを開けません(%s)", path.c_str()));
 
 	int size = reader->GetFileSize();
 	ByteBuffer buf;
@@ -1377,7 +1332,7 @@ bool DxTextRenderer::AddFontFromFile(std::wstring path)
 	HANDLE handle = ::AddFontMemResourceEx(buf.GetPointer(), size, NULL, &count);
 
 	Logger::WriteTop(L"フォント読み込み：" + path);
-	return handle != 0;
+	return handle != nullptr;
 }
 
 /**********************************************************
@@ -1418,9 +1373,7 @@ DxText::DxText()
 	bPermitCamera_ = true;
 	bSyntacticAnalysis_ = true;
 }
-DxText::~DxText()
-{
-}
+DxText::~DxText() = default;
 void DxText::Copy(const DxText& src)
 {
 	dxFont_ = src.dxFont_;
@@ -1441,7 +1394,7 @@ void DxText::SetFontType(const wchar_t* type)
 	lstrcpy(info.lfFaceName, type);
 	info.lfCharSet = DEFAULT_CHARSET;
 
-	for (int i = 0; i < (int)wcslen(type); i++) {
+	for (int i = 0; i < (int)wcslen(type); ++i) {
 		if (!(IsCharAlphaNumeric(type[i]) || type[i] == L' ' || type[i] == L'-')) {
 			info.lfCharSet = SHIFTJIS_CHARSET;
 			break;
@@ -1509,9 +1462,8 @@ DxTextStepper::DxTextStepper()
 	countFrame_ = 0;
 	Clear();
 }
-DxTextStepper::~DxTextStepper()
-{
-}
+DxTextStepper::~DxTextStepper() = default;
+
 void DxTextStepper::Clear()
 {
 	posNext_ = 0;
@@ -1525,17 +1477,17 @@ void DxTextStepper::_Next()
 
 	if (source_[posNext_] == DxTextScanner::TAG_START[0]) {
 		text_ += source_[posNext_];
-		posNext_++;
+		++posNext_;
 		while (true) {
 			bool bBreak = (source_[posNext_] == DxTextScanner::TAG_END[0]);
 			text_ += source_[posNext_];
-			posNext_++;
+			++posNext_;
 			if (bBreak)
 				break;
 		}
 	} else {
 		text_ += source_[posNext_];
-		posNext_++;
+		++posNext_;
 	}
 }
 void DxTextStepper::Next()
@@ -1543,9 +1495,7 @@ void DxTextStepper::Next()
 	double ratioFrame = (double)countNextPerFrame_ / (double)framePerSec_;
 	int lastCountFrame = (int)countFrame_;
 	countFrame_ += ratioFrame;
-	while (true) {
-		if (countFrame_ < 1.0)
-			break;
+	while (!(countFrame_ < 1.0)) {
 		countFrame_ -= 1.0;
 		_Next();
 	}

--- a/source/GcLib/directx/DxText.hpp
+++ b/source/GcLib/directx/DxText.hpp
@@ -30,18 +30,18 @@ public:
 public:
 	DxFont();
 	virtual ~DxFont();
-	void SetLogFont(LOGFONT& font) { info_ = font; }
-	LOGFONT GetLogFont() { return info_; }
+	void SetLogFont(const LOGFONT& font) { info_ = font; }
+	LOGFONT GetLogFont() const { return info_; }
 	void SetTopColor(D3DCOLOR color) { colorTop_ = color; }
-	D3DCOLOR GetTopColor() { return colorTop_; }
+	D3DCOLOR GetTopColor() const { return colorTop_; }
 	void SetBottomColor(D3DCOLOR color) { colorBottom_ = color; }
-	D3DCOLOR GetBottomColor() { return colorBottom_; }
+	D3DCOLOR GetBottomColor() const { return colorBottom_; }
 	void SetBorderType(int type) { typeBorder_ = type; }
-	int GetBorderType() { return typeBorder_; }
+	int GetBorderType() const { return typeBorder_; }
 	void SetBorderWidth(int width) { widthBorder_ = width; }
-	int GetBorderWidth() { return widthBorder_; }
+	int GetBorderWidth() const { return widthBorder_; }
 	void SetBorderColor(D3DCOLOR color) { colorBorder_ = color; }
-	D3DCOLOR GetBorderColor() { return colorBorder_; }
+	D3DCOLOR GetBorderColor() const { return colorBorder_; }
 
 protected:
 	LOGFONT info_; //フォント種別
@@ -62,8 +62,8 @@ public:
 	virtual ~DxChar();
 	bool Create(int code, gstd::Font& winFont, DxFont& dxFont);
 	gstd::ref_count_ptr<Texture> GetTexture() { return texture_; }
-	int GetWidth() { return width_; }
-	int GetHeight() { return height_; }
+	int GetWidth() const { return width_; }
+	int GetHeight() const { return height_; }
 	LOGFONT GetInfo() { return font_.GetLogFont(); }
 
 private:
@@ -106,7 +106,8 @@ public:
 			return font_.colorTop_ < key.font_.colorTop_;
 		if (font_.colorBottom_ != key.font_.colorBottom_)
 			return font_.colorBottom_ < key.font_.colorBottom_;
-		//				if(font_.typeBorder_ != key.font_.typeBorder_)return (font_.typeBorder_ != key.font_.typeBorder_ );
+		// if (font_.typeBorder_ != key.font_.typeBorder_)
+		// 	return font_.typeBorder_ != key.font_.typeBorder_;
 		if (font_.widthBorder_ != key.font_.widthBorder_)
 			return font_.widthBorder_ < key.font_.widthBorder_;
 		if (font_.colorBorder_ != key.font_.colorBorder_)
@@ -125,7 +126,7 @@ public:
 	DxCharCache();
 	~DxCharCache();
 	void Clear();
-	int GetCacheCount() { return mapCache_.size(); }
+	int GetCacheCount() const { return mapCache_.size(); }
 
 	gstd::ref_count_ptr<DxChar> GetChar(DxCharCacheKey& key);
 	void AddChar(DxCharCacheKey& key, gstd::ref_count_ptr<DxChar> value);
@@ -183,21 +184,21 @@ public:
 
 public:
 	DxTextToken() { type_ = TK_UNKNOWN; }
-	DxTextToken(Type type, std::wstring element)
+	DxTextToken(Type type, const std::wstring& element)
 	{
 		type_ = type;
 		element_ = element;
 	}
 
 	virtual ~DxTextToken() {}
-	Type GetType() { return type_; }
+	Type GetType() const { return type_; }
 	std::wstring& GetElement() { return element_; }
 
 	int GetInteger();
 	double GetReal();
 	bool GetBoolean();
 	std::wstring GetString();
-	std::wstring& GetIdentifier();
+	std::wstring GetIdentifier() const;
 
 protected:
 	Type type_;
@@ -223,15 +224,15 @@ public:
 	DxTextToken& GetToken(); //現在のトークンを取得
 	DxTextToken& Next();
 	bool HasNext();
-	void CheckType(DxTextToken& tok, int type);
-	void CheckIdentifer(DxTextToken& tok, std::wstring id);
-	int GetCurrentLine();
+	void CheckType(const DxTextToken& tok, int type);
+	void CheckIdentifer(const DxTextToken& tok, const std::wstring& id);
+	int GetCurrentLine() const;
 	int SearchCurrentLine();
 
-	std::vector<wchar_t>::iterator GetCurrentPointer();
+	std::vector<wchar_t>::iterator GetCurrentPointer() const;
 	void SetCurrentPointer(std::vector<wchar_t>::iterator pos);
 	void SetPointerBegin() { pointer_ = buffer_.begin(); }
-	int GetCurrentPosition();
+	int GetCurrentPosition() const;
 	void SetTagScanEnable(bool bEnable) { bTagScan_ = bEnable; }
 
 protected:
@@ -272,8 +273,8 @@ public:
 		typeTag_ = TYPE_UNKNOWN;
 	}
 	virtual ~DxTextTag(){};
-	int GetTagType() { return typeTag_; }
-	int GetTagIndex() { return indexTag_; }
+	int GetTagType() const { return typeTag_; }
+	int GetTagIndex() const { return indexTag_; }
 	void SetTagIndex(int index) { indexTag_ = index; }
 
 protected:
@@ -287,12 +288,12 @@ public:
 		typeTag_ = TYPE_RUBY;
 		leftMargin_ = 0;
 	}
-	int GetLeftMargin() { return leftMargin_; }
+	int GetLeftMargin() const { return leftMargin_; }
 	void SetLeftMargin(int left) { leftMargin_ = left; }
 
 	std::wstring& GetText() { return text_; }
 	void SetText(std::wstring text) { text_ = text; }
-	std::wstring& GetRuby() { return ruby_; }
+	std::wstring GetRuby() { return ruby_; }
 	void SetRuby(std::wstring ruby) { ruby_ = ruby; }
 
 	gstd::ref_count_ptr<DxText> GetRenderText() { return dxText_; }
@@ -325,13 +326,13 @@ public:
 		sidePitch_ = 0;
 	}
 	virtual ~DxTextLine(){};
-	int GetWidth() { return width_; }
-	int GetHeight() { return height_; }
-	int GetSidePitch() { return sidePitch_; }
+	int GetWidth() const { return width_; }
+	int GetHeight() const { return height_; }
+	int GetSidePitch() const { return sidePitch_; }
 	void SetSidePitch(int pitch) { sidePitch_ = pitch; }
 	std::vector<int>& GetTextCodes() { return code_; }
-	int GetTextCodeCount() { return code_.size(); }
-	int GetTagCount() { return tag_.size(); }
+	int GetTextCodeCount() const { return code_.size(); }
+	int GetTagCount() const { return tag_.size(); }
 	gstd::ref_count_ptr<DxTextTag> GetTag(int index) { return tag_[index]; }
 
 protected:
@@ -354,16 +355,16 @@ public:
 		bAutoIndent_ = false;
 	}
 	virtual ~DxTextInfo(){};
-	int GetTotalWidth() { return totalWidth_; }
-	int GetTotalHeight() { return totalHeight_; }
-	int GetValidStartLine() { return lineValidStart_; }
-	int GetValidEndLine() { return lineValidEnd_; }
+	int GetTotalWidth() const { return totalWidth_; }
+	int GetTotalHeight() const { return totalHeight_; }
+	int GetValidStartLine() const { return lineValidStart_; }
+	int GetValidEndLine() const { return lineValidEnd_; }
 	void SetValidStartLine(int line) { lineValidStart_ = line; }
 	void SetValidEndLine(int line) { lineValidEnd_ = line; }
-	bool IsAutoIndent() { return bAutoIndent_; }
+	bool IsAutoIndent() const { return bAutoIndent_; }
 	void SetAutoIndent(bool bEnable) { bAutoIndent_ = bEnable; }
 
-	int GetLineCount() { return textLine_.size(); }
+	int GetLineCount() const { return textLine_.size(); }
 	void AddTextLine(gstd::ref_count_ptr<DxTextLine> text) { textLine_.push_back(text), lineValidEnd_++; }
 	gstd::ref_count_ptr<DxTextLine> GetTextLine(int pos) { return textLine_[pos]; }
 
@@ -404,9 +405,9 @@ public:
 	}
 	void SetVertexColor(D3DCOLOR color) { color_ = color; }
 
-	void SetAngle(D3DXVECTOR3& angle) { angle_ = angle; }
-	void SetScale(D3DXVECTOR3& scale) { scale_ = scale; }
-	void SetTransCenter(D3DXVECTOR2& center) { center_ = center; }
+	void SetAngle(const D3DXVECTOR3& angle) { angle_ = angle; }
+	void SetScale(const D3DXVECTOR3& scale) { scale_ = scale; }
+	void SetTransCenter(const D3DXVECTOR2& center) { center_ = center; }
 	void SetAutoCenter(bool bAuto) { bAutoCenter_ = bAuto; }
 	void SetPermitCamera(bool bPermit) { bPermitCamera_ = bPermit; }
 
@@ -455,7 +456,7 @@ public:
 	void Render(DxText* dxText);
 	void Render(DxText* dxText, gstd::ref_count_ptr<DxTextInfo> textInfo);
 
-	int GetCacheCount() { return cache_.GetCacheCount(); }
+	int GetCacheCount() const { return cache_.GetCacheCount(); }
 
 	bool AddFontFromFile(std::wstring path);
 
@@ -465,8 +466,8 @@ protected:
 	D3DCOLOR colorVertex_;
 	gstd::CriticalSection lock_;
 
-	SIZE _GetTextSize(HDC hDC, wchar_t* pText);
-	gstd::ref_count_ptr<DxTextLine> _GetTextInfoSub(std::wstring text, DxText* dxText, DxTextInfo* textInfo, gstd::ref_count_ptr<DxTextLine> textLine, HDC& hDC, int& totalWidth, int& totalHeight);
+	SIZE _GetTextSize(HDC hDC, const wchar_t* pText);
+	gstd::ref_count_ptr<DxTextLine> _GetTextInfoSub(const std::wstring& text, const DxText* dxText, DxTextInfo* textInfo, gstd::ref_count_ptr<DxTextLine> textLine, HDC& hDC, int& totalWidth, int& totalHeight);
 	void _CreateRenderObject(gstd::ref_count_ptr<DxTextRenderObject> objRender, POINT pos, DxFont& dxFont, gstd::ref_count_ptr<DxTextLine> textLine);
 	std::wstring _ReplaceRenderText(std::wstring& text);
 };
@@ -497,12 +498,12 @@ public:
 	gstd::ref_count_ptr<DxTextRenderObject> CreateRenderObject();
 	gstd::ref_count_ptr<DxTextRenderObject> CreateRenderObject(gstd::ref_count_ptr<DxTextInfo> textInfo);
 
-	DxFont GetFont() { return dxFont_; }
-	void SetFont(DxFont font) { dxFont_ = font; }
-	void SetFont(LOGFONT logFont) { dxFont_.SetLogFont(logFont); }
+	DxFont GetFont() const { return dxFont_; }
+	void SetFont(const DxFont& font) { dxFont_ = font; }
+	void SetFont(const LOGFONT& logFont) { dxFont_.SetLogFont(logFont); }
 
 	void SetFontType(const wchar_t* type);
-	int GetFontSize() { return dxFont_.GetLogFont().lfHeight; }
+	int GetFontSize() const { return dxFont_.GetLogFont().lfHeight; }
 	void SetFontSize(int size)
 	{
 		LOGFONT info = dxFont_.GetLogFont();
@@ -534,37 +535,38 @@ public:
 	void SetFontBorderType(int type) { dxFont_.SetBorderType(type); }
 	void SetFontBorderColor(D3DCOLOR color) { dxFont_.SetBorderColor(color); }
 
-	POINT GetPosition() { return pos_; }
+	POINT GetPosition() const { return pos_; }
 	void SetPosition(int x, int y)
 	{
 		pos_.x = x;
 		pos_.y = y;
 	}
 	void SetPosition(POINT pos) { pos_ = pos; }
-	int GetMaxWidth() { return widthMax_; }
+	int GetMaxWidth() const { return widthMax_; }
 	void SetMaxWidth(int width) { widthMax_ = width; }
-	int GetMaxHeight() { return heightMax_; }
+	int GetMaxHeight() const { return heightMax_; }
 	void SetMaxHeight(int height) { heightMax_ = height; }
-	int GetSidePitch() { return sidePitch_; }
+	int GetSidePitch() const { return sidePitch_; }
 	void SetSidePitch(int pitch) { sidePitch_ = pitch; }
-	int GetLinePitch() { return linePitch_; }
+	int GetLinePitch() const { return linePitch_; }
 	void SetLinePitch(int pitch) { linePitch_ = pitch; }
-	RECT GetMargin() { return margin_; }
+	RECT GetMargin() const { return margin_; }
 	void SetMargin(RECT margin) { margin_ = margin; }
-	int GetHorizontalAlignment() { return alignmentHorizontal_; }
+	int GetHorizontalAlignment() const { return alignmentHorizontal_; }
 	void SetHorizontalAlignment(int value) { alignmentHorizontal_ = value; }
-	int GetVerticalAlignment() { return alignmentVertical_; }
+	int GetVerticalAlignment() const { return alignmentVertical_; }
 	void SetVerticalAlignment(int value) { alignmentVertical_ = value; }
 
-	D3DCOLOR GetVertexColor() { return colorVertex_; }
+	D3DCOLOR GetVertexColor() const { return colorVertex_; }
 	void SetVertexColor(D3DCOLOR color) { colorVertex_ = color; }
-	bool IsPermitCamera() { return bPermitCamera_; }
+	bool IsPermitCamera() const { return bPermitCamera_; }
 	void SetPermitCamera(bool bPermit) { bPermitCamera_ = bPermit; }
-	bool IsSyntacticAnalysis() { return bSyntacticAnalysis_; }
+	bool IsSyntacticAnalysis() const { return bSyntacticAnalysis_; }
 	void SetSyntacticAnalysis(bool bEnable) { bSyntacticAnalysis_ = bEnable; }
 
 	std::wstring& GetText() { return text_; }
-	void SetText(std::wstring text) { text_ = text; }
+	const std::wstring& GetText() const { return text_; }
+	void SetText(const std::wstring& text) { text_ = text; }
 
 	gstd::ref_count_ptr<Shader> GetShader() { return shader_; }
 	void SetShader(gstd::ref_count_ptr<Shader> shader) { shader_ = shader; }
@@ -596,11 +598,11 @@ public:
 	virtual ~DxTextStepper();
 	void Clear();
 
-	std::wstring GetText() { return text_; }
+	std::wstring GetText() const { return text_; }
 	void Next();
 	void NextSkip();
-	bool HasNext();
-	void SetSource(std::wstring text);
+	bool HasNext() const;
+	void SetSource(const std::wstring& text);
 
 protected:
 	int posNext_;

--- a/source/GcLib/directx/DxText.hpp
+++ b/source/GcLib/directx/DxText.hpp
@@ -190,7 +190,7 @@ public:
 		element_ = element;
 	}
 
-	virtual ~DxTextToken() {}
+	virtual ~DxTextToken() = default;
 	Type GetType() const { return type_; }
 	std::wstring& GetElement() { return element_; }
 
@@ -217,8 +217,8 @@ public:
 
 public:
 	DxTextScanner(wchar_t* str, int charCount);
-	DxTextScanner(std::wstring str);
-	DxTextScanner(std::vector<wchar_t>& buf);
+	DxTextScanner(const std::wstring& str);
+	DxTextScanner(const std::vector<wchar_t>& buf);
 	virtual ~DxTextScanner();
 
 	DxTextToken& GetToken(); //現在のトークンを取得
@@ -240,12 +240,12 @@ protected:
 	std::vector<wchar_t> buffer_;
 	std::vector<wchar_t>::iterator pointer_; //今の位置
 	DxTextToken token_; //現在のトークン
-	boolean bTagScan_;
+	bool bTagScan_;
 
 	wchar_t _NextChar(); //ポインタを進めて次の文字を調べる
 	virtual void _SkipComment(); //コメントをとばす
 	virtual void _SkipSpace(); //空白をとばす
-	virtual void _RaiseError(std::wstring str); //例外を投げます
+	virtual void _RaiseError(const std::wstring& str); //例外を投げます
 	bool _IsTextStartSign();
 	bool _IsTextScan();
 };
@@ -272,7 +272,7 @@ public:
 		indexTag_ = 0;
 		typeTag_ = TYPE_UNKNOWN;
 	}
-	virtual ~DxTextTag(){};
+	virtual ~DxTextTag() = default;
 	int GetTagType() const { return typeTag_; }
 	int GetTagIndex() const { return indexTag_; }
 	void SetTagIndex(int index) { indexTag_ = index; }
@@ -325,7 +325,7 @@ public:
 		height_ = 0;
 		sidePitch_ = 0;
 	}
-	virtual ~DxTextLine(){};
+	virtual ~DxTextLine() = default;
 	int GetWidth() const { return width_; }
 	int GetHeight() const { return height_; }
 	int GetSidePitch() const { return sidePitch_; }
@@ -354,7 +354,7 @@ public:
 		lineValidEnd_ = 0;
 		bAutoIndent_ = false;
 	}
-	virtual ~DxTextInfo(){};
+	virtual ~DxTextInfo() = default;
 	int GetTotalWidth() const { return totalWidth_; }
 	int GetTotalHeight() const { return totalHeight_; }
 	int GetValidStartLine() const { return lineValidStart_; }
@@ -386,7 +386,7 @@ private:
 
 public:
 	DxTextRenderObject();
-	virtual ~DxTextRenderObject() {}
+	virtual ~DxTextRenderObject() = default;
 
 	void Render();
 	void AddRenderObject(gstd::ref_count_ptr<Sprite2D> obj);
@@ -513,19 +513,19 @@ public:
 	void SetFontBold(bool bBold)
 	{
 		LOGFONT info = dxFont_.GetLogFont();
-		info.lfWeight = (bBold == false) * FW_NORMAL + (bBold == TRUE) * FW_BOLD;
+		info.lfWeight = bBold ? FW_BOLD : FW_NORMAL;
 		SetFont(info);
 	}
 	void SetFontItalic(bool bItalic)
 	{
 		LOGFONT info = dxFont_.GetLogFont();
-		info.lfItalic = bItalic;
+		info.lfItalic = static_cast<BYTE>(bItalic);
 		SetFont(info);
 	}
 	void SetFontUnderLine(bool bLine)
 	{
 		LOGFONT info = dxFont_.GetLogFont();
-		info.lfUnderline = bLine;
+		info.lfUnderline = static_cast<BYTE>(bLine);
 		SetFont(info);
 	}
 

--- a/source/GcLib/directx/DxUtility.cpp
+++ b/source/GcLib/directx/DxUtility.cpp
@@ -18,7 +18,7 @@ D3DCOLOR& ColorAccess::SetColorA(D3DCOLOR& color, int alpha)
 		alpha = 0;
 	return gstd::BitAccess::SetByte(color, BIT_ALPHA, (unsigned char)alpha);
 }
-inline int ColorAccess::GetColorR(const D3DCOLOR color)
+inline int ColorAccess::GetColorR(const D3DCOLOR& color)
 {
 	return gstd::BitAccess::GetByte(color, BIT_RED);
 }
@@ -56,10 +56,10 @@ D3DCOLOR& ColorAccess::SetColorB(D3DCOLOR& color, int blue)
 }
 D3DCOLORVALUE ColorAccess::SetColor(D3DCOLORVALUE value, D3DCOLOR color)
 {
-	float a = (float)GetColorA(color) / 255.0f;
-	float r = (float)GetColorR(color) / 255.0f;
-	float g = (float)GetColorG(color) / 255.0f;
-	float b = (float)GetColorB(color) / 255.0f;
+	float a = (float)GetColorA(color) / 255.0F;
+	float r = (float)GetColorR(color) / 255.0F;
+	float g = (float)GetColorG(color) / 255.0F;
+	float b = (float)GetColorB(color) / 255.0F;
 	value.r *= r;
 	value.g *= g;
 	value.b *= b;
@@ -68,10 +68,10 @@ D3DCOLORVALUE ColorAccess::SetColor(D3DCOLORVALUE value, D3DCOLOR color)
 }
 D3DMATERIAL9 ColorAccess::SetColor(D3DMATERIAL9 mat, D3DCOLOR color)
 {
-	float a = (float)GetColorA(color) / 255.0f;
-	float r = (float)GetColorR(color) / 255.0f;
-	float g = (float)GetColorG(color) / 255.0f;
-	float b = (float)GetColorB(color) / 255.0f;
+	float a = (float)GetColorA(color) / 255.0F;
+	float r = (float)GetColorR(color) / 255.0F;
+	float g = (float)GetColorG(color) / 255.0F;
+	float b = (float)GetColorB(color) / 255.0F;
 	mat.Diffuse.r *= r;
 	mat.Diffuse.g *= g;
 	mat.Diffuse.b *= b;
@@ -101,13 +101,16 @@ D3DCOLOR& ColorAccess::ApplyAlpha(D3DCOLOR& color, double alpha)
 D3DCOLOR& ColorAccess::SetColorHSV(D3DCOLOR& color, int hue, int saturation, int value)
 {
 	float f;
-	int i, p, q, t;
+	int i;
+	int p;
+	int q;
+	int t;
 
-	i = (int)floor(hue / 60.0f) % 6;
-	f = (float)(hue / 60.0f) - (float)floor(hue / 60.0f);
-	p = (int)gstd::Math::Round(value * (1.0f - (saturation / 255.0f)));
-	q = (int)gstd::Math::Round(value * (1.0f - (saturation / 255.0f) * f));
-	t = (int)gstd::Math::Round(value * (1.0f - (saturation / 255.0f) * (1.0f - f)));
+	i = (int)floor(hue / 60.0F) % 6;
+	f = (float)(hue / 60.0F) - (float)floor(hue / 60.0F);
+	p = (int)gstd::Math::Round(value * (1.0F - (saturation / 255.0F)));
+	q = (int)gstd::Math::Round(value * (1.0F - (saturation / 255.0F) * f));
+	t = (int)gstd::Math::Round(value * (1.0F - (saturation / 255.0F) * (1.0F - f)));
 
 	int red = 0;
 	int green = 0;
@@ -156,7 +159,9 @@ D3DCOLOR& ColorAccess::SetColorHSV(D3DCOLOR& color, int hue, int saturation, int
 **********************************************************/
 D3DXVECTOR4 DxMath::VectMatMulti(D3DXVECTOR4 v, const D3DMATRIX& mat)
 {
-	float x, y, z;
+	float x;
+	float y;
+	float z;
 
 	x = v.x;
 	y = v.y;
@@ -169,7 +174,7 @@ D3DXVECTOR4 DxMath::VectMatMulti(D3DXVECTOR4 v, const D3DMATRIX& mat)
 
 	return v;
 }
-bool DxMath::IsIntersected(D3DXVECTOR2& pos, std::vector<D3DXVECTOR2>& list)
+bool DxMath::IsIntersected(const D3DXVECTOR2& pos, const std::vector<D3DXVECTOR2>& list)
 {
 	if (list.size() <= 2)
 		return false;
@@ -188,13 +193,13 @@ bool DxMath::IsIntersected(D3DXVECTOR2& pos, std::vector<D3DXVECTOR2>& list)
 	}
 	return res;
 }
-bool DxMath::IsIntersected(DxCircle& circle1, DxCircle& circle2)
+bool DxMath::IsIntersected(const DxCircle& circle1, const DxCircle& circle2)
 {
 	double r1 = pow(circle1.GetX() - circle2.GetX(), 2) + pow(circle1.GetY() - circle2.GetY(), 2);
 	double r2 = pow(circle1.GetR() + circle2.GetR(), 2);
 	return r1 <= r2;
 }
-bool DxMath::IsIntersected(DxCircle& circle, DxWidthLine& line)
+bool DxMath::IsIntersected(const DxCircle& circle, const DxWidthLine& line)
 {
 	//先端もしくは終端が円内にあるかを調べる
 	{
@@ -241,24 +246,25 @@ bool DxMath::IsIntersected(DxCircle& circle, DxWidthLine& line)
 	bool res = e < r;
 	return res;
 }
-bool DxMath::IsIntersected(DxWidthLine& line1, DxWidthLine& line2)
+bool DxMath::IsIntersected(const DxWidthLine& line1, const DxWidthLine& line2)
 {
 	return false;
 }
-bool DxMath::IsIntersected(DxLine3D& line, std::vector<DxTriangle>& triangles, std::vector<D3DXVECTOR3>& out)
+bool DxMath::IsIntersected(const DxLine3D& line, const std::vector<DxTriangle>& triangles, std::vector<D3DXVECTOR3>& out)
 {
 	out.clear();
 
-	for (int iTri = 0; iTri < triangles.size(); iTri++) {
-		DxTriangle& tri = triangles[iTri];
+	for (auto& tri : triangles) {
 		D3DXPLANE plane; //3角形の面
 		D3DXPlaneFromPoints(&plane, &tri.GetPosition(0), &tri.GetPosition(1), &tri.GetPosition(2));
 
 		D3DXVECTOR3 vOut; // 面と視線の交点の座標
-		if (D3DXPlaneIntersectLine(&vOut, &plane, &line.GetPosition(0), &line.GetPosition(1))) {
+		if (D3DXPlaneIntersectLine(&vOut, &plane, &line.GetPosition(0), &line.GetPosition(1)) != nullptr) {
 			// 内外判定
 			D3DXVECTOR3 vN[3];
-			D3DXVECTOR3 vv1, vv2, vv3;
+			D3DXVECTOR3 vv1;
+			D3DXVECTOR3 vv2;
+			D3DXVECTOR3 vv3;
 			vv1 = tri.GetPosition(0) - vOut;
 			vv2 = tri.GetPosition(1) - vOut;
 			vv3 = tri.GetPosition(2) - vOut;
@@ -267,12 +273,9 @@ bool DxMath::IsIntersected(DxLine3D& line, std::vector<DxTriangle>& triangles, s
 			D3DXVec3Cross(&vN[2], &vv3, &vv2);
 			if (D3DXVec3Dot(&vN[0], &vN[1]) < 0 || D3DXVec3Dot(&vN[0], &vN[2]) < 0)
 				continue;
-			else { // 内側(3角形に接触)
-				out.push_back(vOut);
-			}
+			// 内側(3角形に接触)
+			out.push_back(vOut);
 		}
-	} //for (int i = 0; i < tris.size(); i++)
-
-	bool res = out.size() > 0;
-	return res;
+	}
+	return !out.empty();
 }

--- a/source/GcLib/directx/DxUtility.cpp
+++ b/source/GcLib/directx/DxUtility.cpp
@@ -6,7 +6,7 @@ using namespace directx;
 /**********************************************************
 //ColorAccess
 **********************************************************/
-int ColorAccess::GetColorA(D3DCOLOR& color)
+inline int ColorAccess::GetColorA(const D3DCOLOR& color)
 {
 	return gstd::BitAccess::GetByte(color, BIT_ALPHA);
 }
@@ -18,7 +18,7 @@ D3DCOLOR& ColorAccess::SetColorA(D3DCOLOR& color, int alpha)
 		alpha = 0;
 	return gstd::BitAccess::SetByte(color, BIT_ALPHA, (unsigned char)alpha);
 }
-int ColorAccess::GetColorR(D3DCOLOR color)
+inline int ColorAccess::GetColorR(const D3DCOLOR color)
 {
 	return gstd::BitAccess::GetByte(color, BIT_RED);
 }
@@ -30,7 +30,7 @@ D3DCOLOR& ColorAccess::SetColorR(D3DCOLOR& color, int red)
 		red = 0;
 	return gstd::BitAccess::SetByte(color, BIT_RED, (unsigned char)red);
 }
-int ColorAccess::GetColorG(D3DCOLOR& color)
+inline int ColorAccess::GetColorG(const D3DCOLOR& color)
 {
 	return gstd::BitAccess::GetByte(color, BIT_GREEN);
 }
@@ -42,7 +42,7 @@ D3DCOLOR& ColorAccess::SetColorG(D3DCOLOR& color, int green)
 		green = 0;
 	return gstd::BitAccess::SetByte(color, BIT_GREEN, (unsigned char)green);
 }
-int ColorAccess::GetColorB(D3DCOLOR& color)
+inline int ColorAccess::GetColorB(const D3DCOLOR& color)
 {
 	return gstd::BitAccess::GetByte(color, BIT_BLUE);
 }
@@ -154,7 +154,7 @@ D3DCOLOR& ColorAccess::SetColorHSV(D3DCOLOR& color, int hue, int saturation, int
 /**********************************************************
 //DxMath
 **********************************************************/
-D3DXVECTOR4 DxMath::VectMatMulti(D3DXVECTOR4 v, D3DMATRIX& mat)
+D3DXVECTOR4 DxMath::VectMatMulti(D3DXVECTOR4 v, const D3DMATRIX& mat)
 {
 	float x, y, z;
 

--- a/source/GcLib/directx/DxUtility.hpp
+++ b/source/GcLib/directx/DxUtility.hpp
@@ -18,7 +18,7 @@ public:
 	};
 	static int GetColorA(const D3DCOLOR& color);
 	static D3DCOLOR& SetColorA(D3DCOLOR& color, int alpha);
-	static int GetColorR(const D3DCOLOR color);
+	static int GetColorR(const D3DCOLOR& color);
 	static D3DCOLOR& SetColorR(D3DCOLOR& color, int red);
 	static int GetColorG(const D3DCOLOR& color);
 	static D3DCOLOR& SetColorG(D3DCOLOR& color, int green);
@@ -49,7 +49,7 @@ public:
 		y_ = y;
 		r_ = r;
 	}
-	virtual ~DxCircle() {}
+	virtual ~DxCircle() = default;
 	double GetX() const { return x_; }
 	void SetX(float x) { x_ = x; }
 	double GetY() const { return y_; }
@@ -82,7 +82,7 @@ public:
 		posY2_ = y2;
 		width_ = width;
 	}
-	virtual ~DxWidthLine() {}
+	virtual ~DxWidthLine() = default;
 	double GetX1() const { return posX1_; }
 	double GetY1() const { return posY1_; }
 	double GetX2() const { return posX2_; }
@@ -99,16 +99,16 @@ private:
 
 class DxLine3D {
 public:
-	DxLine3D(){};
+	DxLine3D() = default;
 	DxLine3D(const D3DXVECTOR3& p1, const D3DXVECTOR3& p2)
 	{
 		vertex_[0] = p1;
 		vertex_[1] = p2;
 	}
 
-	D3DXVECTOR3& GetPosition(int index) { return vertex_[index]; }
-	D3DXVECTOR3& GetPosition1() { return vertex_[0]; }
-	D3DXVECTOR3& GetPosition2() { return vertex_[1]; }
+	D3DXVECTOR3 GetPosition(int index) const { return vertex_[index]; }
+	D3DXVECTOR3 GetPosition1() const { return vertex_[0]; }
+	D3DXVECTOR3 GetPosition2() const { return vertex_[1]; }
 
 private:
 	D3DXVECTOR3 vertex_[2];
@@ -116,7 +116,7 @@ private:
 
 class DxTriangle {
 public:
-	DxTriangle() {}
+	DxTriangle() = default;
 	DxTriangle(const D3DXVECTOR3& p1, const D3DXVECTOR3& p2, const D3DXVECTOR3& p3)
 	{
 		vertex_[0] = p1;
@@ -125,10 +125,10 @@ public:
 		_Compute();
 	}
 
-	D3DXVECTOR3& GetPosition(int index) { return vertex_[index]; }
-	D3DXVECTOR3& GetPosition1() { return vertex_[0]; }
-	D3DXVECTOR3& GetPosition2() { return vertex_[1]; }
-	D3DXVECTOR3& GetPosition3() { return vertex_[2]; }
+	D3DXVECTOR3 GetPosition(int index) const { return vertex_[index]; }
+	D3DXVECTOR3 GetPosition1() const { return vertex_[0]; }
+	D3DXVECTOR3 GetPosition2() const { return vertex_[1]; }
+	D3DXVECTOR3 GetPosition3() const { return vertex_[2]; }
 
 private:
 	D3DXVECTOR3 vertex_[3];
@@ -185,19 +185,19 @@ public:
 	static D3DXVECTOR4 VectMatMulti(D3DXVECTOR4 v, const D3DMATRIX& mat);
 
 	//衝突判定：点－多角形
-	static bool IsIntersected(D3DXVECTOR2& pos, std::vector<D3DXVECTOR2>& list);
+	static bool IsIntersected(const D3DXVECTOR2& pos, const std::vector<D3DXVECTOR2>& list);
 
 	//衝突判定：円-円
-	static bool IsIntersected(DxCircle& circle1, DxCircle& circle2);
+	static bool IsIntersected(const DxCircle& circle1, const DxCircle& circle2);
 
 	//衝突判定：円-直線
-	static bool IsIntersected(DxCircle& circle, DxWidthLine& line);
+	static bool IsIntersected(const DxCircle& circle, const DxWidthLine& line);
 
 	//衝突判定：直線-直線
-	static bool IsIntersected(DxWidthLine& line1, DxWidthLine& line2);
+	static bool IsIntersected(const DxWidthLine& line1, const DxWidthLine& line2);
 
 	//衝突判定：直線：三角
-	static bool IsIntersected(DxLine3D& line, std::vector<DxTriangle>& triangles, std::vector<D3DXVECTOR3>& out);
+	static bool IsIntersected(const DxLine3D& line, const std::vector<DxTriangle>& triangles, std::vector<D3DXVECTOR3>& out);
 };
 
 struct RECT_D {

--- a/source/GcLib/directx/DxUtility.hpp
+++ b/source/GcLib/directx/DxUtility.hpp
@@ -16,13 +16,13 @@ public:
 		BIT_GREEN = 8,
 		BIT_BLUE = 0,
 	};
-	static int GetColorA(D3DCOLOR& color);
+	static int GetColorA(const D3DCOLOR& color);
 	static D3DCOLOR& SetColorA(D3DCOLOR& color, int alpha);
-	static int GetColorR(D3DCOLOR color);
+	static int GetColorR(const D3DCOLOR color);
 	static D3DCOLOR& SetColorR(D3DCOLOR& color, int red);
-	static int GetColorG(D3DCOLOR& color);
+	static int GetColorG(const D3DCOLOR& color);
 	static D3DCOLOR& SetColorG(D3DCOLOR& color, int green);
-	static int GetColorB(D3DCOLOR& color);
+	static int GetColorB(const D3DCOLOR& color);
 	static D3DCOLOR& SetColorB(D3DCOLOR& color, int blue);
 
 	static D3DCOLORVALUE SetColor(D3DCOLORVALUE value, D3DCOLOR color);
@@ -50,11 +50,11 @@ public:
 		r_ = r;
 	}
 	virtual ~DxCircle() {}
-	double GetX() { return x_; }
+	double GetX() const { return x_; }
 	void SetX(float x) { x_ = x; }
-	double GetY() { return y_; }
+	double GetY() const { return y_; }
 	void SetY(float y) { y_ = y; }
-	double GetR() { return r_; }
+	double GetR() const { return r_; }
 	void SetR(float r) { r_ = r; }
 
 private:
@@ -83,11 +83,11 @@ public:
 		width_ = width;
 	}
 	virtual ~DxWidthLine() {}
-	double GetX1() { return posX1_; }
-	double GetY1() { return posY1_; }
-	double GetX2() { return posX2_; }
-	double GetY2() { return posY2_; }
-	double GetWidth() { return width_; }
+	double GetX1() const { return posX1_; }
+	double GetY1() const { return posY1_; }
+	double GetX2() const { return posX2_; }
+	double GetY2() const { return posY2_; }
+	double GetWidth() const { return width_; }
 
 private:
 	double posX1_;
@@ -182,7 +182,7 @@ public:
 	}
 
 	//ベクトルと行列の積
-	static D3DXVECTOR4 VectMatMulti(D3DXVECTOR4 v, D3DMATRIX& mat);
+	static D3DXVECTOR4 VectMatMulti(D3DXVECTOR4 v, const D3DMATRIX& mat);
 
 	//衝突判定：点－多角形
 	static bool IsIntersected(D3DXVECTOR2& pos, std::vector<D3DXVECTOR2>& list);

--- a/source/GcLib/directx/DxWindow.cpp
+++ b/source/GcLib/directx/DxWindow.cpp
@@ -462,21 +462,19 @@ RECT DxWindow::GetAbsoluteWindowRect()
 	}
 	return res;
 }
-bool DxWindow::IsWindowExists(int id)
+bool DxWindow::IsWindowExists(int id) const
 {
 	if (bWindowDelete_)
 		return false;
 	bool res = false;
 	if (GetID() == id)
 		return true;
-	std::list<ref_count_ptr<DxWindow>>::iterator itr;
-	;
-	for (itr = listWindowChild_.begin(); itr != listWindowChild_.end(); itr++) {
-		if ((*itr) == NULL)
+	for (const auto& windowChild : listWindowChild_) {
+		if (windowChild == NULL)
 			continue;
-		if ((*itr)->IsWindowDelete())
+		if (windowChild->IsWindowDelete())
 			continue;
-		res |= (*itr)->IsWindowExists(id);
+		res |= windowChild->IsWindowExists(id);
 		if (res)
 			break;
 	}

--- a/source/GcLib/directx/DxWindow.hpp
+++ b/source/GcLib/directx/DxWindow.hpp
@@ -36,8 +36,8 @@ public:
 	void SetSourceWindow(gstd::ref_count_ptr<DxWindow> source) { windowSource_ = source; }
 	gstd::ref_count_ptr<DxWindow> GetSourceWindow() { return windowSource_; }
 	void AddEventType(int type) { type_ |= type; }
-	bool HasEventType(int type) { return (type_ & type) != 0; }
-	bool IsEmpty() { return type_ == 0; }
+	bool HasEventType(int type) const { return (type_ & type) != 0; }
+	bool IsEmpty() const { return type_ == 0; }
 
 protected:
 	gstd::ref_count_ptr<DxWindow> windowSource_; //ウィンドウ
@@ -85,7 +85,7 @@ public:
 	DxWindow();
 	virtual ~DxWindow();
 	virtual void DeleteWindow(); //削除フラグを立てます
-	bool IsWindowDelete() { return bWindowDelete_; }
+	bool IsWindowDelete() const { return bWindowDelete_; }
 	void Dispose(); //各参照などを解放します
 	virtual void AddedManager() {}
 	void AddChild(gstd::ref_count_ptr<DxWindow> window);
@@ -99,19 +99,19 @@ public:
 
 	virtual void IntersectMouseCursor() {}
 
-	int GetID() { return idWindow_; }
+	int GetID() const { return idWindow_; }
 	virtual bool IsIntersected(POINT pos);
 	void SetWindowRect(RECT rect) { rectWindow_ = rect; }
-	RECT GetWindowRect() { return rectWindow_; }
+	RECT GetWindowRect() const { return rectWindow_; }
 	RECT GetAbsoluteWindowRect();
 	virtual void SetWindowEnable(bool bEnable) { bWindowEnable_ = bEnable; }
-	virtual bool IsWindowEnable() { return bWindowEnable_; }
+	virtual bool IsWindowEnable() const { return bWindowEnable_; }
 	virtual void SetWindowVisible(bool bVisible) { bWindowVisible_ = bVisible; }
-	virtual bool IsWindowVisible() { return bWindowVisible_; }
-	virtual bool IsWindowExists(int id);
+	virtual bool IsWindowVisible() const { return bWindowVisible_; }
+	virtual bool IsWindowExists(int id) const;
 
 	void SetAlpha(int alpha) { ColorAccess::SetColorA(color_, alpha); }
-	int GetAlpha() { return ColorAccess::GetColorA(color_); }
+	int GetAlpha() const { return ColorAccess::GetColorA(color_); }
 	int GetAbsoluteAlpha();
 
 	void SetFrameSprite(gstd::ref_count_ptr<Sprite2D> sprite) { spriteFrame_ = sprite; }
@@ -165,8 +165,8 @@ public:
 	virtual void RenderIntersectedFrame();
 	virtual void RenderSelectedFrame();
 
-	bool IsIntersected() { return bIntersected_; }
-	bool IsSelected() { return bSelected_; }
+	bool IsIntersected() const { return bIntersected_; }
+	bool IsSelected() const { return bSelected_; }
 	void SetSelected(bool bSelected) { bSelected_ = bSelected; }
 
 protected:
@@ -188,7 +188,7 @@ public:
 	virtual void DispatchedEvent(gstd::ref_count_ptr<DxWindowEvent> event);
 	void SetText(gstd::ref_count_ptr<DxText> text);
 	void SetButton(std::vector<gstd::ref_count_ptr<DxButton>> listButton);
-	int GetSelectedIndex() { return index_; }
+	int GetSelectedIndex() const { return index_; }
 	void UpdateWindowRect();
 
 protected:

--- a/source/GcLib/directx/DxWindow.hpp
+++ b/source/GcLib/directx/DxWindow.hpp
@@ -32,7 +32,7 @@ public:
 
 public:
 	DxWindowEvent() { type_ = 0; };
-	virtual ~DxWindowEvent(){};
+	virtual ~DxWindowEvent() = default;
 	void SetSourceWindow(gstd::ref_count_ptr<DxWindow> source) { windowSource_ = source; }
 	gstd::ref_count_ptr<DxWindow> GetSourceWindow() { return windowSource_; }
 	void AddEventType(int type) { type_ |= type; }
@@ -50,7 +50,7 @@ protected:
 class DxWindowManager : public gstd::TaskBase {
 public:
 	DxWindowManager();
-	virtual ~DxWindowManager();
+	~DxWindowManager() override;
 	void Clear();
 
 	void AddWindow(gstd::ref_count_ptr<DxWindow> window);
@@ -64,7 +64,7 @@ public:
 	void SetWindowEnableWithoutArgumentWindow(bool bEnable, DxWindow* window);
 
 	gstd::ref_count_ptr<DxWindow> GetIntersectedWindow();
-	gstd::ref_count_ptr<DxWindow> GetIntersectedWindow(POINT& pos, gstd::ref_count_ptr<DxWindow> parent = NULL);
+	gstd::ref_count_ptr<DxWindow> GetIntersectedWindow(POINT& pos, gstd::ref_count_ptr<DxWindow> parent = nullptr);
 
 protected:
 	std::list<gstd::ref_count_ptr<DxWindow>> listWindow_; //最前面がアクティブ
@@ -100,7 +100,7 @@ public:
 	virtual void IntersectMouseCursor() {}
 
 	int GetID() const { return idWindow_; }
-	virtual bool IsIntersected(POINT pos);
+	virtual bool IsIntersected(POINT& pos);
 	void SetWindowRect(RECT rect) { rectWindow_ = rect; }
 	RECT GetWindowRect() const { return rectWindow_; }
 	RECT GetAbsoluteWindowRect();
@@ -145,9 +145,9 @@ private:
 class DxLabel : public DxWindow {
 public:
 	DxLabel();
-	virtual void Work();
-	virtual void Render();
-	void SetText(std::wstring str);
+	void Work() override;
+	void Render() override;
+	void SetText(const std::wstring& str);
 	void SetText(gstd::ref_count_ptr<DxText> text, bool bArrange = false);
 
 protected:
@@ -160,8 +160,8 @@ protected:
 class DxButton : public DxLabel {
 public:
 	DxButton();
-	virtual void Work();
-	virtual void Render();
+	void Work() override;
+	void Render() override;
 	virtual void RenderIntersectedFrame();
 	virtual void RenderSelectedFrame();
 
@@ -185,7 +185,7 @@ public:
 
 public:
 	DxMessageBox();
-	virtual void DispatchedEvent(gstd::ref_count_ptr<DxWindowEvent> event);
+	void DispatchedEvent(gstd::ref_count_ptr<DxWindowEvent> event) override;
 	void SetText(gstd::ref_count_ptr<DxText> text);
 	void SetButton(std::vector<gstd::ref_count_ptr<DxButton>> listButton);
 	int GetSelectedIndex() const { return index_; }

--- a/source/GcLib/directx/ElfreinaMesh.cpp
+++ b/source/GcLib/directx/ElfreinaMesh.cpp
@@ -872,7 +872,7 @@ bool ElfreinaMesh::CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> re
 	}
 	return res;
 }
-bool ElfreinaMesh::CreateFromFileInLoadThread(std::wstring path)
+bool ElfreinaMesh::CreateFromFileInLoadThread(const std::wstring& path)
 {
 	return DxMesh::CreateFromFileInLoadThread(path, MESH_ELFREINA);
 }
@@ -938,7 +938,7 @@ gstd::ref_count_ptr<RenderBlocks> ElfreinaMesh::CreateRenderBlocks()
 	}
 	return res;
 }
-gstd::ref_count_ptr<RenderBlocks> ElfreinaMesh::CreateRenderBlocks(std::wstring nameAnime, double time)
+gstd::ref_count_ptr<RenderBlocks> ElfreinaMesh::CreateRenderBlocks(const std::wstring& nameAnime, double time)
 {
 	if (data_ == NULL)
 		return NULL;
@@ -970,7 +970,7 @@ double ElfreinaMesh::_CalcFrameToTime(double time, gstd::ref_count_ptr<ElfreinaM
 	}
 	return time;
 }
-gstd::ref_count_ptr<Matrices> ElfreinaMesh::CreateAnimationMatrix(std::wstring nameAnime, double time)
+gstd::ref_count_ptr<Matrices> ElfreinaMesh::CreateAnimationMatrix(const std::wstring& nameAnime, double time)
 {
 	if (data_ == NULL)
 		return NULL;
@@ -988,7 +988,7 @@ gstd::ref_count_ptr<Matrices> ElfreinaMesh::CreateAnimationMatrix(std::wstring n
 	return matrix;
 }
 
-D3DXMATRIX ElfreinaMesh::GetAnimationMatrix(std::wstring nameAnime, double time, std::wstring nameBone)
+D3DXMATRIX ElfreinaMesh::GetAnimationMatrix(const std::wstring& nameAnime, double time, const std::wstring& nameBone)
 {
 	D3DXMATRIX res;
 	ElfreinaMeshData* data = (ElfreinaMeshData*)data_.GetPointer();

--- a/source/GcLib/directx/ElfreinaMesh.cpp
+++ b/source/GcLib/directx/ElfreinaMesh.cpp
@@ -9,12 +9,8 @@ using namespace directx;
 //ElfreinaMesh
 **********************************************************/
 //ElfreinaMeshData
-ElfreinaMeshData::ElfreinaMeshData()
-{
-}
-ElfreinaMeshData::~ElfreinaMeshData()
-{
-}
+ElfreinaMeshData::ElfreinaMeshData() = default;
+ElfreinaMeshData::~ElfreinaMeshData() = default;
 bool ElfreinaMeshData::CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> reader)
 {
 	bool res = false;
@@ -45,8 +41,8 @@ bool ElfreinaMeshData::CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader
 		}
 
 		//頂点バッファ作成
-		for (int iMesh = 0; iMesh < mesh_.size(); iMesh++) {
-			mesh_[iMesh]->InitializeVertexBuffer();
+		for (auto& iMesh : mesh_) {
+			iMesh->InitializeVertexBuffer();
 		}
 
 		res = true;
@@ -88,9 +84,9 @@ bool ElfreinaMeshData::CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader
 				}
 			}
 		}
-		for (int iBone = 0; iBone < bone_.size(); iBone++) {
+		for (auto & iBone : bone_) {
 			std::wstring log = L" Bone ";
-			std::wstring name = bone_[iBone]->name_;
+			std::wstring name = iBone->name_;
 			log += StringUtility::Format(L"name[%s] ", name.c_str());
 			Logger::WriteTop(log);
 		}
@@ -147,7 +143,7 @@ void ElfreinaMeshData::_ReadMeshContainer(gstd::Scanner& scanner)
 				if (tok.GetType() != Token::TK_STRING)
 					continue;
 				bone_[iBone]->name_ = tok.GetString();
-				iBone++;
+				++iBone;
 			}
 		} else if (tok.GetElement() == L"OffsetMatrices") {
 			int iCount = 0;
@@ -162,14 +158,14 @@ void ElfreinaMeshData::_ReadMeshContainer(gstd::Scanner& scanner)
 					if (iCount != 0 && iBone != -1 && iCount != 16)
 						throw gstd::wexception(L"ElfreinaMeshData:OffsetMatricesの数が不正です");
 					iCount = 0;
-					iBone++;
+					++iBone;
 				}
 
 				if (tok.GetType() != Token::TK_INT && tok.GetType() != Token::TK_REAL)
 					continue;
 
 				bone_[iBone]->matOffset_.m[iCount / 4][iCount % 4] = tok.GetReal();
-				iCount++;
+				++iCount;
 			}
 		} else if (tok.GetElement() == L"Materials") {
 			int posMat = 0;
@@ -189,13 +185,13 @@ void ElfreinaMeshData::_ReadMeshContainer(gstd::Scanner& scanner)
 				} else if (tok.GetElement() == L"Material") {
 					scanner.CheckType(scanner.Next(), Token::TK_OPENC);
 					_ReadMaterials(scanner, *material_[posMat].GetPointer());
-					posMat++;
+					++posMat;
 				}
 			}
 		} else if (tok.GetElement() == L"Mesh") {
 			scanner.CheckType(scanner.Next(), Token::TK_OPENC);
 			_ReadMesh(scanner, *mesh_[countReadMesh].GetPointer());
-			countReadMesh++;
+			++countReadMesh;
 		}
 	}
 }
@@ -390,14 +386,14 @@ void ElfreinaMeshData::_ReadMesh(gstd::Scanner& scanner, Mesh& mesh)
 		std::vector<Mesh::BoneWeightData>& datas = vectWeight[iVert];
 		if (false) {
 			//BLEND2
-			Mesh::BoneWeightData* data1 = NULL;
-			Mesh::BoneWeightData* data2 = NULL;
-			for (int iDatas = 0; iDatas < datas.size(); iDatas++) {
-				Mesh::BoneWeightData* data = &datas[iDatas];
+			Mesh::BoneWeightData* data1 = nullptr;
+			Mesh::BoneWeightData* data2 = nullptr;
+			for (auto& iDatas : datas) {
+				Mesh::BoneWeightData* data = &iDatas;
 				totalWeight[data->index] += data->weight;
-				if (data1 == NULL)
+				if (data1 == nullptr)
 					data1 = data;
-				else if (data2 == NULL) {
+				else if (data2 == nullptr) {
 					data2 = data;
 					if (data1->weight < data2->weight) {
 						Mesh::BoneWeightData* temp = data1;
@@ -415,25 +411,25 @@ void ElfreinaMeshData::_ReadMesh(gstd::Scanner& scanner, Mesh& mesh)
 			}
 
 			//頂点データに設定
-			if (data1 != NULL && data2 != NULL) {
-				float sub = 1.0f - data1->weight - data2->weight;
-				data1->weight += sub / 2.0f;
-				data2->weight += sub / 2.0f;
-				if (data1->weight > 1.0f)
-					data1->weight = 1.0f;
-				if (data2->weight > 1.0f)
-					data2->weight = 1.0f;
+			if (data1 != nullptr && data2 != nullptr) {
+				float sub = 1.0F - data1->weight - data2->weight;
+				data1->weight += sub / 2.0F;
+				data2->weight += sub / 2.0F;
+				if (data1->weight > 1.0F)
+					data1->weight = 1.0F;
+				if (data2->weight > 1.0F)
+					data2->weight = 1.0F;
 			}
 
-			if (data1 != NULL)
+			if (data1 != nullptr)
 				mesh.SetVertexBlend(iVert, 0, data1->index, data1->weight);
-			if (data2 != NULL)
+			if (data2 != nullptr)
 				mesh.SetVertexBlend(iVert, 1, data2->index, data2->weight);
 		} else {
 			int dataCount = datas.size();
-			for (int iDatas = 0; iDatas < dataCount; iDatas++) {
+			for (int iDatas = 0; iDatas < dataCount; ++iDatas) {
 				Mesh::BoneWeightData* data = &datas[iDatas];
-				if (data == NULL)
+				if (data == nullptr)
 					continue;
 				totalWeight[data->index] += data->weight;
 				mesh.SetVertexBlend(iVert, iDatas, data->index, data->weight);
@@ -444,7 +440,7 @@ void ElfreinaMeshData::_ReadMesh(gstd::Scanner& scanner, Mesh& mesh)
 	//重心
 	double maxWeight = 0;
 	mesh.CalculateWeightCenter();
-	for (int iBone = 0; iBone < totalWeight.size(); iBone++) {
+	for (int iBone = 0; iBone < totalWeight.size(); ++iBone) {
 		if (totalWeight[iBone] < maxWeight)
 			continue;
 		mesh.indexWeightForCalucZValue_ = iBone;
@@ -454,7 +450,7 @@ void ElfreinaMeshData::_ReadMesh(gstd::Scanner& scanner, Mesh& mesh)
 
 void ElfreinaMeshData::_ReadHierarchyList(gstd::Scanner& scanner)
 {
-	for (int iBone = 0; iBone < bone_.size(); iBone++) {
+	for (int iBone = 0; iBone < bone_.size(); ++iBone) {
 		std::wstring name = bone_[iBone]->name_;
 		mapBoneNameIndex_[name] = iBone;
 	}
@@ -473,7 +469,7 @@ void ElfreinaMeshData::_ReadHierarchyList(gstd::Scanner& scanner)
 int ElfreinaMeshData::_ReadNode(gstd::Scanner& scanner, int parent)
 {
 	int indexBone = -1;
-	Bone* bone = NULL;
+	Bone* bone = nullptr;
 	while (true) {
 		gstd::Token& tok = scanner.Next();
 		if (tok.GetType() == Token::TK_CLOSEC)
@@ -516,7 +512,7 @@ void ElfreinaMeshData::_ReadAnimationList(gstd::Scanner& scanner)
 			scanner.CheckType(scanner.Next(), Token::TK_OPENC);
 			scanner.CheckType(scanner.Next(), Token::TK_NEWLINE);
 			gstd::ref_count_ptr<AnimationData> anime = _ReadAnimationData(scanner);
-			if (anime != NULL) {
+			if (anime != nullptr) {
 				anime_[anime->name_] = anime;
 			}
 		}
@@ -560,9 +556,9 @@ gstd::ref_count_ptr<ElfreinaMeshData::AnimationData> ElfreinaMeshData::_ReadAnim
 			while (true) {
 				tok = scanner.Next();
 				if (tok.GetType() == Token::TK_OPENC)
-					count++;
+					++count;
 				else if (tok.GetType() == Token::TK_CLOSEC)
-					count--;
+					--count;
 				if (count == 0)
 					break;
 			}
@@ -591,7 +587,7 @@ void ElfreinaMeshData::_ReadBoneAnimation(gstd::Scanner& scanner, AnimationData&
 void ElfreinaMeshData::_ReadBoneAnimationPart(gstd::Scanner& scanner, AnimationData& anime)
 {
 	int indexBone = -1;
-	BoneAnimationPart* part = new BoneAnimationPart();
+	auto* part = new BoneAnimationPart();
 	while (true) {
 		gstd::Token& tok = scanner.Next();
 		if (tok.GetType() == Token::TK_CLOSEC)
@@ -656,9 +652,7 @@ ElfreinaMeshData::Mesh::Mesh()
 {
 	SetPrimitiveType(D3DPT_TRIANGLELIST);
 }
-ElfreinaMeshData::Mesh::~Mesh()
-{
-}
+ElfreinaMeshData::Mesh::~Mesh() = default;
 void ElfreinaMeshData::Mesh::Render()
 {
 	IDirect3DDevice9* device = DirectGraphics::GetBase()->GetDevice();
@@ -718,8 +712,7 @@ gstd::ref_count_ptr<Matrices> ElfreinaMeshData::AnimationData::CreateBoneAnimati
 
 		//子の行列を計算
 		std::vector<int>& indexChild = bones[iBone]->GetChildIndex();
-		for (int iChild = 0; iChild < indexChild.size(); iChild++) {
-			int index = indexChild[iChild];
+		for (int index : indexChild) {
 			_CreateBoneAnimationMatrix(time, mesh, matrix, index, mat);
 		}
 	}
@@ -739,8 +732,7 @@ void ElfreinaMeshData::AnimationData::_CreateBoneAnimationMatrix(int time, Elfre
 
 	//子の行列を計算
 	std::vector<int>& indexChild = bones[indexOwn]->GetChildIndex();
-	for (int iChild = 0; iChild < indexChild.size(); iChild++) {
-		int index = indexChild[iChild];
+	for (int index : indexChild) {
 		_CreateBoneAnimationMatrix(time, mesh, matrix, index, mat);
 	}
 }
@@ -748,7 +740,7 @@ D3DXMATRIX ElfreinaMeshData::AnimationData::_CalculateMatrix(double time, int in
 {
 	D3DXMATRIX res;
 	BoneAnimationPart* part = animeBone_[index].GetPointer();
-	if (part == NULL) {
+	if (part == nullptr) {
 		D3DXMatrixIdentity(&res);
 		return res;
 	}
@@ -777,7 +769,7 @@ D3DXMATRIX ElfreinaMeshData::AnimationData::_CalculateMatrix(double time, int in
 
 	float timeDiffKey = (float)timeTotal_ * keyTime[keyNext] - (float)timeTotal_ * keyTime[keyPrevious];
 	float timeDiffAnime = (float)(time - timeTotal_ * keyTime[keyPrevious]);
-	float rateToNext = timeDiffKey != 0.0f ? timeDiffAnime / timeDiffKey : 0;
+	float rateToNext = timeDiffKey != 0.0F ? timeDiffAnime / timeDiffKey : 0;
 
 	//各行列を作成
 	std::vector<D3DXVECTOR3>& keyTrans = part->GetTransKey();
@@ -810,22 +802,20 @@ D3DXMATRIX ElfreinaMeshData::AnimationData::_CalculateMatrix(double time, int in
 }
 
 //RenderObjectElfreinaBlock
-RenderObjectElfreinaBlock::~RenderObjectElfreinaBlock()
-{
-}
+RenderObjectElfreinaBlock::~RenderObjectElfreinaBlock() = default;
 bool RenderObjectElfreinaBlock::IsTranslucent()
 {
-	ElfreinaMeshData::Mesh* obj = (ElfreinaMeshData::Mesh*)obj_.GetPointer();
+	auto* obj = (ElfreinaMeshData::Mesh*)obj_.GetPointer();
 	D3DMATERIAL9& mat = obj->material_->mat_;
 	bool bTrans = true;
-	bTrans &= (mat.Diffuse.a != 1.0f);
+	bTrans &= (mat.Diffuse.a != 1.0F);
 	return RenderObjectB2NXBlock::IsTranslucent() || bTrans;
 }
 void RenderObjectElfreinaBlock::CalculateZValue()
 {
 	DirectGraphics* graph = DirectGraphics::GetBase();
 	IDirect3DDevice9* pDevice = graph->GetDevice();
-	ElfreinaMeshData::Mesh* obj = (ElfreinaMeshData::Mesh*)obj_.GetPointer();
+	auto* obj = (ElfreinaMeshData::Mesh*)obj_.GetPointer();
 
 	D3DXMATRIX matTrans = obj->_CreateWorldTransformMaxtrix();
 	D3DXMATRIX matView;
@@ -846,25 +836,25 @@ bool ElfreinaMesh::CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> re
 	bool res = false;
 	{
 		Lock lock(DxMeshManager::GetBase()->GetLock());
-		if (data_ != NULL)
+		if (data_ != nullptr)
 			Release();
 
 		std::wstring name = reader->GetOriginalPath();
 
 		data_ = _GetFromManager(name);
-		if (data_ == NULL) {
+		if (data_ == nullptr) {
 			if (!reader->Open())
 				throw gstd::wexception(L"ファイルが開けません");
 			data_ = new ElfreinaMeshData();
 			data_->SetName(name);
-			ElfreinaMeshData* data = (ElfreinaMeshData*)data_.GetPointer();
+			auto* data = (ElfreinaMeshData*)data_.GetPointer();
 			res = data->CreateFromFileReader(reader);
 			if (res) {
 				Logger::WriteTop(StringUtility::Format(L"メッシュを読み込みました[%s]", name.c_str()));
 				_AddManager(name, data_);
 
 			} else {
-				data_ = NULL;
+				data_ = nullptr;
 			}
 		} else {
 			res = true;
@@ -878,18 +868,18 @@ bool ElfreinaMesh::CreateFromFileInLoadThread(const std::wstring& path)
 }
 std::wstring ElfreinaMesh::GetPath()
 {
-	if (data_ == NULL)
+	if (data_ == nullptr)
 		return L"";
 	return ((ElfreinaMeshData*)data_.GetPointer())->path_;
 }
 void ElfreinaMesh::Render()
 {
-	if (data_ == NULL)
+	if (data_ == nullptr)
 		return;
 
-	ElfreinaMeshData* data = (ElfreinaMeshData*)data_.GetPointer();
-	for (int iMesh = 0; iMesh < data->mesh_.size(); iMesh++) {
-		ElfreinaMeshData::Mesh* mesh = data->mesh_[iMesh].GetPointer();
+	auto* data = (ElfreinaMeshData*)data_.GetPointer();
+	for (auto& iMesh : data->mesh_) {
+		ElfreinaMeshData::Mesh* mesh = iMesh.GetPointer();
 		mesh->SetPosition(position_);
 		mesh->SetAngle(angle_);
 		mesh->SetScale(scale_);
@@ -901,32 +891,31 @@ void ElfreinaMesh::Render()
 }
 void ElfreinaMesh::Render(std::wstring nameAnime, int time)
 {
-	if (data_ == NULL)
+	if (data_ == nullptr)
 		return;
 
 	gstd::ref_count_ptr<Matrices> matrix = CreateAnimationMatrix(nameAnime, time);
-	if (matrix == NULL)
+	if (matrix == nullptr)
 		return;
 
-	ElfreinaMeshData* data = (ElfreinaMeshData*)data_.GetPointer();
+	auto* data = (ElfreinaMeshData*)data_.GetPointer();
 	while (!data->bLoad_) {
 		::Sleep(1);
 	}
 
-	for (int iMesh = 0; iMesh < data->mesh_.size(); iMesh++) {
-		ElfreinaMeshData::Mesh* mesh = data->mesh_[iMesh].GetPointer();
+	for (auto& iMesh : data->mesh_) {
+		ElfreinaMeshData::Mesh* mesh = iMesh.GetPointer();
 		mesh->SetMatrix(matrix);
 	}
 	Render();
 }
 gstd::ref_count_ptr<RenderBlocks> ElfreinaMesh::CreateRenderBlocks()
 {
-	if (data_ == NULL)
-		return NULL;
+	if (data_ == nullptr)
+		return nullptr;
 	gstd::ref_count_ptr<RenderBlocks> res = new RenderBlocks();
-	ElfreinaMeshData* data = (ElfreinaMeshData*)data_.GetPointer();
-	for (int iMesh = 0; iMesh < data->mesh_.size(); iMesh++) {
-		gstd::ref_count_ptr<ElfreinaMeshData::Mesh> mesh = data->mesh_[iMesh];
+	auto* data = (ElfreinaMeshData*)data_.GetPointer();
+	for (auto& mesh : data->mesh_) {
 		mesh->SetPosition(position_);
 		mesh->SetAngle(angle_);
 		mesh->SetScale(scale_);
@@ -940,18 +929,17 @@ gstd::ref_count_ptr<RenderBlocks> ElfreinaMesh::CreateRenderBlocks()
 }
 gstd::ref_count_ptr<RenderBlocks> ElfreinaMesh::CreateRenderBlocks(const std::wstring& nameAnime, double time)
 {
-	if (data_ == NULL)
-		return NULL;
+	if (data_ == nullptr)
+		return nullptr;
 
 	gstd::ref_count_ptr<Matrices> matrix = CreateAnimationMatrix(nameAnime, time);
-	if (matrix == NULL)
-		return NULL;
-	ElfreinaMeshData* data = (ElfreinaMeshData*)data_.GetPointer();
-	for (int iMesh = 0; iMesh < data->mesh_.size(); iMesh++) {
-		ElfreinaMeshData::Mesh* mesh = data->mesh_[iMesh].GetPointer();
+	if (matrix == nullptr)
+		return nullptr;
+	auto* data = (ElfreinaMeshData*)data_.GetPointer();
+	for (auto& iMesh : data->mesh_) {
+		ElfreinaMeshData::Mesh* mesh = iMesh.GetPointer();
 		mesh->SetMatrix(matrix);
 	}
-
 	return CreateRenderBlocks();
 }
 double ElfreinaMesh::_CalcFrameToTime(double time, gstd::ref_count_ptr<ElfreinaMeshData::AnimationData> anime)
@@ -972,13 +960,13 @@ double ElfreinaMesh::_CalcFrameToTime(double time, gstd::ref_count_ptr<ElfreinaM
 }
 gstd::ref_count_ptr<Matrices> ElfreinaMesh::CreateAnimationMatrix(const std::wstring& nameAnime, double time)
 {
-	if (data_ == NULL)
-		return NULL;
+	if (data_ == nullptr)
+		return nullptr;
 
-	ElfreinaMeshData* data = (ElfreinaMeshData*)data_.GetPointer();
+	auto* data = (ElfreinaMeshData*)data_.GetPointer();
 	bool bExist = data->anime_.find(nameAnime) != data->anime_.end();
 	if (!bExist)
-		return NULL;
+		return nullptr;
 	gstd::ref_count_ptr<ElfreinaMeshData::AnimationData> anime = data->anime_[nameAnime];
 
 	//ループ有無で時間を計算する
@@ -991,9 +979,10 @@ gstd::ref_count_ptr<Matrices> ElfreinaMesh::CreateAnimationMatrix(const std::wst
 D3DXMATRIX ElfreinaMesh::GetAnimationMatrix(const std::wstring& nameAnime, double time, const std::wstring& nameBone)
 {
 	D3DXMATRIX res;
-	ElfreinaMeshData* data = (ElfreinaMeshData*)data_.GetPointer();
-	if (data->mapBoneNameIndex_.find(nameBone) != data->mapBoneNameIndex_.end()) {
-		int indexBone = data->mapBoneNameIndex_[nameBone];
+	auto* data = (ElfreinaMeshData*)data_.GetPointer();
+	auto boneIndexItr = data->mapBoneNameIndex_.find(nameBone);
+	if (boneIndexItr != data->mapBoneNameIndex_.end()) {
+		int boneIndex = boneIndexItr->second;
 		bool bExist = data->anime_.find(nameAnime) != data->anime_.end();
 		if (bExist) {
 			gstd::ref_count_ptr<ElfreinaMeshData::AnimationData> anime = data->anime_[nameAnime];
@@ -1001,10 +990,10 @@ D3DXMATRIX ElfreinaMesh::GetAnimationMatrix(const std::wstring& nameAnime, doubl
 			//ループ有無で時間を計算する
 			time = _CalcFrameToTime(time, anime);
 			gstd::ref_count_ptr<Matrices> matrix = anime->CreateBoneAnimationMatrix(time, data);
-			D3DXMATRIX matBone = matrix->GetMatrix(indexBone);
+			D3DXMATRIX matBone = matrix->GetMatrix(boneIndex);
 
-			D3DXMATRIX matInv = data->bone_[indexBone]->matOffset_;
-			D3DXMatrixInverse(&matInv, NULL, &matInv);
+			D3DXMATRIX matInv = data->bone_[boneIndex]->matOffset_;
+			D3DXMatrixInverse(&matInv, nullptr, &matInv);
 			// D3DXVECTOR3 pos;
 			// D3DXVec3TransformCoord(&pos, &D3DXVECTOR3(0, 0, 0), &matInv);
 			// D3DXMatrixTranslation(&matInv, pos.x, pos.y, pos.z);

--- a/source/GcLib/directx/ElfreinaMesh.hpp
+++ b/source/GcLib/directx/ElfreinaMesh.hpp
@@ -59,7 +59,7 @@ public:
 public:
 	Bone(){};
 	virtual ~Bone(){};
-	int GetParentIndex() { return indexParent_; }
+	int GetParentIndex() const { return indexParent_; }
 	std::vector<int>& GetChildIndex() { return indexChild_; }
 	D3DXMATRIX& GetOffsetMatrix() { return matOffset_; }
 	D3DXMATRIX& GetInitPostureMatrix() { return matInitPosture_; }
@@ -157,16 +157,16 @@ public:
 	ElfreinaMesh() {}
 	virtual ~ElfreinaMesh() {}
 	virtual bool CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> reader);
-	virtual bool CreateFromFileInLoadThread(std::wstring path);
+	virtual bool CreateFromFileInLoadThread(const std::wstring& path);
 	virtual std::wstring GetPath();
 	virtual void Render();
 	virtual void Render(std::wstring nameAnime, int time);
 
 	gstd::ref_count_ptr<RenderBlocks> CreateRenderBlocks();
-	gstd::ref_count_ptr<RenderBlocks> CreateRenderBlocks(std::wstring nameAnime, double time);
+	gstd::ref_count_ptr<RenderBlocks> CreateRenderBlocks(const std::wstring& nameAnime, double time);
 
-	gstd::ref_count_ptr<Matrices> CreateAnimationMatrix(std::wstring nameAnime, double time);
-	virtual D3DXMATRIX GetAnimationMatrix(std::wstring nameAnime, double time, std::wstring nameBone);
+	gstd::ref_count_ptr<Matrices> CreateAnimationMatrix(const std::wstring& nameAnime, double time);
+	virtual D3DXMATRIX GetAnimationMatrix(const std::wstring& nameAnime, double time, const std::wstring& nameBone);
 
 protected:
 	double _CalcFrameToTime(double time, gstd::ref_count_ptr<ElfreinaMeshData::AnimationData> anime);

--- a/source/GcLib/directx/ElfreinaMesh.hpp
+++ b/source/GcLib/directx/ElfreinaMesh.hpp
@@ -22,7 +22,7 @@ public:
 
 public:
 	ElfreinaMeshData();
-	~ElfreinaMeshData();
+	~ElfreinaMeshData() override;
 	bool CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> reader);
 	std::vector<gstd::ref_count_ptr<Bone>>& GetBones() { return bone_; }
 
@@ -57,8 +57,8 @@ public:
 		NO_PARENT = -1,
 	};
 public:
-	Bone(){};
-	virtual ~Bone(){};
+	Bone() = default;
+	virtual ~Bone() = default;
 	int GetParentIndex() const { return indexParent_; }
 	std::vector<int>& GetChildIndex() { return indexChild_; }
 	D3DXMATRIX& GetOffsetMatrix() { return matOffset_; }
@@ -78,8 +78,8 @@ class ElfreinaMeshData::Material {
 	friend RenderObjectElfreinaBlock;
 
 public:
-	Material(){};
-	virtual ~Material(){};
+	Material() = default;
+	virtual ~Material() = default;
 
 protected:
 	std::wstring name_;
@@ -92,8 +92,8 @@ class ElfreinaMeshData::Mesh : public RenderObjectB4NX {
 
 public:
 	Mesh();
-	virtual ~Mesh();
-	virtual void Render();
+	~Mesh() override;
+	void Render() override;
 	gstd::ref_count_ptr<RenderBlock> CreateRenderBlock();
 
 protected:
@@ -113,8 +113,8 @@ class ElfreinaMeshData::AnimationData {
 	friend ElfreinaMeshData;
 
 public:
-	AnimationData(){};
-	virtual ~AnimationData(){};
+	AnimationData() = default;
+	virtual ~AnimationData() = default;
 	gstd::ref_count_ptr<Matrices> CreateBoneAnimationMatrix(double time, ElfreinaMeshData* mesh);
 
 protected:
@@ -131,8 +131,8 @@ class ElfreinaMeshData::BoneAnimationPart {
 	friend ElfreinaMeshData;
 
 public:
-	BoneAnimationPart(){};
-	virtual ~BoneAnimationPart(){};
+	BoneAnimationPart() = default;
+	virtual ~BoneAnimationPart() = default;
 	std::vector<float>& GetTimeKey() { return keyTime_; }
 	std::vector<D3DXVECTOR3>& GetTransKey() { return keyTrans_; }
 	std::vector<D3DXQUATERNION>& GetRotateKey() { return keyRotate_; }
@@ -147,26 +147,26 @@ protected:
 
 class RenderObjectElfreinaBlock : public RenderObjectB2NXBlock {
 public:
-	~RenderObjectElfreinaBlock();
-	virtual bool IsTranslucent();
-	virtual void CalculateZValue();
+	~RenderObjectElfreinaBlock() override;
+	bool IsTranslucent() override;
+	void CalculateZValue() override;
 };
 
 class ElfreinaMesh : public DxMesh {
 public:
-	ElfreinaMesh() {}
-	virtual ~ElfreinaMesh() {}
-	virtual bool CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> reader);
-	virtual bool CreateFromFileInLoadThread(const std::wstring& path);
-	virtual std::wstring GetPath();
-	virtual void Render();
+	ElfreinaMesh() = default;
+	~ElfreinaMesh() override = default;
+	bool CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> reader) override;
+	bool CreateFromFileInLoadThread(const std::wstring& path) override;
+	std::wstring GetPath() override;
+	void Render() override;
 	virtual void Render(std::wstring nameAnime, int time);
 
 	gstd::ref_count_ptr<RenderBlocks> CreateRenderBlocks();
 	gstd::ref_count_ptr<RenderBlocks> CreateRenderBlocks(const std::wstring& nameAnime, double time);
 
 	gstd::ref_count_ptr<Matrices> CreateAnimationMatrix(const std::wstring& nameAnime, double time);
-	virtual D3DXMATRIX GetAnimationMatrix(const std::wstring& nameAnime, double time, const std::wstring& nameBone);
+	D3DXMATRIX GetAnimationMatrix(const std::wstring& nameAnime, double time, const std::wstring& nameBone) override;
 
 protected:
 	double _CalcFrameToTime(double time, gstd::ref_count_ptr<ElfreinaMeshData::AnimationData> anime);

--- a/source/GcLib/directx/EventScript.cpp
+++ b/source/GcLib/directx/EventScript.cpp
@@ -21,7 +21,7 @@ void EventScriptSource::AddCode(gstd::ref_count_ptr<EventScriptCode> code)
 {
 	code_.push_back(code);
 }
-gstd::ref_count_ptr<EventScriptBlock_Main> EventScriptSource::GetEventBlock(std::string name)
+gstd::ref_count_ptr<EventScriptBlock_Main> EventScriptSource::GetEventBlock(const std::string& name)
 {
 	if (event_.find(name) == event_.end())
 		return NULL;
@@ -40,7 +40,7 @@ const std::string EventScriptScanner::TAG_RUBY = "ruby";
 const std::string EventScriptScanner::TAG_FONT = "font";
 const char CHAR_TAG_START = '[';
 const char CHAR_TAG_END = ']';
-EventScriptScanner::EventScriptScanner(char* str, int size)
+EventScriptScanner::EventScriptScanner(const char* str, int size)
 {
 	std::vector<char> buf;
 	buf.resize(size);
@@ -51,14 +51,14 @@ EventScriptScanner::EventScriptScanner(char* str, int size)
 	buf.push_back('\0');
 	this->EventScriptScanner::EventScriptScanner(buf);
 }
-EventScriptScanner::EventScriptScanner(std::string str)
+EventScriptScanner::EventScriptScanner(const std::string& str)
 {
 	std::vector<char> buf;
 	buf.resize(str.size() + 1);
 	memcpy(&buf[0], str.c_str(), str.size() + 1);
 	this->EventScriptScanner::EventScriptScanner(buf);
 }
-EventScriptScanner::EventScriptScanner(std::vector<char>& buf)
+EventScriptScanner::EventScriptScanner(const std::vector<char>& buf)
 {
 	buffer_ = buf;
 	pointer_ = buffer_.begin();
@@ -134,7 +134,7 @@ void EventScriptScanner::_SkipSpace()
 		ch = _NextChar();
 	}
 }
-void EventScriptScanner::_RaiseError(std::wstring str)
+void EventScriptScanner::_RaiseError(const std::wstring& str)
 {
 	throw gstd::wexception(str);
 }
@@ -396,21 +396,21 @@ bool EventScriptScanner::HasNext()
 {
 	return pointer_ != buffer_.end() && *pointer_ != '\0' && token_.GetType() != EventScriptToken::TK_EOF;
 }
-void EventScriptScanner::CheckType(EventScriptToken& tok, int type)
+void EventScriptScanner::CheckType(const EventScriptToken& tok, int type)
 {
 	if (tok.type_ != type) {
 		std::wstring str = StringUtility::Format(L"CheckType error[%s]:", tok.element_.c_str());
 		_RaiseError(str);
 	}
 }
-void EventScriptScanner::CheckIdentifer(EventScriptToken& tok, std::string id)
+void EventScriptScanner::CheckIdentifer(const EventScriptToken& tok, const std::string& id)
 {
 	if (tok.type_ != EventScriptToken::TK_ID || tok.GetIdentifier() != id) {
 		std::wstring str = StringUtility::Format(L"CheckID error[%s]:", tok.element_.c_str());
 		_RaiseError(str);
 	}
 }
-int EventScriptScanner::GetCurrentLine()
+int EventScriptScanner::GetCurrentLine() const
 {
 	return line_;
 }
@@ -431,7 +431,7 @@ int EventScriptScanner::SearchCurrentLine()
 	}
 	return line;
 }
-std::vector<char>::iterator EventScriptScanner::GetCurrentPointer()
+std::vector<char>::iterator EventScriptScanner::GetCurrentPointer() const
 {
 	return pointer_;
 }
@@ -439,7 +439,7 @@ void EventScriptScanner::SetCurrentPointer(std::vector<char>::iterator pos)
 {
 	pointer_ = pos;
 }
-int EventScriptScanner::GetCurrentPosition()
+int EventScriptScanner::GetCurrentPosition() const
 {
 	if (buffer_.size() == 0)
 		return 0;
@@ -448,35 +448,35 @@ int EventScriptScanner::GetCurrentPosition()
 }
 
 //EventScriptToken
-std::string& EventScriptToken::GetIdentifier()
+std::string EventScriptToken::GetIdentifier() const
 {
 	if (type_ != TK_ID) {
 		throw gstd::wexception(L"EventScriptToken::GetIdentifier:データのタイプが違います");
 	}
 	return element_;
 }
-std::string EventScriptToken::GetString()
+std::string EventScriptToken::GetString() const
 {
 	if (type_ != TK_STRING) {
 		throw gstd::wexception(L"EventScriptToken::GetString:データのタイプが違います");
 	}
 	return element_.substr(1, element_.size() - 2);
 }
-int EventScriptToken::GetInteger()
+int EventScriptToken::GetInteger() const
 {
 	if (type_ != TK_INT) {
 		throw gstd::wexception(L"EventScriptToken::GetInterger:データのタイプが違います");
 	}
 	return atoi(element_.c_str());
 }
-double EventScriptToken::GetReal()
+double EventScriptToken::GetReal() const
 {
 	if (type_ != TK_REAL && type_ != TK_INT) {
 		throw gstd::wexception(L"EventScriptToken::GetReal:データのタイプが違います");
 	}
 	return atof(element_.c_str());
 }
-bool EventScriptToken::GetBoolean()
+bool EventScriptToken::GetBoolean() const
 {
 	bool res = false;
 	if (type_ == TK_REAL && type_ == TK_INT) {
@@ -1025,7 +1025,7 @@ EventScriptCode_NextLine::EventScriptCode_NextLine()
 {
 	type_ = TYPE_NEXT_LINE;
 }
-std::string EventScriptCode_NextLine::GetCodeText()
+std::string EventScriptCode_NextLine::GetCodeText() const
 {
 	return EventScriptScanner::TAG_START + EventScriptScanner::TAG_NEW_LINE + EventScriptScanner::TAG_END;
 }
@@ -1169,31 +1169,31 @@ EventScriptCodeExecuter::EventScriptCodeExecuter(EventEngine* engine)
 EventScriptCodeExecuter::~EventScriptCodeExecuter()
 {
 }
-int EventScriptCodeExecuter::_GetElementInteger(std::string value)
+int EventScriptCodeExecuter::_GetElementInteger(const std::string& value)
 {
 	EventValueParser parser(engine_);
 	ref_count_ptr<EventValue> res = parser.GetEventValue(value);
 	return floorl(res->GetReal() + 0.5);
 }
-double EventScriptCodeExecuter::_GetElementReal(std::string value)
+double EventScriptCodeExecuter::_GetElementReal(const std::string& value)
 {
 	EventValueParser parser(engine_);
 	ref_count_ptr<EventValue> res = parser.GetEventValue(value);
 	return res->GetReal();
 }
-bool EventScriptCodeExecuter::_GetElementBoolean(std::string value)
+bool EventScriptCodeExecuter::_GetElementBoolean(const std::string& value)
 {
 	EventValueParser parser(engine_);
 	ref_count_ptr<EventValue> res = parser.GetEventValue(value);
 	return res->GetBoolean();
 }
-std::string EventScriptCodeExecuter::_GetElementString(std::string value)
+std::string EventScriptCodeExecuter::_GetElementString(const std::string& value)
 {
 	EventValueParser parser(engine_);
 	ref_count_ptr<EventValue> res = parser.GetEventValue(value);
 	return res->GetString();
 }
-bool EventScriptCodeExecuter::_IsValieElement(std::string value)
+bool EventScriptCodeExecuter::_IsValieElement(const std::string& value)
 {
 	return value != EventScriptCode::STRING_INVALID;
 }
@@ -1963,7 +1963,7 @@ EventLogText::EventLogText(EventEngine* engine)
 EventLogText::~EventLogText()
 {
 }
-void EventLogText::Add(std::string text, std::string name)
+void EventLogText::Add(std::string text)
 {
 	text += EventScriptScanner::TAG_START + EventScriptScanner::TAG_NEW_LINE + EventScriptScanner::TAG_END + "--------------------------------";
 	EventLogWindow* wnd = engine_->GetWindowManager()->GetLogWindow().GetPointer();
@@ -2008,7 +2008,7 @@ gstd::TextParser::Result EventValue::ConvertToTextParserResult()
 	}
 	return res;
 }
-void EventValue::Copy(gstd::TextParser::Result& val)
+void EventValue::Copy(const gstd::TextParser::Result& val)
 {
 	if (val.IsReal()) {
 		type_ = EventValue::TYPE_REAL;
@@ -2022,7 +2022,7 @@ void EventValue::Copy(gstd::TextParser::Result& val)
 		valueString_ = str;
 	}
 }
-void EventValue::Copy(EventValue& val)
+void EventValue::Copy(const EventValue& val)
 {
 	*this = val;
 }
@@ -2090,19 +2090,19 @@ bool EventFrame::HasNextCode()
 	}
 	return res;
 }
-gstd::ref_count_ptr<EventValue> EventFrame::GetValue(std::string key)
+gstd::ref_count_ptr<EventValue> EventFrame::GetValue(const std::string& key)
 {
 	if (mapValue_.find(key) == mapValue_.end())
 		return NULL;
 	return mapValue_[key];
 }
-void EventFrame::AddValue(std::string key, gstd::ref_count_ptr<EventValue> val)
+void EventFrame::AddValue(const std::string& key, gstd::ref_count_ptr<EventValue> val)
 {
 	// if(mapValue_.find(key) != mapValue_.end())
 	// 	return NULL;
 	mapValue_[key] = val;
 }
-void EventFrame::SetValue(std::string key, gstd::ref_count_ptr<EventValue> val)
+void EventFrame::SetValue(const std::string& key, gstd::ref_count_ptr<EventValue> val)
 {
 	mapValue_[key] = val;
 }
@@ -2211,7 +2211,7 @@ EventValueParser::EventValueParser(EventEngine* engine)
 {
 	engine_ = engine;
 }
-gstd::TextParser::Result EventValueParser::_ParseIdentifer(std::vector<char>::iterator pos)
+gstd::TextParser::Result EventValueParser::_ParseIdentifer(std::vector<char>::iterator)
 {
 	Result res;
 	Token& tok = scan_->GetToken();
@@ -2269,7 +2269,7 @@ std::vector<std::string> EventValueParser::_GetFuctionArgument()
 	}
 	return res;
 }
-gstd::ref_count_ptr<EventValue> EventValueParser::GetEventValue(std::string text)
+gstd::ref_count_ptr<EventValue> EventValueParser::GetEventValue(const std::string& text)
 {
 	SetSource(text);
 	gstd::ref_count_ptr<EventValue> res = new EventValue();
@@ -2299,11 +2299,11 @@ void EventImage::Render(int layer)
 {
 	objManager_[layer]->RenderObject();
 }
-int EventImage::GetForegroundLayerIndex()
+int EventImage::GetForegroundLayerIndex() const
 {
 	return indexForeground_;
 }
-int EventImage::GetBackgroundLayerIndex()
+int EventImage::GetBackgroundLayerIndex() const
 {
 	return 1 - indexForeground_;
 }
@@ -2350,17 +2350,17 @@ void EventKeyState::Work()
 {
 	bNextEnable_ = true;
 }
-bool EventKeyState::IsNext()
+bool EventKeyState::IsNext() const
 {
 	if (!bNextEnable_)
 		return false;
 
+	const DirectInput* input = DirectInput::GetBase();
+
+	auto mngWindow = engine_->GetWindowManager();
+	auto wndEvent = mngWindow->GetMouseCaptureLayer()->GetEvent();
+
 	bool res = false;
-	DirectInput* input = DirectInput::GetBase();
-
-	gstd::ref_count_ptr<EventWindowManager> mngWindow = engine_->GetWindowManager();
-	gstd::ref_count_ptr<DxWindowEvent> wndEvent = mngWindow->GetMouseCaptureLayer()->GetEvent();
-
 	res |= (wndEvent != NULL && wndEvent->HasEventType(DxWindowEvent::TYPE_MOUSE_LEFT_CLICK));
 	res |= (input->GetKeyState(DIK_Z) == KEY_PUSH);
 	res |= (input->GetKeyState(DIK_RETURN) == KEY_PUSH);
@@ -2368,10 +2368,10 @@ bool EventKeyState::IsNext()
 
 	return res;
 }
-bool EventKeyState::IsSkip()
+bool EventKeyState::IsSkip() const
 {
+	const DirectInput* input = DirectInput::GetBase();
 	bool res = false;
-	DirectInput* input = DirectInput::GetBase();
 	res |= (input->GetKeyState(DIK_LCONTROL) == KEY_HOLD);
 	return res;
 }
@@ -2387,7 +2387,7 @@ EventSound::~EventSound()
 	if (playerSe_ != NULL)
 		playerSe_->Delete();
 }
-void EventSound::Play(int type, std::string path)
+void EventSound::Play(int type, const std::string& path)
 {
 	DirectSoundManager* manager = DirectSoundManager::GetBase();
 	gstd::ref_count_ptr<SoundPlayer> player = type == TYPE_BGM ? playerBgm_ : playerSe_;
@@ -2570,7 +2570,7 @@ void EventEngine::_RunCode()
 				activeCodeExecuter_ = new EventScriptCodeExecuter_WaitTime(this, codeWaitTime);
 			} else if (typeCode == EventScriptCode::TYPE_CLEAR_MESSAGE) {
 				std::string text = StringUtility::ConvertWideToMulti(textEvent_->GetText());
-				logEvent_->Add(text, "");
+				logEvent_->Add(text);
 				textEvent_->Clear();
 			} else if (typeCode == EventScriptCode::TYPE_NAME) {
 				EventScriptCode_Name* codeName = (EventScriptCode_Name*)code.GetPointer();
@@ -2824,7 +2824,7 @@ void EventEngine::_WorkWindow()
 {
 	windowManager_->Work();
 }
-gstd::ref_count_ptr<EventScriptSource> EventEngine::_GetSource(std::wstring path)
+gstd::ref_count_ptr<EventScriptSource> EventEngine::_GetSource(const std::wstring& path)
 {
 	gstd::ref_count_ptr<EventScriptSource> res = NULL;
 	if (mapSource_.find(path) != mapSource_.end()) {
@@ -2888,7 +2888,7 @@ void EventEngine::Render()
 	windowManager_->Render();
 }
 
-void EventEngine::SetSource(std::wstring path)
+void EventEngine::SetSource(const std::wstring& path)
 {
 	ref_count_ptr<EventScriptSource> source = _GetSource(path);
 	ref_count_ptr<EventFrame> frame = new EventFrame();
@@ -2899,7 +2899,7 @@ void EventEngine::SetSource(std::wstring path)
 
 	frame_.push_back(frame);
 }
-gstd::ref_count_ptr<EventScriptSource> EventEngine::GetSource(std::wstring path)
+gstd::ref_count_ptr<EventScriptSource> EventEngine::GetSource(const std::wstring& path)
 {
 	if (mapSource_.find(path) == mapSource_.end())
 		return NULL;
@@ -3037,7 +3037,7 @@ bool EventEngine::IsSaveEnable()
 	bool bEnable = ref_count_ptr<EventScriptCodeExecuter_WaitClick>::DownCast(activeCodeExecuter_) != NULL;
 	return bEnable;
 }
-bool EventEngine::Load(std::wstring path)
+bool EventEngine::Load(const std::wstring& path)
 {
 	RecordBuffer record;
 	record.ReadFromFile(path);
@@ -3056,7 +3056,7 @@ bool EventEngine::Load(gstd::RecordBuffer& record)
 
 	return true;
 }
-bool EventEngine::Save(std::wstring path)
+bool EventEngine::Save(const std::wstring& path)
 {
 	RecordBuffer record;
 	Write(record);
@@ -3242,15 +3242,15 @@ void DxScriptForEvent::Clear()
 		objManager_->DeleteObject(*itr);
 	}
 }
-bool DxScriptForEvent::SetSourceFromFile(std::wstring path)
+bool DxScriptForEvent::SetSourceFromFile(const std::wstring& path)
 {
 	SetScriptEngineCache(engine_->GetScriptEngineCache());
 	return ScriptClientBase::SetSourceFromFile(path);
 }
-void DxScriptForEvent::SetSource(std::string source)
+void DxScriptForEvent::SetSource(const std::string& source)
 {
-	code_ = source;
 	ScriptClientBase::SetSource(source);
+	code_ = source;
 }
 int DxScriptForEvent::AddObject(gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj)
 {

--- a/source/GcLib/directx/EventScript.cpp
+++ b/source/GcLib/directx/EventScript.cpp
@@ -9,9 +9,7 @@ using namespace directx;
 //EventScriptSource
 //コンパイルされたイベントスクリプトコード
 **********************************************************/
-EventScriptSource::EventScriptSource()
-{
-}
+EventScriptSource::EventScriptSource() = default;
 EventScriptSource::~EventScriptSource()
 {
 	code_.clear();
@@ -23,28 +21,29 @@ void EventScriptSource::AddCode(gstd::ref_count_ptr<EventScriptCode> code)
 }
 gstd::ref_count_ptr<EventScriptBlock_Main> EventScriptSource::GetEventBlock(const std::string& name)
 {
-	if (event_.find(name) == event_.end())
-		return NULL;
-	return event_[name];
+	auto eventItr = event_.find(name);
+	if (eventItr != event_.end())
+		return eventItr->second;
+	return nullptr;
 }
 
 /**********************************************************
 //EventScriptScanner
 **********************************************************/
-const int EventScriptScanner::TOKEN_TAG_START = EventScriptToken::TK_OPENB;
-const int EventScriptScanner::TOKEN_TAG_END = EventScriptToken::TK_CLOSEB;
+constexpr int EventScriptScanner::TOKEN_TAG_START = EventScriptToken::TK_OPENB;
+constexpr int EventScriptScanner::TOKEN_TAG_END = EventScriptToken::TK_CLOSEB;
 const std::string EventScriptScanner::TAG_START = "[";
 const std::string EventScriptScanner::TAG_END = "]";
 const std::string EventScriptScanner::TAG_NEW_LINE = "r";
 const std::string EventScriptScanner::TAG_RUBY = "ruby";
 const std::string EventScriptScanner::TAG_FONT = "font";
-const char CHAR_TAG_START = '[';
-const char CHAR_TAG_END = ']';
+constexpr char CHAR_TAG_START = '[';
+constexpr char CHAR_TAG_END = ']';
 EventScriptScanner::EventScriptScanner(const char* str, int size)
 {
 	std::vector<char> buf;
 	buf.resize(size);
-	if (buf.size() != 0) {
+	if (!buf.empty()) {
 		memcpy(&buf[0], str, size);
 	}
 
@@ -66,35 +65,33 @@ EventScriptScanner::EventScriptScanner(const std::vector<char>& buf)
 	line_ = 1;
 	bTagScan_ = false;
 }
-EventScriptScanner::~EventScriptScanner()
-{
-}
+EventScriptScanner::~EventScriptScanner() = default;
 
 char EventScriptScanner::_NextChar()
 {
-	if (HasNext() == false) {
+	if (!HasNext()) {
 		_RaiseError(L"_NextChar:すでに文字列終端です");
 	}
 
-	if (IsDBCSLeadByte(*pointer_))
+	if (IsDBCSLeadByte(*pointer_) != 0)
 		pointer_ += 2;
 	else
-		pointer_++;
+		++pointer_;
 
 	if (IsDBCSLeadByte(*pointer_) == 0 && *pointer_ == '\n')
-		line_++;
+		++line_;
 	return *pointer_;
 }
 void EventScriptScanner::_SkipComment()
 {
 	while (true) {
-		std::vector<char>::iterator posStart = pointer_;
+		auto posStart = pointer_;
 		_SkipSpace();
 
 		char ch = *pointer_;
 
 		if (ch == '/') { //コメントアウト処理
-			std::vector<char>::iterator tPos = pointer_;
+			auto tPos = pointer_;
 			ch = _NextChar();
 			if (ch == '/') { // "//"
 				while (true) {
@@ -127,11 +124,8 @@ void EventScriptScanner::_SkipComment()
 }
 void EventScriptScanner::_SkipSpace()
 {
-	char ch = *pointer_;
-	while (true) {
-		if (ch != ' ' && ch != '\t')
-			break;
-		ch = _NextChar();
+	while (*pointer_ == L' ' || *pointer_ == L'\t') {
+		_NextChar();
 	}
 }
 void EventScriptScanner::_RaiseError(const std::wstring& str)
@@ -140,14 +134,14 @@ void EventScriptScanner::_RaiseError(const std::wstring& str)
 }
 bool EventScriptScanner::_IsTextStartSign()
 {
-	if (bTagScan_)
+	if (bTagScan_ != false)
 		return false;
 
 	bool res = false;
 	char ch = *pointer_;
 
 	if (false && ch == '\\') {
-		std::vector<char>::iterator pos = pointer_;
+		auto pos = pointer_;
 		ch = _NextChar(); //次のタグまで進める
 		bool bDBSSLeadByte = IsDBCSLeadByte(ch) != 0;
 		bool bLess = (!bDBSSLeadByte && ch == CHAR_TAG_START);
@@ -171,7 +165,8 @@ bool EventScriptScanner::_IsTextScan()
 	char ch = _NextChar();
 	if (!HasNext()) {
 		return false;
-	} else if (ch == '/') {
+	}
+	if (ch == '/') {
 		ch = *(pointer_ + 1);
 		if (ch == '/' || ch == '*')
 			res = false;
@@ -207,7 +202,7 @@ EventScriptToken& EventScriptScanner::Next()
 	}
 
 	EventScriptToken::Type type = EventScriptToken::TK_UNKNOWN;
-	std::vector<char>::iterator posStart = pointer_; //先頭を保存
+	auto posStart = pointer_; //先頭を保存
 
 	if (_IsTextStartSign()) {
 		ch = *pointer_;
@@ -357,7 +352,7 @@ EventScriptToken& EventScriptScanner::Next()
 
 				if (ch == 'E' || ch == 'e') {
 					//1E-5みたいなケース
-					std::vector<char>::iterator pos = pointer_;
+					auto pos = pointer_;
 					ch = _NextChar();
 					while (isdigit(ch) || ch == '-')
 						ch = _NextChar(); //数字だけの間ポインタを進める
@@ -394,7 +389,9 @@ EventScriptToken& EventScriptScanner::Next()
 }
 bool EventScriptScanner::HasNext()
 {
-	return pointer_ != buffer_.end() && *pointer_ != '\0' && token_.GetType() != EventScriptToken::TK_EOF;
+	return pointer_ != buffer_.end()
+		&& *pointer_ != '\0'
+		&& token_.GetType() != EventScriptToken::TK_EOF;
 }
 void EventScriptScanner::CheckType(const EventScriptToken& tok, int type)
 {
@@ -417,12 +414,10 @@ int EventScriptScanner::GetCurrentLine() const
 int EventScriptScanner::SearchCurrentLine()
 {
 	int line = 1;
-	char* pbuf = &(*buffer_.begin());
-	char* ebuf = &(*pointer_);
-	while (true) {
-		if (pbuf >= ebuf)
-			break;
-		else if (*pbuf == '\n')
+	const char* pbuf = &(*buffer_.begin());
+	const char* ebuf = &(*pointer_);
+	while (pbuf < ebuf) {
+		if (*pbuf == '\n')
 			line++;
 		if (IsDBCSLeadByte(*pbuf))
 			pbuf += 2;
@@ -441,9 +436,9 @@ void EventScriptScanner::SetCurrentPointer(std::vector<char>::iterator pos)
 }
 int EventScriptScanner::GetCurrentPosition() const
 {
-	if (buffer_.size() == 0)
+	if (buffer_.empty())
 		return 0;
-	char* pos = (char*)&*pointer_;
+	const char* pos = &*pointer_;
 	return pos - &buffer_[0];
 }
 
@@ -478,24 +473,18 @@ double EventScriptToken::GetReal() const
 }
 bool EventScriptToken::GetBoolean() const
 {
-	bool res = false;
 	if (type_ == TK_REAL && type_ == TK_INT) {
-		res = GetReal() == 1;
+		return GetReal() == 1;
 	} else {
-		res = element_ == "true";
+		return element_ == "true";
 	}
-	return res;
 }
 
 /**********************************************************
 //EventScriptCompiler
 **********************************************************/
-EventScriptCompiler::EventScriptCompiler()
-{
-}
-EventScriptCompiler::~EventScriptCompiler()
-{
-}
+EventScriptCompiler::EventScriptCompiler() = default;
+EventScriptCompiler::~EventScriptCompiler() = default;
 void EventScriptCompiler::_ParseBlock(ref_count_ptr<EventScriptCode> blockStartCode)
 {
 	while (scan_->HasNext()) {
@@ -506,7 +495,7 @@ void EventScriptCompiler::_ParseBlock(ref_count_ptr<EventScriptCode> blockStartC
 			element = StringUtility::ReplaceAll(element, "\r", "");
 			element = StringUtility::ReplaceAll(element, "\n", "");
 			element = StringUtility::ReplaceAll(element, "\t", "");
-			if (element.size() == 0 || element == "")
+			if (element.empty())
 				continue;
 			ref_count_ptr<EventScriptCode_Text> code = new EventScriptCode_Text();
 			code->SetLine(scan_->GetCurrentLine());
@@ -515,15 +504,13 @@ void EventScriptCompiler::_ParseBlock(ref_count_ptr<EventScriptCode> blockStartC
 		} else if (typeToken == EventScriptScanner::TOKEN_TAG_START) {
 			scan_->Next();
 			ref_count_ptr<EventScriptCode> res = _ParseTag(blockStartCode);
-			if (res != NULL) {
+			if (res != nullptr) {
 				source_->AddCode(res);
 			}
 		}
 
 		/*
-		for (int iCode = 0; iCode < source_->code_.size(); iCode++)
-		{
-			gstd::ref_count_ptr<EventScriptCode> code = source_->code_[iCode];
+		for (const auto& code : source_->code_) {
 			std::string log = StringUtility::Format("code:type[%d] line[%d]", code->GetType(), code->GetLine());
 			Logger::WriteTop(log);
 		}
@@ -533,15 +520,14 @@ void EventScriptCompiler::_ParseBlock(ref_count_ptr<EventScriptCode> blockStartC
 }
 ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<EventScriptCode> blockStartCode)
 {
-	ref_count_ptr<EventScriptCode> res = NULL;
+	ref_count_ptr<EventScriptCode> res = nullptr;
 	EventScriptToken& tok = scan_->GetToken();
 	std::string element = tok.GetElement();
 	if (element == "event_block_start") {
 		int pos = source_->GetCodeCount();
 		ref_count_ptr<EventScriptBlock_Main> block = new EventScriptBlock_Main();
 		std::map<std::string, EventScriptToken> mapElement = _GetAllTagElement();
-		std::map<std::string, EventScriptToken>::iterator itr;
-		for (itr = mapElement.begin(); itr != mapElement.end(); itr++) {
+		for (auto itr = mapElement.begin(); itr != mapElement.end(); ++itr) {
 			std::string key = itr->first;
 			EventScriptToken value = itr->second;
 			if (key == "name") {
@@ -571,10 +557,9 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 	} else if (element == EventScriptCode::TAG_WAIT_NEXT_PAGE) {
 		res = new EventScriptCode_WaitNextPage();
 	} else if (element == EventScriptCode::TAG_WAIT_TIME) {
-		EventScriptCode_WaitTime* code = new EventScriptCode_WaitTime();
+		auto* code = new EventScriptCode_WaitTime();
 		std::map<std::string, EventScriptToken> mapElement = _GetAllTagElement();
-		std::map<std::string, EventScriptToken>::iterator itr;
-		for (itr = mapElement.begin(); itr != mapElement.end(); itr++) {
+		for (auto itr = mapElement.begin(); itr != mapElement.end(); ++itr) {
 			std::string key = itr->first;
 			EventScriptToken value = itr->second;
 			if (key == "frame") {
@@ -587,8 +572,8 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 	} else if (element == EventScriptCode::TAG_CLEAR_MESSAGE) {
 		res = new EventScriptCode_ClearMessage();
 	} else if (element == EventScriptCode::TAG_NAME) {
-		EventScriptCode_Name* code = new EventScriptCode_Name();
-		std::vector<char>::iterator pos = scan_->GetCurrentPointer();
+		auto* code = new EventScriptCode_Name();
+		auto pos = scan_->GetCurrentPointer();
 		EventScriptToken tok = scan_->Next();
 		int type = tok.GetType();
 		if (type == EventScriptScanner::TOKEN_TAG_END) {
@@ -598,8 +583,7 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 			code->SetName(name);
 		} else {
 			std::map<std::string, EventScriptToken> mapElement = _GetAllTagElement();
-			std::map<std::string, EventScriptToken>::iterator itr;
-			for (itr = mapElement.begin(); itr != mapElement.end(); itr++) {
+			for (auto itr = mapElement.begin(); itr != mapElement.end(); ++itr) {
 				std::string key = itr->first;
 				EventScriptToken value = itr->second;
 				if (key == "name") {
@@ -610,10 +594,9 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 
 		res = code;
 	} else if (element == EventScriptCode::TAG_TRANSITION) {
-		EventScriptCode_Transition* code = new EventScriptCode_Transition();
+		auto* code = new EventScriptCode_Transition();
 		std::map<std::string, EventScriptToken> mapElement = _GetAllTagElement();
-		std::map<std::string, EventScriptToken>::iterator itr;
-		for (itr = mapElement.begin(); itr != mapElement.end(); itr++) {
+		for (auto itr = mapElement.begin(); itr != mapElement.end(); ++itr) {
 			std::string key = itr->first;
 			EventScriptToken value = itr->second;
 			if (key == "type") {
@@ -633,10 +616,9 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 		}
 		res = code;
 	} else if (element == EventScriptCode::TAG_VISIBLE_TEXT) {
-		EventScriptCode_VisibleText* code = new EventScriptCode_VisibleText();
+		auto* code = new EventScriptCode_VisibleText();
 		std::map<std::string, EventScriptToken> mapElement = _GetAllTagElement();
-		std::map<std::string, EventScriptToken>::iterator itr;
-		for (itr = mapElement.begin(); itr != mapElement.end(); itr++) {
+		for (auto itr = mapElement.begin(); itr != mapElement.end(); ++itr) {
 			std::string key = itr->first;
 			EventScriptToken value = itr->second;
 			if (key == "visible") {
@@ -645,7 +627,7 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 		}
 		res = code;
 	} else if (element == EventScriptCode::TAG_VAR) {
-		EventScriptCode_Var* code = new EventScriptCode_Var();
+		auto* code = new EventScriptCode_Var();
 		std::string name = scan_->Next().GetElement();
 		scan_->CheckType(scan_->Next(), EventScriptToken::TK_EQUAL);
 		std::string value = _GetNextTagElement();
@@ -657,7 +639,7 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 		code->SetValue(value);
 		res = code;
 	} else if (element == EventScriptCode::TAG_EVAL) {
-		EventScriptCode_Eval* code = new EventScriptCode_Eval();
+		auto* code = new EventScriptCode_Eval();
 		std::string name = scan_->Next().GetElement();
 		scan_->CheckType(scan_->Next(), EventScriptToken::TK_EQUAL);
 		std::string value = _GetNextTagElement();
@@ -666,7 +648,7 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 		code->SetValue(value);
 		res = code;
 	} else if (element == EventScriptCode::TAG_SYSVAL) {
-		EventScriptCode_SysVal* code = new EventScriptCode_SysVal();
+		auto* code = new EventScriptCode_SysVal();
 		std::string name = scan_->Next().GetElement();
 		scan_->CheckType(scan_->Next(), EventScriptToken::TK_EQUAL);
 		std::string value = _GetNextTagElement();
@@ -675,7 +657,7 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 		code->SetValue(value);
 		res = code;
 	} else if (element == EventScriptCode::TAG_OUTPUT) {
-		EventScriptCode_Output* code = new EventScriptCode_Output();
+		auto* code = new EventScriptCode_Output();
 		scan_->CheckIdentifer(scan_->Next(), "msg");
 		scan_->CheckType(scan_->Next(), EventScriptToken::TK_EQUAL);
 		std::string value = _GetNextTagElement();
@@ -683,10 +665,9 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 		code->SetValue(value);
 		res = code;
 	} else if (element == EventScriptCode::TAG_IMAGE) {
-		EventScriptCode_Image* code = new EventScriptCode_Image();
+		auto* code = new EventScriptCode_Image();
 		std::map<std::string, EventScriptToken> mapElement = _GetAllTagElement();
-		std::map<std::string, EventScriptToken>::iterator itr;
-		for (itr = mapElement.begin(); itr != mapElement.end(); itr++) {
+		for (auto itr = mapElement.begin(); itr != mapElement.end(); ++itr) {
 			std::string key = itr->first;
 			EventScriptToken value = itr->second;
 			if (key == "id")
@@ -723,15 +704,14 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 		}
 		res = code;
 	} else if (element == EventScriptCode::TAG_BGM || element == EventScriptCode::TAG_SE) {
-		EventScriptCode_Sound* code = new EventScriptCode_Sound();
+		auto* code = new EventScriptCode_Sound();
 		if (element == EventScriptCode::TAG_BGM)
 			code->SetSoundType(EventSound::TYPE_BGM);
 		else
 			code->SetSoundType(EventSound::TYPE_SE);
 
 		std::map<std::string, EventScriptToken> mapElement = _GetAllTagElement();
-		std::map<std::string, EventScriptToken>::iterator itr;
-		for (itr = mapElement.begin(); itr != mapElement.end(); itr++) {
+		for (auto itr = mapElement.begin(); itr != mapElement.end(); ++itr) {
 			std::string key = itr->first;
 			EventScriptToken value = itr->second;
 			if (key == "path") {
@@ -748,7 +728,7 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 		int pos = source_->GetCodeCount();
 		code->SetStartPosition(pos + 1);
 		std::string param = _GetNextTagElement();
-		if (param.size() != 0) {
+		if (!param.empty()) {
 			code->SetParameter(param);
 		}
 
@@ -781,12 +761,11 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 		}
 		block_.pop_back();
 	} else if (element == EventScriptCode::TAG_GOSUB || element == EventScriptCode::TAG_GOTO) {
-		EventScriptCode_Jump* code = new EventScriptCode_Jump();
+		auto* code = new EventScriptCode_Jump();
 		code->SetGosub(element == EventScriptCode::TAG_GOSUB);
 
 		std::map<std::string, EventScriptToken> mapElement = _GetAllTagElement();
-		std::map<std::string, EventScriptToken>::iterator itr;
-		for (itr = mapElement.begin(); itr != mapElement.end(); itr++) {
+		for (auto itr = mapElement.begin(); itr != mapElement.end(); ++itr) {
 			std::string key = itr->first;
 			EventScriptToken value = itr->second;
 			if (key == "path") {
@@ -797,10 +776,9 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 		}
 		res = code;
 	} else if (element == EventScriptCode::TAG_SCRIPT) {
-		EventScriptCode_Script* code = new EventScriptCode_Script();
+		auto* code = new EventScriptCode_Script();
 		std::map<std::string, EventScriptToken> mapElement = _GetAllTagElement();
-		std::map<std::string, EventScriptToken>::iterator itr;
-		for (itr = mapElement.begin(); itr != mapElement.end(); itr++) {
+		for (auto itr = mapElement.begin(); itr != mapElement.end(); ++itr) {
 			std::string key = itr->first;
 			EventScriptToken value = itr->second;
 			if (key == "path") {
@@ -835,11 +813,10 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 		}
 		res = code;
 	} else if (element == EventScriptCode::TAG_SCRIPT_END) {
-		EventScriptCode_Script* code = new EventScriptCode_Script();
+		auto* code = new EventScriptCode_Script();
 		code->SetEndScript(true);
 		std::map<std::string, EventScriptToken> mapElement = _GetAllTagElement();
-		std::map<std::string, EventScriptToken>::iterator itr;
-		for (itr = mapElement.begin(); itr != mapElement.end(); itr++) {
+		for (auto itr = mapElement.begin(); itr != mapElement.end(); ++itr) {
 			std::string key = itr->first;
 			EventScriptToken value = itr->second;
 			if (key == "path") {
@@ -852,10 +829,9 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 		}
 		res = code;
 	} else if (element == EventScriptCode::TAG_END) {
-		EventScriptCode_End* code = new EventScriptCode_End();
+		auto* code = new EventScriptCode_End();
 		std::map<std::string, EventScriptToken> mapElement = _GetAllTagElement();
-		std::map<std::string, EventScriptToken>::iterator itr;
-		for (itr = mapElement.begin(); itr != mapElement.end(); itr++) {
+		for (auto itr = mapElement.begin(); itr != mapElement.end(); ++itr) {
 			std::string key = itr->first;
 			EventScriptToken value = itr->second;
 			if (key == "arg") {
@@ -864,10 +840,9 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 		}
 		res = code;
 	} else if (element == EventScriptCode::TAG_BATTLE) {
-		EventScriptCode_Battle* code = new EventScriptCode_Battle();
+		auto* code = new EventScriptCode_Battle();
 		std::map<std::string, EventScriptToken> mapElement = _GetAllTagElement();
-		std::map<std::string, EventScriptToken>::iterator itr;
-		for (itr = mapElement.begin(); itr != mapElement.end(); itr++) {
+		for (auto itr = mapElement.begin(); itr != mapElement.end(); ++itr) {
 			std::string key = itr->first;
 			EventScriptToken value = itr->second;
 			if (key == "path") {
@@ -888,7 +863,7 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 		res = code;
 	}
 
-	if (res != NULL) {
+	if (res != nullptr) {
 		int line = scan_->GetCurrentLine();
 		res->SetLine(line);
 	}
@@ -898,7 +873,7 @@ ref_count_ptr<EventScriptCode> EventScriptCompiler::_ParseTag(ref_count_ptr<Even
 std::map<std::string, EventScriptToken> EventScriptCompiler::_GetAllTagElement()
 {
 	std::map<std::string, EventScriptToken> res;
-	std::vector<char>::iterator pos = scan_->GetCurrentPointer();
+	auto pos = scan_->GetCurrentPointer();
 	while (true) {
 		pos = scan_->GetCurrentPointer();
 		EventScriptToken& tok = scan_->Next();
@@ -926,8 +901,8 @@ std::string EventScriptCompiler::_GetNextTagElement()
 }
 std::string EventScriptCompiler::_GetNextTagElement(int type)
 {
-	std::string res = "";
-	std::vector<char>::iterator pos = scan_->GetCurrentPointer();
+	std::string res;
+	auto pos = scan_->GetCurrentPointer();
 	while (true) {
 		pos = scan_->GetCurrentPointer();
 		EventScriptToken& tok = scan_->Next();
@@ -947,7 +922,7 @@ gstd::ref_count_ptr<EventScriptSource> EventScriptCompiler::Compile()
 {
 	FileManager* fileManager = FileManager::GetBase();
 	ref_count_ptr<FileReader> reader = fileManager->GetFileReader(path_);
-	if (reader == NULL || !reader->Open()) {
+	if (reader == nullptr || !reader->Open()) {
 		Logger::WriteTop(ErrorUtility::GetFileNotFoundErrorMessage(path_));
 		return false;
 	}
@@ -962,10 +937,10 @@ gstd::ref_count_ptr<EventScriptSource> EventScriptCompiler::Compile()
 	source_ = new EventScriptSource();
 
 	try {
-		_ParseBlock(NULL);
+		_ParseBlock(nullptr);
 	} catch (gstd::wexception& e) {
 		int line = scan_->GetCurrentLine();
-		throw gstd::wexception(StringUtility::Format(L"%s line[%d]", e.what(), line).c_str());
+		throw gstd::wexception(StringUtility::Format(L"%s line[%d]", e.what(), line));
 	}
 
 	return source_;
@@ -1010,9 +985,7 @@ EventScriptCode::EventScriptCode()
 	line_ = -1;
 	type_ = TYPE_UNKNOWN;
 }
-EventScriptCode::~EventScriptCode()
-{
-}
+EventScriptCode::~EventScriptCode() = default;
 
 //EventScriptCode_Text
 EventScriptCode_Text::EventScriptCode_Text()
@@ -1166,9 +1139,7 @@ EventScriptCodeExecuter::EventScriptCodeExecuter(EventEngine* engine)
 	engine_ = engine;
 	bEnd_ = false;
 }
-EventScriptCodeExecuter::~EventScriptCodeExecuter()
-{
-}
+EventScriptCodeExecuter::~EventScriptCodeExecuter() = default;
 int EventScriptCodeExecuter::_GetElementInteger(const std::string& value)
 {
 	EventValueParser parser(engine_);
@@ -1193,7 +1164,7 @@ std::string EventScriptCodeExecuter::_GetElementString(const std::string& value)
 	ref_count_ptr<EventValue> res = parser.GetEventValue(value);
 	return res->GetString();
 }
-bool EventScriptCodeExecuter::_IsValieElement(const std::string& value)
+bool EventScriptCodeExecuter::_IsValidElement(const std::string& value)
 {
 	return value != EventScriptCode::STRING_INVALID;
 }
@@ -1239,7 +1210,7 @@ void EventScriptCodeExecuter_WaitTime::Execute()
 		if (bKeySkip)
 			bEnd_ = true;
 	}
-	count_++;
+	++count_;
 }
 
 //EventScriptCodeExecuter_Transition
@@ -1273,19 +1244,19 @@ void EventScriptCodeExecuter_Transition::Execute()
 		image->Render(image->GetForegroundLayerIndex());
 
 		graphics->EndScene();
-		graphics->SetRenderTarget(NULL);
+		graphics->SetRenderTarget(nullptr);
 		image->SwapForeBackLayerIndex();
 
 		int layer = image->GetForegroundLayerIndex();
 		gstd::ref_count_ptr<DxScriptObjectManager> objManager = image->GetObjectManager(layer);
-		DxScriptObjectBase* obj = NULL;
+		DxScriptObjectBase* obj = nullptr;
 		int type = code_->GetTransType();
 		switch (type) {
 		case EventScriptCode_Transition::TRANS_NONE:
 			break;
 		case EventScriptCode_Transition::TRANS_FADE: {
 			int frame = _GetElementInteger(code_->GetFrame());
-			TransitionEffect_FadeOut* effect = new TransitionEffect_FadeOut();
+			auto* effect = new TransitionEffect_FadeOut();
 			effect->Initialize(frame, texture);
 			effect_ = effect;
 			obj = new DxScriptRenderObject_Transition(effect_.GetPointer());
@@ -1295,7 +1266,7 @@ void EventScriptCodeExecuter_Transition::Execute()
 		}
 		case EventScriptCode_Transition::TRANS_SCRIPT: {
 			RECT_D rect = { 0., 0., (double)graphics->GetScreenWidth(), (double)graphics->GetScreenHeight() };
-			DxScriptSpriteObject2D* sprite = new DxScriptSpriteObject2D();
+			auto* sprite = new DxScriptSpriteObject2D();
 			sprite->SetTexture(texture);
 			sprite->SetRenderPriority(1.0);
 			sprite->GetSpritePointer()->SetDestinationRect(rect);
@@ -1318,23 +1289,23 @@ void EventScriptCodeExecuter_Transition::Execute()
 		}
 	}
 
-	if (effect_ == NULL && script_ == NULL) {
+	if (effect_ == nullptr && script_ == nullptr) {
 		bEnd_ = true;
 		return;
 	}
 
-	if (effect_ != NULL)
+	if (effect_ != nullptr)
 		effect_->Work();
-	else if (script_ != NULL)
+	else if (script_ != nullptr)
 		script_->Run("MainLoop");
 
 	gstd::ref_count_ptr<EventKeyState> keyState = engine_->GetEventKeyState();
 	bool bkeyNext = keyState->IsNext();
 	bool bKeySkip = keyState->IsSkip();
 
-	if (effect_ != NULL)
+	if (effect_ != nullptr)
 		bEnd_ = effect_->IsEnd();
-	else if (script_ != NULL)
+	else if (script_ != nullptr)
 		bEnd_ = script_->IsScriptEnd();
 
 	if (bEnd_ || bkeyNext || bKeySkip) {
@@ -1343,7 +1314,7 @@ void EventScriptCodeExecuter_Transition::Execute()
 		gstd::ref_count_ptr<DxScriptObjectManager> objManager = image->GetObjectManager(layer);
 		objManager->DeleteObject(EventImage::ID_TRANSITION);
 	}
-	frame_++;
+	++frame_;
 }
 
 //EventScriptCodeExecuter_Image
@@ -1361,9 +1332,9 @@ EventScriptCodeExecuter_Image::EventScriptCodeExecuter_Image(EventEngine* engine
 }
 EventScriptCodeExecuter_Image::~EventScriptCodeExecuter_Image()
 {
-	objManager_ = NULL;
-	nowSprite_ = NULL;
-	oldSprite_ = NULL;
+	objManager_ = nullptr;
+	nowSprite_ = nullptr;
+	oldSprite_ = nullptr;
 }
 void EventScriptCodeExecuter_Image::_Initialize()
 {
@@ -1379,7 +1350,7 @@ void EventScriptCodeExecuter_Image::_Initialize()
 	std::wstring wPath = StringUtility::ConvertMultiToWide(path);
 	int idObj = _GetElementInteger(code_->GetObjectIdentifier());
 	nowSprite_ = ref_count_ptr<DxScriptSpriteObject2D>::unsync::DownCast(objManager_->GetObject(idObj));
-	if (nowSprite_ == NULL && path.size() > 0) {
+	if (nowSprite_ == nullptr && !path.empty()) {
 		nowSprite_ = new DxScriptSpriteObject2D();
 		nowSprite_->SetRenderPriority(priority_);
 		objManager_->AddObject(idObj, nowSprite_);
@@ -1387,9 +1358,9 @@ void EventScriptCodeExecuter_Image::_Initialize()
 	}
 
 	//パス確認
-	if (nowSprite_ != NULL) {
+	if (nowSprite_ != nullptr) {
 		ref_count_ptr<Texture> texture = nowSprite_->GetObjectPointer()->GetTexture();
-		if (texture == NULL) {
+		if (texture == nullptr) {
 			texture = new Texture();
 			// texture->CreateFromFile(path);
 			texture->CreateFromFileInLoadThread(wPath, true);
@@ -1402,7 +1373,7 @@ void EventScriptCodeExecuter_Image::_Initialize()
 			bTrans_ = true;
 		}
 
-		if (path.size() != 0) {
+		if (!path.empty()) {
 			if (texture->GetName() != wPath) {
 				//画像変更
 				int idObjOld = EventImage::INDEX_OLD_START + idObj;
@@ -1427,21 +1398,21 @@ void EventScriptCodeExecuter_Image::_Initialize()
 			objManager_->AddObject(idObjOld, oldSprite_);
 
 			objManager_->DeleteObject(idObj);
-			nowSprite_ = NULL;
+			nowSprite_ = nullptr;
 			bTrans_ = true;
 		}
 	}
 
-	if (nowSprite_ != NULL) {
-		if (_IsValieElement(code_->GetLeftDestPoint()))
+	if (nowSprite_ != nullptr) {
+		if (_IsValidElement(code_->GetLeftDestPoint()))
 			nowSprite_->SetX(_GetElementInteger(code_->GetLeftDestPoint()));
-		if (_IsValieElement(code_->GetTopDestPoint()))
+		if (_IsValidElement(code_->GetTopDestPoint()))
 			nowSprite_->SetY(_GetElementInteger(code_->GetTopDestPoint()));
-		if (_IsValieElement(code_->GetPriority()))
+		if (_IsValidElement(code_->GetPriority()))
 			nowSprite_->SetRenderPriority(_GetElementReal(code_->GetPriority()));
 	}
 
-	if (_IsValieElement(code_->GetTransition()))
+	if (_IsValidElement(code_->GetTransition()))
 		bTrans_ &= _GetElementBoolean(code_->GetTransition());
 }
 void EventScriptCodeExecuter_Image::Execute()
@@ -1455,10 +1426,10 @@ void EventScriptCodeExecuter_Image::Execute()
 	bool bKeySkip = keyState->IsSkip();
 
 	if (frame_ >= frameTrans || !bTrans_ || bkeyNext || bKeySkip) {
-		if (oldSprite_ != NULL) {
+		if (oldSprite_ != nullptr) {
 			objManager_->DeleteObject(oldSprite_->GetObjectID());
 		}
-		if (nowSprite_ != NULL)
+		if (nowSprite_ != nullptr)
 			nowSprite_->SetAlpha(255);
 		bEnd_ = true;
 		return;
@@ -1466,13 +1437,13 @@ void EventScriptCodeExecuter_Image::Execute()
 
 	double dAlpha = (double)255 / (double)frameTrans;
 
-	if (nowSprite_ != NULL)
+	if (nowSprite_ != nullptr)
 		nowSprite_->SetAlpha(dAlpha * frame_);
-	if (oldSprite_ != NULL) {
+	if (oldSprite_ != nullptr) {
 		oldSprite_->SetAlpha(255 - dAlpha * frame_);
 	}
 
-	frame_++;
+	++frame_;
 }
 
 //EventScriptCodeExecuter_Script
@@ -1551,7 +1522,7 @@ void EventMouseCaptureLayer::AddedManager()
 void EventMouseCaptureLayer::DispatchedEvent(gstd::ref_count_ptr<DxWindowEvent> event)
 {
 	gstd::ref_count_ptr<DxWindow> window = event->GetSourceWindow();
-	if (window != NULL && window->GetID() == GetID()) {
+	if (window != nullptr && window->GetID() == GetID()) {
 		if (event->HasEventType(DxWindowEvent::TYPE_MOUSE_LEFT_CLICK)) {
 			event_ = event;
 		}
@@ -1559,7 +1530,7 @@ void EventMouseCaptureLayer::DispatchedEvent(gstd::ref_count_ptr<DxWindowEvent> 
 }
 void EventMouseCaptureLayer::ClearEvent()
 {
-	event_ = NULL;
+	event_ = nullptr;
 }
 
 //EventWindow
@@ -1639,7 +1610,7 @@ void EventTextWindow::Render()
 		heightTotal += lineText->GetHeight() + dxText_->GetLinePitch();
 		if (heightTotal > maxHeight - 8)
 			break;
-		lineStart--;
+		--lineStart;
 	}
 	textInfo->SetValidStartLine(max(lineStart, 1));
 	textInfo->SetValidEndLine(lineEnd);
@@ -1649,7 +1620,7 @@ bool EventTextWindow::IsWait()
 {
 	EventEngine* engine = _GetManager()->GetEngine();
 	gstd::ref_count_ptr<EventScriptCodeExecuter> executer = engine->GetActiveCodeExecuter();
-	return dynamic_cast<EventScriptCodeExecuter_WaitClick*>(executer.GetPointer()) != NULL;
+	return dynamic_cast<EventScriptCodeExecuter_WaitClick*>(executer.GetPointer()) != nullptr;
 }
 //EventNameWindow
 EventNameWindow::EventNameWindow()
@@ -1670,7 +1641,7 @@ void EventNameWindow::Work()
 {
 	DxWindow::Work();
 	int alpha = GetAlpha();
-	if (text_->GetText().size() == 0) {
+	if (text_->GetText().empty()) {
 		alpha = max(0, alpha - 8);
 	} else
 		alpha = 255;
@@ -1679,7 +1650,7 @@ void EventNameWindow::Work()
 void EventNameWindow::Render()
 {
 	DxWindow::Render();
-	if (text_->GetText().size() > 0)
+	if (!text_->GetText().empty())
 		RenderText();
 }
 void EventNameWindow::RenderText()
@@ -1770,7 +1741,7 @@ void EventLogWindow::Render()
 
 		int height = 0;
 		int countLine = textInfo->GetLineCount();
-		for (int iLine = 0; iLine < countLine; iLine++) {
+		for (int iLine = 0; iLine < countLine; ++iLine) {
 			gstd::ref_count_ptr<DxTextLine> lineText = textInfo->GetTextLine(iLine);
 			height += lineText->GetHeight() + dxText_->GetLinePitch();
 		}
@@ -1785,10 +1756,9 @@ void EventLogWindow::Render()
 
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	graphics->SetViewPort(left, top, rect.right - rect.left, maxHeight);
-	std::list<int>::iterator itrHeight = listHeight.begin();
-	;
-	std::list<gstd::ref_count_ptr<DxTextInfo>>::iterator itrInfo = listInfo.begin();
-	for (; itrInfo != listInfo.end(); itrInfo++, itrHeight++) {
+	auto itrHeight = listHeight.begin();
+	auto itrInfo = listInfo.begin();
+	for (; itrInfo != listInfo.end(); ++itrInfo, ++itrHeight) {
 		gstd::ref_count_ptr<DxTextInfo> textInfo = (*itrInfo);
 		dxText_->SetPosition(left, top);
 		dxText_->SetMaxHeight(maxHeight);
@@ -1811,12 +1781,12 @@ void EventLogWindow::ResetPosition()
 	int countInfo = log->GetInfoCount();
 	posMin_ = 0;
 	int heightTotal = 0;
-	for (int iInfo = 0; iInfo < countInfo; iInfo++) {
+	for (int iInfo = 0; iInfo < countInfo; ++iInfo) {
 		gstd::ref_count_ptr<DxTextInfo> textInfo = log->GetTextInfo(iInfo);
 
 		int height = 0;
 		int countLine = textInfo->GetLineCount();
-		for (int iLine = 0; iLine < countLine; iLine++) {
+		for (int iLine = 0; iLine < countLine; ++iLine) {
 			gstd::ref_count_ptr<DxTextLine> lineText = textInfo->GetTextLine(iLine);
 			height += lineText->GetHeight() + dxText_->GetLinePitch();
 		}
@@ -1837,9 +1807,8 @@ void EventLogWindow::ResetPosition()
 int EventScriptObjectManager::AddObject(gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj)
 {
 	int res = DxScript::ID_INVALID;
-	if (listUnusedIndex_.size() != 0) {
-		std::list<int>::iterator itr = listUnusedIndex_.begin();
-		for (; itr != listUnusedIndex_.end(); itr++) {
+	if (!listUnusedIndex_.empty()) {
+		for (auto itr = listUnusedIndex_.begin(); itr != listUnusedIndex_.end(); ++itr) {
 			int index = (*itr);
 			if (index >= INDEX_FREE_START) {
 				res = index;
@@ -1867,8 +1836,8 @@ void EventScriptObjectManager::Read(gstd::RecordBuffer& record)
 	record.GetRecord("ids", &listValidId[0], listValidId.size() * sizeof(int));
 
 	//オブジェクト
-	for (int iObj = 0; iObj < listValidId.size(); iObj++) {
-		DxScriptSpriteObject2D* obj = new DxScriptSpriteObject2D();
+	for (int iObj = 0; iObj < listValidId.size(); ++iObj) {
+		auto* obj = new DxScriptSpriteObject2D();
 		Sprite2D* sprite = obj->GetSpritePointer();
 
 		RecordBuffer recObj;
@@ -1902,14 +1871,11 @@ void EventScriptObjectManager::Write(gstd::RecordBuffer& record)
 {
 	int iObj = 0;
 	std::vector<int> listValidId;
-	for (iObj = 0; iObj < EventImage::INDEX_OLD_START; iObj++) {
-		gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj = obj_[iObj];
-		if (obj == NULL)
-			continue;
-
-		listValidId.push_back(iObj);
+	for (iObj = 0; iObj < EventImage::INDEX_OLD_START; ++iObj) {
+		if (obj_[iObj] != nullptr)
+			listValidId.push_back(iObj);
 	}
-	if (listValidId.size() == 0)
+	if (listValidId.empty())
 		return;
 
 	//有効なID数
@@ -1917,7 +1883,7 @@ void EventScriptObjectManager::Write(gstd::RecordBuffer& record)
 	record.SetRecord("ids", &listValidId[0], listValidId.size() * sizeof(int));
 
 	//オブジェクト
-	for (iObj = 0; iObj < listValidId.size(); iObj++) {
+	for (iObj = 0; iObj < listValidId.size(); ++iObj) {
 		int index = listValidId[iObj];
 		gstd::ref_count_ptr<DxScriptSpriteObject2D>::unsync obj = gstd::ref_count_ptr<DxScriptSpriteObject2D>::unsync::DownCast(obj_[index]);
 		Sprite2D* sprite = obj->GetSpritePointer();
@@ -1946,12 +1912,11 @@ void EventScriptObjectManager::Write(gstd::RecordBuffer& record)
 //EventText
 bool EventText::IsVoiceText()
 {
-	bool res = false;
 	if (text_.size() >= 2) {
 		std::wstring str = text_.substr(0, 2);
-		res = str.find(L"「") != std::wstring::npos;
+		return str.find(L"「") != std::wstring::npos;
 	}
-	return res;
+	return false;
 }
 
 //EventLogText
@@ -1960,9 +1925,7 @@ EventLogText::EventLogText(EventEngine* engine)
 	max_ = 100;
 	engine_ = engine;
 }
-EventLogText::~EventLogText()
-{
-}
+EventLogText::~EventLogText() = default;
 void EventLogText::Add(std::string text)
 {
 	text += EventScriptScanner::TAG_START + EventScriptScanner::TAG_NEW_LINE + EventScriptScanner::TAG_END + "--------------------------------";
@@ -2059,9 +2022,7 @@ EventFrame::EventFrame()
 	bEnd_ = false;
 	bAutoGlobal_ = false;
 }
-EventFrame::~EventFrame()
-{
-}
+EventFrame::~EventFrame() = default;
 void EventFrame::SetBlock(gstd::ref_count_ptr<EventScriptBlock> block)
 {
 	block_ = block;
@@ -2072,7 +2033,7 @@ void EventFrame::SetBlock(gstd::ref_count_ptr<EventScriptBlock> block)
 }
 gstd::ref_count_ptr<EventScriptCode> EventFrame::NextCode()
 {
-	posCode_++;
+	++posCode_;
 	return GetCurrentCode();
 }
 gstd::ref_count_ptr<EventScriptCode> EventFrame::GetCurrentCode()
@@ -2081,20 +2042,19 @@ gstd::ref_count_ptr<EventScriptCode> EventFrame::GetCurrentCode()
 }
 bool EventFrame::HasNextCode()
 {
-	bool res = false;
-	if (block_ != NULL) {
-		res = posCode_ < block_->GetEndPosition();
+	if (block_ != nullptr) {
+		return posCode_ < block_->GetEndPosition();
 	} else {
 		int count = sourceActive_->GetCodeCount();
-		res = posCode_ < count - 1;
+		return posCode_ < count - 1;
 	}
-	return res;
 }
 gstd::ref_count_ptr<EventValue> EventFrame::GetValue(const std::string& key)
 {
-	if (mapValue_.find(key) == mapValue_.end())
-		return NULL;
-	return mapValue_[key];
+	auto valueItr = mapValue_.find(key);
+	if (valueItr != mapValue_.end())
+		return valueItr->second;
+	return nullptr;
 }
 void EventFrame::AddValue(const std::string& key, gstd::ref_count_ptr<EventValue> val)
 {
@@ -2108,11 +2068,10 @@ void EventFrame::SetValue(const std::string& key, gstd::ref_count_ptr<EventValue
 }
 bool EventFrame::IsInnerBlock()
 {
-	bool res = false;
-	if (block_ != NULL) {
-		res = block_->IsInner();
+	if (block_ != nullptr) {
+		return block_->IsInner();
 	}
-	return res;
+	return false;
 }
 void EventFrame::ReadRecord(gstd::RecordBuffer& record, EventEngine* engine)
 {
@@ -2138,14 +2097,14 @@ void EventFrame::ReadRecord(gstd::RecordBuffer& record, EventEngine* engine)
 
 	//変数
 	int countValue = record.GetRecordAsInteger("countValue");
-	for (int iValue = 0; iValue < countValue; iValue++) {
+	for (int iValue = 0; iValue < countValue; ++iValue) {
 		std::string keyName = StringUtility::Format("valueName%d", iValue);
 		std::string keyValue = StringUtility::Format("value%d", iValue);
 
 		std::string name = record.GetRecordAsStringA(keyName);
 		RecordBuffer rcValue;
 		record.GetRecordAsRecordBuffer(keyValue, rcValue);
-		EventValue* value = new EventValue();
+		auto* value = new EventValue();
 		value->Read(rcValue);
 		mapValue_[name] = value;
 	}
@@ -2163,11 +2122,11 @@ void EventFrame::WriteRecord(gstd::RecordBuffer& record, EventEngine* engine)
 	record.SetRecordAsStringW("pathSource", wPathSource);
 
 	//ブロックの位置を記録
-	if (gstd::ref_count_ptr<EventScriptCode_If>::DownCast(block_) != NULL) {
+	if (gstd::ref_count_ptr<EventScriptCode_If>::DownCast(block_) != nullptr) {
 		//ifの場合はコードの位置
 		int index = -1;
 		int codeCount = sourceActive_->GetCodeCount();
-		for (int iCode = 0; iCode < codeCount; iCode++) {
+		for (int iCode = 0; iCode < codeCount; ++iCode) {
 			void* pCode = sourceActive_->GetCode(iCode).GetPointer();
 			void* pBlock = block_.GetPointer();
 			if (pCode == pBlock) {
@@ -2180,7 +2139,7 @@ void EventFrame::WriteRecord(gstd::RecordBuffer& record, EventEngine* engine)
 			throw gstd::wexception(L"ifブロックが不正で保存できません");
 
 		record.SetRecordAsInteger("BlockIndex", index);
-	} else if (gstd::ref_count_ptr<EventScriptBlock_Main>::DownCast(block_) != NULL) {
+	} else if (gstd::ref_count_ptr<EventScriptBlock_Main>::DownCast(block_) != nullptr) {
 		//その他はブロック名称
 		gstd::ref_count_ptr<EventScriptBlock_Main> mainBlock = gstd::ref_count_ptr<EventScriptBlock_Main>::DownCast(block_);
 		std::string name = mainBlock->GetName();
@@ -2192,17 +2151,16 @@ void EventFrame::WriteRecord(gstd::RecordBuffer& record, EventEngine* engine)
 	int iCountValue = 0;
 	int countValue = mapValue_.size();
 	record.SetRecordAsInteger("countValue", countValue);
-	std::map<std::string, gstd::ref_count_ptr<EventValue>>::iterator itrValue;
-	for (itrValue = mapValue_.begin(); itrValue != mapValue_.end(); itrValue++) {
-		std::string name = (*itrValue).first;
-		gstd::ref_count_ptr<EventValue> value = (*itrValue).second;
+	for (auto& itrValue : mapValue_) {
+		std::string name = itrValue.first;
+		gstd::ref_count_ptr<EventValue> value = itrValue.second;
 		record.SetRecordAsStringA(StringUtility::Format("valueName%d", iCountValue), name);
 
 		RecordBuffer rcValue;
 		value->Write(rcValue);
 		record.SetRecordAsRecordBuffer(StringUtility::Format("value%d", iCountValue), rcValue);
 
-		iCountValue++;
+		++iCountValue;
 	}
 }
 
@@ -2211,7 +2169,7 @@ EventValueParser::EventValueParser(EventEngine* engine)
 {
 	engine_ = engine;
 }
-gstd::TextParser::Result EventValueParser::_ParseIdentifer(std::vector<char>::iterator)
+gstd::TextParser::Result EventValueParser::_ParseIdentifer(std::vector<char>::iterator /*unused*/)
 {
 	Result res;
 	Token& tok = scan_->GetToken();
@@ -2240,7 +2198,7 @@ gstd::TextParser::Result EventValueParser::_ParseIdentifer(std::vector<char>::it
 	} else {
 		std::string sId = StringUtility::ConvertWideToMulti(id);
 		ref_count_ptr<EventValue> val = engine_->GetEventValue(sId);
-		if (val != NULL) {
+		if (val != nullptr) {
 			res = val->ConvertToTextParserResult();
 		}
 	}
@@ -2249,12 +2207,12 @@ gstd::TextParser::Result EventValueParser::_ParseIdentifer(std::vector<char>::it
 std::vector<std::string> EventValueParser::_GetFuctionArgument()
 {
 	std::vector<std::string> res;
-	std::string arg = "";
+	std::string arg;
 	scan_->CheckType(scan_->Next(), Token::TK_OPENP);
 	while (true) {
 		Token& tok = scan_->Next();
 		if (tok.GetType() == Token::TK_CLOSEP) {
-			if (arg.size() != 0)
+			if (!arg.empty())
 				res.push_back(arg);
 			break;
 		}
@@ -2273,7 +2231,7 @@ gstd::ref_count_ptr<EventValue> EventValueParser::GetEventValue(const std::strin
 {
 	SetSource(text);
 	gstd::ref_count_ptr<EventValue> res = new EventValue();
-	if (text.size() == 0)
+	if (text.empty())
 		return res;
 
 	TextParser::Result value = GetResult();
@@ -2285,16 +2243,14 @@ gstd::ref_count_ptr<EventValue> EventValueParser::GetEventValue(const std::strin
 EventImage::EventImage()
 {
 	objManager_.resize(2);
-	for (int iManager = 0; iManager < objManager_.size(); iManager++) {
-		EventScriptObjectManager* manager = new EventScriptObjectManager();
+	for (auto& iManager : objManager_) {
+		auto* manager = new EventScriptObjectManager();
 		manager->SetMaxObject(MAX_OBJECT);
-		objManager_[iManager] = manager;
+		iManager = manager;
 	}
 	indexForeground_ = 0;
 }
-EventImage::~EventImage()
-{
-}
+EventImage::~EventImage() = default;
 void EventImage::Render(int layer)
 {
 	objManager_[layer]->RenderObject();
@@ -2317,7 +2273,7 @@ void EventImage::Read(gstd::RecordBuffer& record)
 	indexForeground_ = record.GetRecordAsInteger("fore");
 
 	//オブジェクト管理
-	for (int iManager = 0; iManager < objManager_.size(); iManager++) {
+	for (int iManager = 0; iManager < objManager_.size(); ++iManager) {
 		RecordBuffer recManager;
 		record.GetRecordAsRecordBuffer(StringUtility::Format("manager%d", iManager), recManager);
 		objManager_[iManager]->Read(recManager);
@@ -2329,7 +2285,7 @@ void EventImage::Write(gstd::RecordBuffer& record)
 	record.SetRecordAsInteger("fore", indexForeground_);
 
 	//オブジェクト管理
-	for (int iManager = 0; iManager < objManager_.size(); iManager++) {
+	for (int iManager = 0; iManager < objManager_.size(); ++iManager) {
 		RecordBuffer recManager;
 		objManager_[iManager]->Write(recManager);
 
@@ -2343,9 +2299,7 @@ EventKeyState::EventKeyState(EventEngine* engine)
 	engine_ = engine;
 	bNextEnable_ = true;
 }
-EventKeyState::~EventKeyState()
-{
-}
+EventKeyState::~EventKeyState() = default;
 void EventKeyState::Work()
 {
 	bNextEnable_ = true;
@@ -2360,51 +2314,44 @@ bool EventKeyState::IsNext() const
 	auto mngWindow = engine_->GetWindowManager();
 	auto wndEvent = mngWindow->GetMouseCaptureLayer()->GetEvent();
 
-	bool res = false;
-	res |= (wndEvent != NULL && wndEvent->HasEventType(DxWindowEvent::TYPE_MOUSE_LEFT_CLICK));
-	res |= (input->GetKeyState(DIK_Z) == KEY_PUSH);
-	res |= (input->GetKeyState(DIK_RETURN) == KEY_PUSH);
-	res |= (input->GetMouseMoveZ() < 0);
-
-	return res;
+	return (wndEvent != nullptr && wndEvent->HasEventType(DxWindowEvent::TYPE_MOUSE_LEFT_CLICK))
+		|| (input->GetKeyState(DIK_Z) == KEY_PUSH)
+		|| (input->GetKeyState(DIK_RETURN) == KEY_PUSH)
+		|| (input->GetMouseMoveZ() < 0);
 }
 bool EventKeyState::IsSkip() const
 {
 	const DirectInput* input = DirectInput::GetBase();
-	bool res = false;
-	res |= (input->GetKeyState(DIK_LCONTROL) == KEY_HOLD);
-	return res;
+	return (input->GetKeyState(DIK_LCONTROL) == KEY_HOLD);
 }
 
 //EventSound
-EventSound::EventSound()
-{
-}
+EventSound::EventSound() = default;
 EventSound::~EventSound()
 {
-	if (playerBgm_ != NULL)
+	if (playerBgm_ != nullptr)
 		playerBgm_->Delete();
-	if (playerSe_ != NULL)
+	if (playerSe_ != nullptr)
 		playerSe_->Delete();
 }
 void EventSound::Play(int type, const std::string& path)
 {
 	DirectSoundManager* manager = DirectSoundManager::GetBase();
 	gstd::ref_count_ptr<SoundPlayer> player = type == TYPE_BGM ? playerBgm_ : playerSe_;
-	if (player != NULL) {
+	if (player != nullptr) {
 		if (type == TYPE_BGM) {
 			player->SetFadeDelete(-10);
-			playerBgm_ = NULL;
+			playerBgm_ = nullptr;
 		} else {
 			player->Stop();
 			player->Delete();
-			playerSe_ = NULL;
+			playerSe_ = nullptr;
 		}
 	}
 
 	std::wstring wPath = StringUtility::ConvertMultiToWide(path);
 	player = manager->GetPlayer(wPath);
-	if (player != NULL) {
+	if (player != nullptr) {
 		bool bLoop = type == TYPE_BGM;
 		SoundPlayer::PlayStyle style;
 		style.SetLoopEnable(bLoop);
@@ -2417,15 +2364,15 @@ void EventSound::Play(int type, const std::string& path)
 }
 void EventSound::Delete(int type)
 {
-	gstd::ref_count_ptr<SoundPlayer> player = type == TYPE_BGM ? playerBgm_ : playerSe_;
-	if (player != NULL) {
+	gstd::ref_count_ptr<SoundPlayer> player = (type == TYPE_BGM ? playerBgm_ : playerSe_);
+	if (player != nullptr) {
 		if (type == TYPE_BGM) {
 			player->SetFadeDelete(-20);
-			playerBgm_ = NULL;
+			playerBgm_ = nullptr;
 		} else {
 			player->Stop();
 			player->Delete();
-			playerSe_ = NULL;
+			playerSe_ = nullptr;
 		}
 	}
 }
@@ -2433,14 +2380,14 @@ void EventSound::Read(gstd::RecordBuffer& record)
 {
 	if (!record.IsExists("path"))
 		return;
-	std::string path = record.GetRecordAsStringA("path");
 	std::string dirModule = StringUtility::ConvertWideToMulti(PathProperty::GetModuleDirectory());
+	std::string path = record.GetRecordAsStringA("path");
 	path = dirModule + path;
 	Play(TYPE_BGM, path);
 }
 void EventSound::Write(gstd::RecordBuffer& record)
 {
-	if (playerBgm_ == NULL)
+	if (playerBgm_ == nullptr)
 		return;
 	std::wstring path = playerBgm_->GetPath();
 	path = PathProperty::GetPathWithoutModuleDirectory(path);
@@ -2459,11 +2406,11 @@ EventEngine::~EventEngine()
 	FileManager::GetBase()->WaitForThreadLoadComplete();
 
 	listScript_.clear();
-	windowManager_ = NULL;
-	textEvent_ = NULL;
-	image_ = NULL;
-	keyState_ = NULL;
-	frameGlobal_ = NULL;
+	windowManager_ = nullptr;
+	textEvent_ = nullptr;
+	image_ = nullptr;
+	keyState_ = nullptr;
+	frameGlobal_ = nullptr;
 }
 bool EventEngine::Initialize()
 {
@@ -2482,18 +2429,18 @@ bool EventEngine::Initialize()
 void EventEngine::_RaiseError(std::wstring msg)
 {
 	ref_count_ptr<EventFrame> frame = *frame_.rbegin();
-	if (frame != NULL) {
+	if (frame != nullptr) {
 		gstd::ref_count_ptr<EventScriptCode> code = frame->GetCurrentCode();
 		std::wstring path = GetSourcePath(frame->GetActiveSource());
-		if (code != NULL) {
+		if (code != nullptr) {
 			msg += StringUtility::Format(L"line[%d] path[%s]", code->GetLine(), path.c_str());
 		}
 	}
-	throw gstd::wexception(msg.c_str());
+	throw gstd::wexception(msg);
 }
 void EventEngine::_RunCode()
 {
-	if (frame_.size() == 0)
+	if (frame_.empty())
 		return;
 
 	bCriticalFrame_ = false;
@@ -2501,20 +2448,19 @@ void EventEngine::_RunCode()
 	keyState_->Work();
 
 	while (true) {
-		if (activeCodeExecuter_ != NULL) {
+		if (activeCodeExecuter_ != nullptr) {
 			activeCodeExecuter_->Execute();
-			std::list<gstd::ref_count_ptr<EventScriptCodeExecuter>>::iterator itr;
-			for (itr = parallelCodeExecuter_.begin(); itr != parallelCodeExecuter_.end();) {
+			for (auto itr = parallelCodeExecuter_.begin(); itr != parallelCodeExecuter_.end();) {
 				(*itr)->Execute();
 				if ((*itr)->IsEnd()) {
 					itr = parallelCodeExecuter_.erase(itr);
 				} else
-					itr++;
+					++itr;
 			}
 
-			bool bEndCode = activeCodeExecuter_->IsEnd() && parallelCodeExecuter_.size() == 0;
+			bool bEndCode = activeCodeExecuter_->IsEnd() && parallelCodeExecuter_.empty();
 			if (bEndCode) {
-				activeCodeExecuter_ = NULL;
+				activeCodeExecuter_ = nullptr;
 			} else {
 				break;
 			}
@@ -2524,7 +2470,7 @@ void EventEngine::_RunCode()
 			bool bSkip = keyState_->IsSkip();
 			if (!bNext && !bSkip) {
 				textEvent_->Next();
-			} else if (bNext || bSkip) {
+			} else {
 				textEvent_->NextSkip();
 			}
 			break;
@@ -2538,9 +2484,10 @@ void EventEngine::_RunCode()
 				//フレーム終了
 				int next = frameActive->GetReturnPosition();
 				frame_.pop_back();
-				if (frame_.size() == 0)
+				if (frame_.empty())
 					return;
-				//if(frameActive->GetBlock()->IsGlobal())return;
+				// if(frameActive->GetBlock()->IsGlobal())
+				// 	return;
 				if (frameActive->IsAutoGlobal())
 					return; //自動グローバル処理の場合は抜ける
 				frameActive = *frame_.rbegin();
@@ -2557,7 +2504,7 @@ void EventEngine::_RunCode()
 			gstd::ref_count_ptr<EventScriptCode> code = frameActive->GetCurrentCode();
 			int typeCode = code->GetType();
 			if (typeCode == EventScriptCode::TYPE_TEXT) {
-				EventScriptCode_Text* codeText = (EventScriptCode_Text*)code.GetPointer();
+				auto* codeText = (EventScriptCode_Text*)code.GetPointer();
 
 				std::wstring wText = StringUtility::ConvertMultiToWide(codeText->GetText());
 				textEvent_->SetSource(wText);
@@ -2566,32 +2513,32 @@ void EventEngine::_RunCode()
 			} else if (typeCode == EventScriptCode::TYPE_WAIT_NEXT_PAGE) {
 				activeCodeExecuter_ = new EventScriptCodeExecuter_WaitNextPage(this);
 			} else if (typeCode == EventScriptCode::TYPE_WAIT_TIME) {
-				EventScriptCode_WaitTime* codeWaitTime = (EventScriptCode_WaitTime*)code.GetPointer();
+				auto* codeWaitTime = (EventScriptCode_WaitTime*)code.GetPointer();
 				activeCodeExecuter_ = new EventScriptCodeExecuter_WaitTime(this, codeWaitTime);
 			} else if (typeCode == EventScriptCode::TYPE_CLEAR_MESSAGE) {
 				std::string text = StringUtility::ConvertWideToMulti(textEvent_->GetText());
 				logEvent_->Add(text);
 				textEvent_->Clear();
 			} else if (typeCode == EventScriptCode::TYPE_NAME) {
-				EventScriptCode_Name* codeName = (EventScriptCode_Name*)code.GetPointer();
+				auto* codeName = (EventScriptCode_Name*)code.GetPointer();
 				EventValueParser parser(this);
 				ref_count_ptr<EventValue> val = parser.GetEventValue(codeName->GetName());
 				std::string name = val->GetString();
 				std::wstring wName = StringUtility::ConvertMultiToWide(name);
 
 				gstd::ref_count_ptr<EventNameWindow> wndName = windowManager_->GetNameWindow();
-				if (wndName != NULL)
+				if (wndName != nullptr)
 					wndName->SetText(wName);
 			} else if (typeCode == EventScriptCode::TYPE_TRANSITION) {
-				EventScriptCode_Transition* codeTrans = (EventScriptCode_Transition*)code.GetPointer();
-				EventScriptCodeExecuter_Transition* executer = new EventScriptCodeExecuter_Transition(this, codeTrans);
+				auto* codeTrans = (EventScriptCode_Transition*)code.GetPointer();
+				auto* executer = new EventScriptCodeExecuter_Transition(this, codeTrans);
 				activeCodeExecuter_ = executer;
 			} else if (typeCode == EventScriptCode::TYPE_VISIBLE_TEXT) {
-				EventScriptCode_VisibleText* codeVisibleText = (EventScriptCode_VisibleText*)code.GetPointer();
+				auto* codeVisibleText = (EventScriptCode_VisibleText*)code.GetPointer();
 				bool bVisible = codeVisibleText->IsVisible();
 				windowManager_->SetTextVisible(bVisible);
 			} else if (typeCode == EventScriptCode::TYPE_VAR) {
-				EventScriptCode_Var* codeVar = (EventScriptCode_Var*)code.GetPointer();
+				auto* codeVar = (EventScriptCode_Var*)code.GetPointer();
 				std::string& name = codeVar->GetName();
 				EventValueParser parser(this);
 				ref_count_ptr<EventValue> val = parser.GetEventValue(codeVar->GetValue());
@@ -2601,7 +2548,7 @@ void EventEngine::_RunCode()
 					frameActive->AddValue(name, val);
 				}
 			} else if (typeCode == EventScriptCode::TYPE_EVAL) {
-				EventScriptCode_Eval* codeEval = (EventScriptCode_Eval*)code.GetPointer();
+				auto* codeEval = (EventScriptCode_Eval*)code.GetPointer();
 				std::string& name = codeEval->GetName();
 				EventValueParser parser(this);
 				ref_count_ptr<EventValue> val = parser.GetEventValue(codeEval->GetValue());
@@ -2613,7 +2560,7 @@ void EventEngine::_RunCode()
 					frameActive->SetValue(name, dest);
 				}
 			} else if (typeCode == EventScriptCode::TYPE_SYSVAL) {
-				EventScriptCode_SysVal* codeSysVal = (EventScriptCode_SysVal*)code.GetPointer();
+				auto* codeSysVal = (EventScriptCode_SysVal*)code.GetPointer();
 				std::string& name = codeSysVal->GetName();
 				bool bGlobal = codeSysVal->IsGlobal();
 				EventValueParser parser(this);
@@ -2637,15 +2584,15 @@ void EventEngine::_RunCode()
 				}
 
 			} else if (typeCode == EventScriptCode::TYPE_OUTPUT) {
-				EventScriptCode_Output* codeOut = (EventScriptCode_Output*)code.GetPointer();
+				auto* codeOut = (EventScriptCode_Output*)code.GetPointer();
 				EventValueParser parser(this);
 				ref_count_ptr<EventValue> val = parser.GetEventValue(codeOut->GetValue());
 
 				std::wstring wText = StringUtility::ConvertMultiToWide(val->GetString());
 				textEvent_->SetSource(wText);
 			} else if (typeCode == EventScriptCode::TYPE_IMAGE) {
-				EventScriptCode_Image* codeImage = (EventScriptCode_Image*)code.GetPointer();
-				EventScriptCodeExecuter_Image* executer = new EventScriptCodeExecuter_Image(this, codeImage);
+				auto* codeImage = (EventScriptCode_Image*)code.GetPointer();
+				auto* executer = new EventScriptCodeExecuter_Image(this, codeImage);
 
 				EventValueParser parser(this);
 				ref_count_ptr<EventValue> val = parser.GetEventValue(codeImage->GetWaitEnd());
@@ -2653,13 +2600,13 @@ void EventEngine::_RunCode()
 				if (bWaitEnd)
 					activeCodeExecuter_ = executer;
 				else
-					parallelCodeExecuter_.push_back(executer);
+					parallelCodeExecuter_.emplace_back(executer);
 			} else if (typeCode == EventScriptCode::TYPE_SOUND) {
-				EventScriptCode_Sound* codeSound = (EventScriptCode_Sound*)code.GetPointer();
+				auto* codeSound = (EventScriptCode_Sound*)code.GetPointer();
 				EventValueParser parser(this);
 				ref_count_ptr<EventValue> val = parser.GetEventValue(codeSound->GetPath());
 				std::string path = val->GetString();
-				if (path.size() > 0) {
+				if (!path.empty()) {
 					sound_->Play(codeSound->GetSoundType(), path);
 				} else {
 					sound_->Delete(codeSound->GetSoundType());
@@ -2700,7 +2647,7 @@ void EventEngine::_RunCode()
 
 				ref_count_ptr<EventScriptBlock> block;
 				ref_count_ptr<EventFrame> frameJump = new EventFrame();
-				if (path.size() == 0) {
+				if (path.empty()) {
 					//自スクリプト
 					block = frameActive->GetActiveSource()->GetEventBlock(name);
 					frameJump->SetActiveSource(frameActive->GetActiveSource());
@@ -2712,7 +2659,7 @@ void EventEngine::_RunCode()
 					block = source->GetEventBlock(name);
 				}
 
-				if (block != NULL) {
+				if (block != nullptr) {
 					if (codeJump->IsGoSub()) {
 						int current = frameActive->GetCurrentPosition() + 1;
 						frameJump->SetBlock(block);
@@ -2742,16 +2689,16 @@ void EventEngine::_RunCode()
 				int target = parser.GetEventValue(codeScript->GetTargetId())->GetReal();
 				std::vector<std::string> listArg = codeScript->GetArgumentList();
 
-				if (method.size() == 0)
+				if (method.empty())
 					_RaiseError(L"methodのないスクリプトを実行しようとしました");
 
 				std::wstring wPath = StringUtility::ConvertMultiToWide(path);
-				DxScriptForEvent* script = new DxScriptForEvent(this);
+				auto* script = new DxScriptForEvent(this);
 				script->SetTargetId(target);
 				script->SetMethod(method);
-				if (path.size() > 0)
+				if (!path.empty())
 					script->SetSourceFromFile(wPath);
-				else if (code.size() > 0) {
+				else if (!code.empty()) {
 					script->SetSource(code);
 
 					std::wstring path = GetSourcePath(frameActive->GetActiveSource());
@@ -2760,7 +2707,7 @@ void EventEngine::_RunCode()
 
 				script->SetScriptId(scriptId);
 				script->Compile();
-				if (listArg.size() > 0) {
+				if (!listArg.empty()) {
 					int countArg = listArg.size();
 					for (int iArg = 0; iArg < countArg; iArg++) {
 						ref_count_ptr<EventValue> eArg = parser.GetEventValue(listArg[iArg]);
@@ -2779,10 +2726,10 @@ void EventEngine::_RunCode()
 					}
 				} else {
 					if (bWait) {
-						EventScriptCodeExecuter_Script* executer = new EventScriptCodeExecuter_Script(this, script);
+						auto* executer = new EventScriptCodeExecuter_Script(this, script);
 						activeCodeExecuter_ = executer;
 					}
-					listScript_.push_back(script);
+					listScript_.emplace_back(script);
 				}
 			} else {
 				//不明なタグや、テキストレンダラにそのままわたすタグ
@@ -2807,16 +2754,14 @@ void EventEngine::_RunCode()
 }
 void EventEngine::_RunScript()
 {
-	//スクリプト実行
-	std::list<gstd::ref_count_ptr<DxScriptForEvent>>::iterator itrScript;
-	for (itrScript = listScript_.begin(); itrScript != listScript_.end();) {
+	for (auto itrScript = listScript_.begin(); itrScript != listScript_.end();) {
 		gstd::ref_count_ptr<DxScriptForEvent>& script = (*itrScript);
 		if (script->IsScriptEnd()) {
 			script->Clear();
 			itrScript = listScript_.erase(itrScript);
 		} else {
 			script->Run("MainLoop");
-			itrScript++;
+			++itrScript;
 		}
 	}
 }
@@ -2826,15 +2771,16 @@ void EventEngine::_WorkWindow()
 }
 gstd::ref_count_ptr<EventScriptSource> EventEngine::_GetSource(const std::wstring& path)
 {
-	gstd::ref_count_ptr<EventScriptSource> res = NULL;
-	if (mapSource_.find(path) != mapSource_.end()) {
-		res = mapSource_[path];
+	gstd::ref_count_ptr<EventScriptSource> res = nullptr;
+	auto sourceItr = mapSource_.find(path);
+	if (sourceItr != mapSource_.end()) {
+		res = sourceItr->second;
 	} else {
 		EventScriptCompiler compiler;
 		compiler.SetPath(path);
 		res = compiler.Compile();
 
-		if (res == NULL) {
+		if (res == nullptr) {
 			throw gstd::wexception(L"コンパイル失敗");
 		}
 
@@ -2901,48 +2847,46 @@ void EventEngine::SetSource(const std::wstring& path)
 }
 gstd::ref_count_ptr<EventScriptSource> EventEngine::GetSource(const std::wstring& path)
 {
-	if (mapSource_.find(path) == mapSource_.end())
-		return NULL;
-	return mapSource_[path];
+	auto sourceItr = mapSource_.find(path);
+	if (sourceItr != mapSource_.end())
+		return sourceItr->second;
+	return nullptr;
 }
 std::wstring EventEngine::GetSourcePath(gstd::ref_count_ptr<EventScriptSource> source)
 {
-	std::wstring res = L"";
-	std::map<std::wstring, gstd::ref_count_ptr<EventScriptSource>>::iterator itrSource;
-	for (itrSource = mapSource_.begin(); itrSource != mapSource_.end(); itrSource++) {
-		gstd::ref_count_ptr<EventScriptSource> tSource = (*itrSource).second;
+	for (auto itrSource = mapSource_.begin(); itrSource != mapSource_.end(); ++itrSource) {
+		auto tSource = (*itrSource).second;
 		if (source == tSource) {
-			res = (*itrSource).first;
-			break;
+			return (*itrSource).first;
 		}
 	}
-	return res;
+	return std::wstring();
 }
 bool EventEngine::IsEnd()
 {
-	return frame_.size() == 0;
+	return frame_.empty();
 }
 gstd::ref_count_ptr<EventValue> EventEngine::GetEventValue(std::string key)
 {
-	gstd::ref_count_ptr<EventValue> res = NULL;
+	gstd::ref_count_ptr<EventValue> res = nullptr;
 	bool bInner = true;
 	int count = frame_.size();
-	for (int iFrame = count - 1; iFrame >= 0 && res == NULL && bInner; iFrame--) {
-		ref_count_ptr<EventFrame> frame = frame_[iFrame];
+	do {
+		ref_count_ptr<EventFrame> frame = frame_[--count];
 		res = frame->GetValue(key);
 		bInner = frame->IsInnerBlock();
-	}
+	} while (count > 0 && res == nullptr && bInner);
 
-	if (res == NULL) {
+	if (res == nullptr) {
 		res = frameGlobal_->GetValue(key);
 	}
 
-	if (res == NULL) {
+	if (res == nullptr) {
 		SystemValueManager* svm = SystemValueManager::GetBase();
 		ref_count_ptr<RecordBuffer> record = svm->GetRecordBuffer(SystemValueManager::RECORD_SYSTEM);
-		if (record == NULL)
+		if (record == nullptr)
 			record = svm->GetRecordBuffer(SystemValueManager::RECORD_SYSTEM_GLOBAL);
-		if (record != NULL) {
+		if (record != nullptr) {
 			if (record->IsExists(key)) {
 				res = new EventValue();
 				int type = record->GetEntryType(key);
@@ -2997,11 +2941,11 @@ void EventEngine::SetState(int state)
 
 	DxButton* btnSave = windowManager->GetSaveButton().GetPointer();
 	DxButton* btnLoad = windowManager->GetLoadButton().GetPointer();
-	if (btnSave != NULL) {
+	if (btnSave != nullptr) {
 		btnSave->SetWindowVisible(state == STATE_RUN);
 		btnSave->SetWindowEnable(state == STATE_RUN);
 	}
-	if (btnLoad != NULL) {
+	if (btnLoad != nullptr) {
 		btnLoad->SetWindowVisible(state == STATE_RUN);
 		btnLoad->SetWindowEnable(state == STATE_RUN);
 	}
@@ -3021,21 +2965,20 @@ void EventEngine::CheckStateChenge()
 		else if (bChangeHideText)
 			SetState(STATE_HIDE_TEXT);
 	} else if (state_ == STATE_HIDE_TEXT) {
-		bool bChangeRun = false;
-		bChangeRun |= keyState_->IsSkip();
-		bChangeRun |= (input->GetMouseState(DI_MOUSE_LEFT) == KEY_PULL);
-		bChangeRun |= (input->GetMouseState(DI_MOUSE_RIGHT) == KEY_PULL);
-		if (bChangeRun)
+		if (keyState_->IsSkip()
+			|| (input->GetMouseState(DI_MOUSE_LEFT) == KEY_PULL)
+			|| (input->GetMouseState(DI_MOUSE_RIGHT) == KEY_PULL)
+		) {
 			SetState(STATE_RUN);
+		}
 	}
 }
 
 bool EventEngine::IsSaveEnable()
 {
-	if (activeCodeExecuter_ == NULL)
+	if (activeCodeExecuter_ == nullptr)
 		return false;
-	bool bEnable = ref_count_ptr<EventScriptCodeExecuter_WaitClick>::DownCast(activeCodeExecuter_) != NULL;
-	return bEnable;
+	return (ref_count_ptr<EventScriptCodeExecuter_WaitClick>::DownCast(activeCodeExecuter_) != nullptr);
 }
 bool EventEngine::Load(const std::wstring& path)
 {
@@ -3071,7 +3014,7 @@ void EventEngine::Read(gstd::RecordBuffer& record)
 
 	//スクリプトパス
 	int countSource = record.GetRecordAsInteger("SourceCount");
-	for (int iSource = 0; iSource < countSource; iSource++) {
+	for (int iSource = 0; iSource < countSource; ++iSource) {
 		std::wstring path = record.GetRecordAsStringW(StringUtility::Format("SourcePath%d", iSource));
 		path = PathProperty::GetModuleDirectory() + path;
 
@@ -3090,10 +3033,10 @@ void EventEngine::Read(gstd::RecordBuffer& record)
 	//フレーム
 	int countFrame = record.GetRecordAsInteger("FrameCount");
 	frame_.resize(countFrame);
-	for (int iFrame = 0; iFrame < countFrame; iFrame++) {
+	for (int iFrame = 0; iFrame < countFrame; ++iFrame) {
 		gstd::RecordBuffer recFrame;
 		record.GetRecordAsRecordBuffer(StringUtility::Format("Frame%d", iFrame), recFrame);
-		EventFrame* frame = new EventFrame();
+		auto* frame = new EventFrame();
 		frame->ReadRecord(recFrame, this);
 
 		frame_[iFrame] = frame;
@@ -3116,16 +3059,16 @@ void EventEngine::Read(gstd::RecordBuffer& record)
 
 	//実行中スクリプト
 	int countScript = record.GetRecordAsInteger("ScriptCount");
-	for (int iScript = 0; iScript < countScript; iScript++) {
+	for (int iScript = 0; iScript < countScript; ++iScript) {
 		RecordBuffer recScript;
 		record.GetRecordAsRecordBuffer(StringUtility::Format("Script%d", iScript), recScript);
 
-		DxScriptForEvent* script = new DxScriptForEvent(this);
+		auto* script = new DxScriptForEvent(this);
 		script->Read(recScript);
 		script->Compile();
 		script->Run(script->GetMethod());
 
-		listScript_.push_back(script);
+		listScript_.emplace_back(script);
 	}
 }
 void EventEngine::Write(gstd::RecordBuffer& record)
@@ -3137,13 +3080,12 @@ void EventEngine::Write(gstd::RecordBuffer& record)
 	//スクリプトパス
 	int iSource = 0;
 	record.SetRecordAsInteger("SourceCount", mapSource_.size());
-	std::map<std::wstring, gstd::ref_count_ptr<EventScriptSource>>::iterator itrSource;
-	for (itrSource = mapSource_.begin(); itrSource != mapSource_.end(); itrSource++) {
+	for (auto itrSource = mapSource_.begin(); itrSource != mapSource_.end(); ++itrSource) {
 		std::wstring path = (*itrSource).first;
 		path = PathProperty::GetPathWithoutModuleDirectory(path);
 
 		record.SetRecordAsStringW(StringUtility::Format("SourcePath%d", iSource), path);
-		iSource++;
+		++iSource;
 	}
 
 	//グローバル変数フレーム
@@ -3154,7 +3096,7 @@ void EventEngine::Write(gstd::RecordBuffer& record)
 	//フレーム
 	int countFrame = frame_.size();
 	record.SetRecordAsInteger("FrameCount", countFrame);
-	for (int iFrame = 0; iFrame < countFrame; iFrame++) {
+	for (int iFrame = 0; iFrame < countFrame; ++iFrame) {
 		gstd::RecordBuffer recFrame;
 		frame_[iFrame]->WriteRecord(recFrame, this);
 		record.SetRecordAsRecordBuffer(StringUtility::Format("Frame%d", iFrame), recFrame);
@@ -3177,10 +3119,8 @@ void EventEngine::Write(gstd::RecordBuffer& record)
 
 	//実行中スクリプト
 	int countScript = 0;
-	std::list<gstd::ref_count_ptr<DxScriptForEvent>>::iterator itrScript;
-	for (itrScript = listScript_.begin(); itrScript != listScript_.end(); itrScript++) {
-		gstd::ref_count_ptr<DxScriptForEvent>& script = (*itrScript);
-		if (script == NULL)
+	for (auto& script : listScript_) {
+		if (script == nullptr)
 			continue;
 		if (script->IsScriptEnd())
 			continue;
@@ -3189,7 +3129,7 @@ void EventEngine::Write(gstd::RecordBuffer& record)
 		script->Write(recScript);
 		record.SetRecordAsRecordBuffer(StringUtility::Format("Script%d", countScript), recScript);
 
-		countScript++;
+		++countScript;
 	}
 	record.SetRecordAsInteger("ScriptCount", countScript);
 }
@@ -3237,9 +3177,8 @@ std::vector<char> DxScriptForEvent::_Include(std::vector<char>& source)
 }
 void DxScriptForEvent::Clear()
 {
-	std::set<int>::iterator itr = listObj_.begin();
-	for (; itr != listObj_.end(); itr++) {
-		objManager_->DeleteObject(*itr);
+	for (int objectId : listObj_) {
+		objManager_->DeleteObject(objectId);
 	}
 }
 bool DxScriptForEvent::SetSourceFromFile(const std::wstring& path)
@@ -3264,10 +3203,9 @@ void DxScriptForEvent::DeleteObject(int id)
 	if (id == ID_INVALID)
 		return;
 	DxScript::DeleteObject(id);
-	std::set<int>::iterator itr = listObj_.find(id);
-	if (itr == listObj_.end())
-		return;
-	listObj_.erase(itr);
+	auto objectItr = listObj_.find(id);
+	if (objectItr != listObj_.end())
+		listObj_.erase(objectItr);
 }
 void DxScriptForEvent::AddArgumentValue(gstd::ref_count_ptr<EventValue> arg)
 {
@@ -3296,7 +3234,7 @@ void DxScriptForEvent::Read(gstd::RecordBuffer& record)
 	//コード
 	code_ = record.GetRecordAsStringA("code");
 
-	if (code_.size() > 0) {
+	if (!code_.empty()) {
 		SetSource(code_);
 		SetPath(path);
 	} else {
@@ -3323,28 +3261,28 @@ void DxScriptForEvent::Write(gstd::RecordBuffer& record)
 //関数：スクリプト操作
 gstd::value DxScriptForEvent::Func_EndScript(script_machine* machine, int argc, value const* argv)
 {
-	DxScriptForEvent* script = (DxScriptForEvent*)machine->data;
+	auto* script = (DxScriptForEvent*)machine->data;
 	script->bScriptEnd_ = true;
 	return gstd::value();
 }
 gstd::value DxScriptForEvent::Func_GetTarget(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScriptForEvent* script = (DxScriptForEvent*)machine->data;
+	auto* script = (DxScriptForEvent*)machine->data;
 	return value(machine->get_engine()->get_real_type(), (long double)script->targetId_);
 }
 gstd::value DxScriptForEvent::Func_GetEventValue(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScriptForEvent* script = (DxScriptForEvent*)machine->data;
+	auto* script = (DxScriptForEvent*)machine->data;
 	std::wstring wName = argv[0].as_string();
 	std::string name = to_mbcs(wName);
 	gstd::ref_count_ptr<EventValue> eValue = script->engine_->GetEventValue(name);
-	if (eValue == NULL)
-		throw gstd::wexception(StringUtility::Format(L"存在しない変数:%s", name.c_str()).c_str());
+	if (eValue == nullptr)
+		throw gstd::wexception(StringUtility::Format(L"存在しない変数:%s", name.c_str()));
 
 	int type = eValue->GetType();
 	if (type == EventValue::TYPE_REAL)
 		return value(machine->get_engine()->get_real_type(), (long double)eValue->GetReal());
-	else if (type == EventValue::TYPE_BOOLEAN)
+	if (type == EventValue::TYPE_BOOLEAN)
 		return value(machine->get_engine()->get_boolean_type(), eValue->GetBoolean());
 	else if (type == EventValue::TYPE_STRING)
 		return value(machine->get_engine()->get_string_type(), to_wide(eValue->GetString()));
@@ -3352,12 +3290,12 @@ gstd::value DxScriptForEvent::Func_GetEventValue(gstd::script_machine* machine, 
 }
 gstd::value DxScriptForEvent::Func_SetEventValue(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScriptForEvent* script = (DxScriptForEvent*)machine->data;
+	auto* script = (DxScriptForEvent*)machine->data;
 	std::wstring wName = argv[0].as_string();
 	std::string name = to_mbcs(wName);
 	gstd::ref_count_ptr<EventValue> eValue = script->engine_->GetEventValue(name);
-	if (eValue == NULL)
-		throw gstd::wexception(StringUtility::Format(L"存在しない変数:%s", name.c_str()).c_str());
+	if (eValue == nullptr)
+		throw gstd::wexception(StringUtility::Format(L"存在しない変数:%s", name.c_str()));
 
 	if (argv[1].get_type() == machine->get_engine()->get_real_type()) {
 		eValue->SetReal(argv[1].as_real());
@@ -3372,7 +3310,7 @@ gstd::value DxScriptForEvent::Func_SetEventValue(gstd::script_machine* machine, 
 //関数：キー入力
 gstd::value DxScriptForEvent::Func_IsSkip(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	DxScriptForEvent* script = (DxScriptForEvent*)machine->data;
+	auto* script = (DxScriptForEvent*)machine->data;
 	EventEngine* engine = script->engine_;
 	gstd::ref_count_ptr<EventKeyState> key = engine->GetEventKeyState();
 

--- a/source/GcLib/directx/EventScript.hpp
+++ b/source/GcLib/directx/EventScript.hpp
@@ -91,9 +91,9 @@ public:
 		element_ = element;
 	}
 
-	virtual ~EventScriptToken() {}
+	virtual ~EventScriptToken() = default;
 	Type GetType() const { return type_; }
-	std::string& GetElement() { return element_; }
+	std::string GetElement() const { return element_; }
 
 	int GetInteger() const;
 	double GetReal() const;
@@ -141,7 +141,7 @@ protected:
 	std::vector<char> buffer_;
 	std::vector<char>::iterator pointer_; //今の位置
 	EventScriptToken token_; //現在のトークン
-	boolean bTagScan_;
+	bool bTagScan_;
 
 	char _NextChar(); //ポインタを進めて次の文字を調べる
 	virtual void _SkipComment(); //コメントをとばす
@@ -195,7 +195,7 @@ public:
 		posEnd_ = POS_NULL;
 		posReturn_ = POS_NULL;
 	}
-	virtual ~EventScriptBlock() {}
+	virtual ~EventScriptBlock() = default;
 	int GetStartPosition() const { return posStart_; }
 	void SetStartPosition(int pos) { posStart_ = pos; }
 	int GetEndPosition() const { return posEnd_; }
@@ -217,10 +217,10 @@ class EventScriptBlock_Main : public EventScriptBlock {
 
 public:
 	EventScriptBlock_Main() { bInner_ = false; }
-	virtual ~EventScriptBlock_Main() {}
+	~EventScriptBlock_Main() override = default;
 	std::string GetName() const { return name_; }
 	void SetName(const std::string& name) { name_ = name; }
-	bool IsGlobal() const { return name_ == BLOCK_GLOBAL; }
+	bool IsGlobal() const override { return name_ == BLOCK_GLOBAL; }
 
 private:
 	std::string name_;
@@ -305,7 +305,7 @@ class EventScriptCode_Text : public EventScriptCode {
 public:
 	EventScriptCode_Text();
 	std::string GetText() const { return text_; }
-	std::string GetCodeText() const { return GetText(); }
+	std::string GetCodeText() const override { return GetText(); }
 	void SetText(const std::string& text) { text_ = text; }
 
 protected:
@@ -314,7 +314,7 @@ protected:
 class EventScriptCode_NextLine : public EventScriptCode {
 public:
 	EventScriptCode_NextLine();
-	std::string GetCodeText() const;
+	std::string GetCodeText() const override;
 };
 class EventScriptCode_WaitClick : public EventScriptCode {
 public:
@@ -587,7 +587,7 @@ protected:
 	double _GetElementReal(const std::string& value);
 	bool _GetElementBoolean(const std::string& value);
 	std::string _GetElementString(const std::string& value);
-	bool _IsValieElement(const std::string& value);
+	bool _IsValidElement(const std::string& value);
 };
 
 class EventScriptCodeExecuter_WaitClick : public EventScriptCodeExecuter {
@@ -596,7 +596,7 @@ public:
 		: EventScriptCodeExecuter(engine)
 	{
 	}
-	virtual void Execute();
+	void Execute() override;
 };
 
 class EventScriptCodeExecuter_WaitNextPage : public EventScriptCodeExecuter {
@@ -605,13 +605,13 @@ public:
 		: EventScriptCodeExecuter(engine)
 	{
 	}
-	virtual void Execute();
+	void Execute() override;
 };
 
 class EventScriptCodeExecuter_WaitTime : public EventScriptCodeExecuter {
 public:
 	EventScriptCodeExecuter_WaitTime(EventEngine* engine, EventScriptCode_WaitTime* code);
-	virtual void Execute();
+	void Execute() override;
 
 private:
 	int count_;
@@ -622,7 +622,7 @@ private:
 class EventScriptCodeExecuter_Transition : public EventScriptCodeExecuter {
 public:
 	EventScriptCodeExecuter_Transition(EventEngine* engine, EventScriptCode_Transition* code);
-	virtual void Execute();
+	void Execute() override;
 
 private:
 	class DxScriptRenderObject_Transition : public DxScriptObjectBase {
@@ -632,8 +632,8 @@ private:
 			effect_ = effect;
 			priRender_ = 1.0;
 		}
-		virtual void Render() { effect_->Render(); }
-		virtual void SetRenderState() {}
+		void Render() override { effect_->Render(); }
+		void SetRenderState() override {}
 
 	private:
 		TransitionEffect* effect_;
@@ -647,8 +647,8 @@ private:
 class EventScriptCodeExecuter_Image : public EventScriptCodeExecuter {
 public:
 	EventScriptCodeExecuter_Image(EventEngine* engine, EventScriptCode_Image* code);
-	~EventScriptCodeExecuter_Image();
-	virtual void Execute();
+	~EventScriptCodeExecuter_Image() override;
+	void Execute() override;
 
 private:
 	EventScriptCode_Image* code_;
@@ -666,7 +666,7 @@ private:
 class EventScriptCodeExecuter_Script : public EventScriptCodeExecuter {
 public:
 	EventScriptCodeExecuter_Script(EventEngine* engine, DxScriptForEvent* script);
-	virtual void Execute();
+	void Execute() override;
 
 private:
 	DxScriptForEvent* script_;
@@ -684,8 +684,8 @@ public:
 	EventWindowManager(EventEngine* engine);
 	EventEngine* GetEngine() { return engine_; }
 	virtual bool Initialize();
-	virtual void Work();
-	virtual void Render();
+	void Work() override;
+	void Render() override;
 
 	gstd::ref_count_ptr<EventMouseCaptureLayer> GetMouseCaptureLayer() { return layerCapture_; }
 	gstd::ref_count_ptr<EventTextWindow> GetTextWindow() { return wndText_; }
@@ -734,8 +734,8 @@ protected:
 };
 class EventMouseCaptureLayer : public EventWindow {
 public:
-	virtual void AddedManager();
-	virtual void DispatchedEvent(gstd::ref_count_ptr<DxWindowEvent> event);
+	void AddedManager() override;
+	void DispatchedEvent(gstd::ref_count_ptr<DxWindowEvent> event) override;
 	void ClearEvent();
 	gstd::ref_count_ptr<DxWindowEvent> GetEvent() { return event_; }
 
@@ -745,8 +745,8 @@ protected:
 class EventTextWindow : public EventWindow {
 public:
 	EventTextWindow();
-	virtual void AddedManager();
-	virtual void Render();
+	void AddedManager() override;
+	void Render() override;
 	bool IsWait();
 
 protected:
@@ -756,8 +756,8 @@ protected:
 class EventNameWindow : public EventWindow {
 public:
 	EventNameWindow();
-	void Work();
-	void Render();
+	void Work() override;
+	void Render() override;
 	virtual void RenderText();
 	std::wstring GetText() const { return text_->GetText(); }
 	void SetText(const std::wstring& text) { text_->SetText(text); }
@@ -768,9 +768,9 @@ private:
 class EventLogWindow : public EventWindow {
 public:
 	EventLogWindow();
-	virtual void AddedManager();
-	virtual void Work();
-	virtual void Render();
+	void AddedManager() override;
+	void Work() override;
+	void Render() override;
 
 	gstd::ref_count_ptr<DxText> GetRenderer() { return dxText_; }
 	void ResetPosition();
@@ -788,8 +788,8 @@ class EventScriptObjectManager : public DxScriptObjectManager, public gstd::Reco
 public:
 	virtual int AddObject(gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj);
 
-	void Read(gstd::RecordBuffer& record);
-	void Write(gstd::RecordBuffer& record);
+	void Read(gstd::RecordBuffer& record) override;
+	void Write(gstd::RecordBuffer& record) override;
 
 private:
 	enum {
@@ -827,7 +827,7 @@ public:
 
 public:
 	EventValue() { type_ = TYPE_UNKNOWN; }
-	virtual ~EventValue(){};
+	~EventValue() override = default;
 	int GetType() const { return type_; }
 	double GetReal() const
 	{
@@ -880,8 +880,8 @@ public:
 	void Copy(const gstd::TextParser::Result& val);
 	void Copy(const EventValue& val);
 
-	void Read(gstd::RecordBuffer& record);
-	void Write(gstd::RecordBuffer& record);
+	void Read(gstd::RecordBuffer& record) override;
+	void Write(gstd::RecordBuffer& record) override;
 
 protected:
 	int type_;
@@ -938,7 +938,7 @@ public:
 	gstd::ref_count_ptr<EventValue> GetEventValue(const std::string& text);
 protected:
 	EventEngine* engine_;
-	virtual Result _ParseIdentifer(std::vector<char>::iterator);
+	virtual Result _ParseIdentifer(std::vector<char>::iterator /*unused*/);
 	std::vector<std::string> _GetFuctionArgument();
 
 };
@@ -955,15 +955,15 @@ public:
 
 public:
 	EventImage();
-	virtual ~EventImage();
+	~EventImage() override;
 	void Render(int layer);
 	int GetForegroundLayerIndex() const;
 	int GetBackgroundLayerIndex() const;
 	void SwapForeBackLayerIndex();
 	gstd::ref_count_ptr<DxScriptObjectManager> GetObjectManager(int layer) { return objManager_[layer]; }
 
-	void Read(gstd::RecordBuffer& record);
-	void Write(gstd::RecordBuffer& record);
+	void Read(gstd::RecordBuffer& record) override;
+	void Write(gstd::RecordBuffer& record) override;
 
 protected:
 	std::vector<gstd::ref_count_ptr<EventScriptObjectManager>> objManager_;
@@ -994,13 +994,13 @@ public:
 
 public:
 	EventSound();
-	virtual ~EventSound();
+	~EventSound() override;
 
 	void Play(int type, const std::string& path);
 	void Delete(int type);
 
-	void Read(gstd::RecordBuffer& record);
-	void Write(gstd::RecordBuffer& record);
+	void Read(gstd::RecordBuffer& record) override;
+	void Write(gstd::RecordBuffer& record) override;
 
 private:
 	gstd::ref_count_ptr<SoundPlayer> playerBgm_;
@@ -1018,7 +1018,7 @@ public:
 
 public:
 	EventEngine();
-	virtual ~EventEngine();
+	~EventEngine() override;
 	virtual bool Initialize();
 
 	virtual void Work();
@@ -1052,8 +1052,8 @@ public:
 	bool Load(const std::wstring& path);
 	bool Load(gstd::RecordBuffer& record);
 	bool Save(const std::wstring& path);
-	void Read(gstd::RecordBuffer& record);
-	void Write(gstd::RecordBuffer& record);
+	void Read(gstd::RecordBuffer& record) override;
+	void Write(gstd::RecordBuffer& record) override;
 
 protected:
 	enum {
@@ -1092,12 +1092,12 @@ protected:
 class DxScriptForEvent : public DxScript, public gstd::Recordable {
 public:
 	DxScriptForEvent(EventEngine* engine);
-	~DxScriptForEvent();
+	~DxScriptForEvent() override;
 	void Clear();
-	virtual bool SetSourceFromFile(const std::wstring& path);
-	virtual void SetSource(const std::string& source);
+	bool SetSourceFromFile(const std::wstring& path) override;
+	void SetSource(const std::string& source) override;
 	virtual int AddObject(gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj);
-	virtual void DeleteObject(int id);
+	void DeleteObject(int id) override;
 
 	std::string GetMethod() const { return method_; }
 	void SetMethod(const std::string& method) { method_ = method; }
@@ -1112,8 +1112,8 @@ public:
 
 	void AddArgumentValue(gstd::ref_count_ptr<EventValue> arg);
 
-	void Read(gstd::RecordBuffer& record);
-	void Write(gstd::RecordBuffer& record);
+	void Read(gstd::RecordBuffer& record) override;
+	void Write(gstd::RecordBuffer& record) override;
 
 	//関数：スクリプト操作
 	static gstd::value Func_EndScript(gstd::script_machine* machine, int argc, gstd::value const* argv);
@@ -1133,7 +1133,7 @@ private:
 	std::set<int> listObj_;
 	std::string code_;
 
-	virtual std::vector<char> _Include(std::vector<char>& source);
+	std::vector<char> _Include(std::vector<char>& source) override;
 };
 
 } // namespace directx

--- a/source/GcLib/directx/EventScript.hpp
+++ b/source/GcLib/directx/EventScript.hpp
@@ -32,10 +32,10 @@ public:
 	EventScriptSource();
 	virtual ~EventScriptSource();
 
-	int GetCodeCount() { return code_.size(); }
+	int GetCodeCount() const { return code_.size(); }
 	void AddCode(gstd::ref_count_ptr<EventScriptCode> code);
 	gstd::ref_count_ptr<EventScriptCode> GetCode(int index) { return code_[index]; }
-	gstd::ref_count_ptr<EventScriptBlock_Main> GetEventBlock(std::string name);
+	gstd::ref_count_ptr<EventScriptBlock_Main> GetEventBlock(const std::string& name);
 
 protected:
 	std::vector<gstd::ref_count_ptr<EventScriptCode>> code_;
@@ -85,21 +85,21 @@ public:
 
 public:
 	EventScriptToken() { type_ = TK_UNKNOWN; }
-	EventScriptToken(Type type, std::string element)
+	EventScriptToken(Type type, const std::string& element)
 	{
 		type_ = type;
 		element_ = element;
 	}
 
 	virtual ~EventScriptToken() {}
-	Type GetType() { return type_; }
+	Type GetType() const { return type_; }
 	std::string& GetElement() { return element_; }
 
-	int GetInteger();
-	double GetReal();
-	bool GetBoolean();
-	std::string GetString();
-	std::string& GetIdentifier();
+	int GetInteger() const;
+	double GetReal() const;
+	bool GetBoolean() const;
+	std::string GetString() const;
+	std::string GetIdentifier() const;
 
 protected:
 	Type type_;
@@ -117,23 +117,23 @@ public:
 	const static std::string TAG_FONT;
 
 public:
-	EventScriptScanner(char* str, int size);
-	EventScriptScanner(std::string str);
-	EventScriptScanner(std::vector<char>& buf);
+	EventScriptScanner(const char* str, int size);
+	EventScriptScanner(const std::string& str);
+	EventScriptScanner(const std::vector<char>& buf);
 	virtual ~EventScriptScanner();
 
 	EventScriptToken& GetToken(); //現在のトークンを取得
 	EventScriptToken& Next();
 	bool HasNext();
-	void CheckType(EventScriptToken& tok, int type);
-	void CheckIdentifer(EventScriptToken& tok, std::string id);
-	int GetCurrentLine();
+	void CheckType(const EventScriptToken& tok, int type);
+	void CheckIdentifer(const EventScriptToken& tok, const std::string& id);
+	int GetCurrentLine() const;
 	int SearchCurrentLine();
 
-	std::vector<char>::iterator GetCurrentPointer();
+	std::vector<char>::iterator GetCurrentPointer() const;
 	void SetCurrentPointer(std::vector<char>::iterator pos);
 	void SetPointerBegin() { pointer_ = buffer_.begin(); }
-	int GetCurrentPosition();
+	int GetCurrentPosition() const;
 	void SetTagScanEnable(bool bEnable) { bTagScan_ = bEnable; }
 
 protected:
@@ -146,7 +146,7 @@ protected:
 	char _NextChar(); //ポインタを進めて次の文字を調べる
 	virtual void _SkipComment(); //コメントをとばす
 	virtual void _SkipSpace(); //空白をとばす
-	virtual void _RaiseError(std::wstring str); //例外を投げます
+	virtual void _RaiseError(const std::wstring& str); //例外を投げます
 	bool _IsTextStartSign();
 	bool _IsTextScan();
 };
@@ -159,7 +159,7 @@ public:
 	EventScriptCompiler();
 	virtual ~EventScriptCompiler();
 
-	void SetPath(std::wstring path) { path_ = path; }
+	void SetPath(const std::wstring& path) { path_ = path; }
 	gstd::ref_count_ptr<EventScriptSource> Compile();
 
 private:
@@ -196,14 +196,14 @@ public:
 		posReturn_ = POS_NULL;
 	}
 	virtual ~EventScriptBlock() {}
-	int GetStartPosition() { return posStart_; }
+	int GetStartPosition() const { return posStart_; }
 	void SetStartPosition(int pos) { posStart_ = pos; }
-	int GetEndPosition() { return posEnd_; }
+	int GetEndPosition() const { return posEnd_; }
 	void SetEndPosition(int pos) { posEnd_ = pos; }
-	int GetReturnPosition() { return posReturn_; }
+	int GetReturnPosition() const { return posReturn_; }
 	void SetReturnPosition(int pos) { posReturn_ = pos; }
-	bool IsInner() { return bInner_; }
-	virtual bool IsGlobal() { return false; }
+	bool IsInner() const { return bInner_; }
+	virtual bool IsGlobal() const { return false; }
 
 protected:
 	bool bInner_;
@@ -218,9 +218,9 @@ class EventScriptBlock_Main : public EventScriptBlock {
 public:
 	EventScriptBlock_Main() { bInner_ = false; }
 	virtual ~EventScriptBlock_Main() {}
-	std::string GetName() { return name_; }
-	void SetName(std::string name) { name_ = name; }
-	bool IsGlobal() { return name_ == BLOCK_GLOBAL; }
+	std::string GetName() const { return name_; }
+	void SetName(const std::string& name) { name_ = name; }
+	bool IsGlobal() const { return name_ == BLOCK_GLOBAL; }
 
 private:
 	std::string name_;
@@ -291,10 +291,10 @@ public:
 	EventScriptCode();
 	virtual ~EventScriptCode();
 
-	int GetType() { return type_; }
-	int GetLine() { return line_; }
+	int GetType() const { return type_; }
+	int GetLine() const { return line_; }
 	void SetLine(int line) { line_ = line; }
-	virtual std::string GetCodeText() { return ""; }
+	virtual std::string GetCodeText() const { return ""; }
 
 protected:
 	int type_;
@@ -304,9 +304,9 @@ protected:
 class EventScriptCode_Text : public EventScriptCode {
 public:
 	EventScriptCode_Text();
-	std::string GetText() { return text_; }
-	std::string GetCodeText() { return GetText(); }
-	void SetText(std::string text) { text_ = text; }
+	std::string GetText() const { return text_; }
+	std::string GetCodeText() const { return GetText(); }
+	void SetText(const std::string& text) { text_ = text; }
 
 protected:
 	std::string text_;
@@ -314,7 +314,7 @@ protected:
 class EventScriptCode_NextLine : public EventScriptCode {
 public:
 	EventScriptCode_NextLine();
-	std::string GetCodeText();
+	std::string GetCodeText() const;
 };
 class EventScriptCode_WaitClick : public EventScriptCode {
 public:
@@ -327,9 +327,9 @@ public:
 class EventScriptCode_WaitTime : public EventScriptCode {
 public:
 	EventScriptCode_WaitTime();
-	std::string GetTime() { return time_; }
-	void SetTime(std::string time) { time_ = time; }
-	bool IsSkipEnable() { return bSkipEnable_; }
+	std::string GetTime() const { return time_; }
+	void SetTime(const std::string& time) { time_ = time; }
+	bool IsSkipEnable() const { return bSkipEnable_; }
 	void SetSkipEnable(bool bEnable) { bSkipEnable_ = bEnable; }
 
 private:
@@ -344,7 +344,7 @@ class EventScriptCode_Name : public EventScriptCode {
 public:
 	EventScriptCode_Name();
 	std::string& GetName() { return name_; }
-	void SetName(std::string name) { name_ = name; }
+	void SetName(const std::string& name) { name_ = name; }
 
 private:
 	std::string name_;
@@ -359,13 +359,13 @@ public:
 
 public:
 	EventScriptCode_Transition();
-	int GetTransType() { return typeTrans_; }
+	int GetTransType() const { return typeTrans_; }
 	void SetTransType(int type) { typeTrans_ = type; }
-	std::string GetFrame() { return frame_; }
+	std::string GetFrame() const { return frame_; }
 	void SetFrame(std::string frame) { frame_ = frame; }
-	std::string GetPath() { return path_; }
+	std::string GetPath() const { return path_; }
 	void SetPath(std::string path) { path_ = path; }
-	std::string GetMethod() { return method_; }
+	std::string GetMethod() const { return method_; }
 	void SetMethod(std::string method) { method_ = method; }
 
 protected:
@@ -377,7 +377,7 @@ protected:
 class EventScriptCode_VisibleText : public EventScriptCode {
 public:
 	EventScriptCode_VisibleText();
-	bool IsVisible() { return bVisible_; }
+	bool IsVisible() const { return bVisible_; }
 	void SetVisible(bool bVisible) { bVisible_ = bVisible; }
 
 private:
@@ -387,9 +387,9 @@ class EventScriptCode_Var : public EventScriptCode {
 public:
 	EventScriptCode_Var();
 	std::string& GetName() { return name_; }
-	void SetName(std::string name) { name_ = name; }
+	void SetName(const std::string& name) { name_ = name; }
 	std::string& GetValue() { return value_; }
-	void SetValue(std::string value) { value_ = value; }
+	void SetValue(const std::string& value) { value_ = value; }
 
 private:
 	std::string name_;
@@ -399,9 +399,9 @@ class EventScriptCode_Eval : public EventScriptCode {
 public:
 	EventScriptCode_Eval();
 	std::string& GetName() { return name_; }
-	void SetName(std::string name) { name_ = name; }
+	void SetName(const std::string& name) { name_ = name; }
 	std::string& GetValue() { return value_; }
-	void SetValue(std::string value) { value_ = value; }
+	void SetValue(const std::string& value) { value_ = value; }
 
 private:
 	std::string name_;
@@ -411,10 +411,10 @@ class EventScriptCode_SysVal : public EventScriptCode {
 public:
 	EventScriptCode_SysVal();
 	std::string& GetName() { return name_; }
-	void SetName(std::string name) { name_ = name; }
+	void SetName(const std::string& name) { name_ = name; }
 	std::string& GetValue() { return value_; }
-	void SetValue(std::string value) { value_ = value; }
-	bool IsGlobal() { return bGlobal_; }
+	void SetValue(const std::string& value) { value_ = value; }
+	bool IsGlobal() const { return bGlobal_; }
 	void SetGlobal(bool b) { bGlobal_ = b; }
 
 private:
@@ -426,7 +426,7 @@ class EventScriptCode_Output : public EventScriptCode {
 public:
 	EventScriptCode_Output();
 	std::string& GetValue() { return value_; }
-	void SetValue(std::string value) { value_ = value; }
+	void SetValue(const std::string& value) { value_ = value; }
 
 private:
 	std::string value_;
@@ -439,24 +439,24 @@ public:
 
 public:
 	EventScriptCode_Image();
-	std::string GetObjectIdentifier() { return idObject_; }
-	void SetObjectIdentifier(std::string id) { idObject_ = id; }
-	std::string GetPath() { return path_; }
-	void SetPath(std::string path) { path_ = path; }
-	int GetLayer() { return layer_; }
+	std::string GetObjectIdentifier() const { return idObject_; }
+	void SetObjectIdentifier(const std::string& id) { idObject_ = id; }
+	std::string GetPath() const { return path_; }
+	void SetPath(const std::string& path) { path_ = path; }
+	int GetLayer() const { return layer_; }
 	void SetLayer(int layer) { layer_ = layer; }
-	std::string GetPriority() { return pri_; }
-	void SetPriority(std::string pri) { pri_ = pri; }
-	std::string GetVisible() { return bVisible_; }
-	void SetVisible(std::string bVisible) { bVisible_ = bVisible_; }
-	std::string GetLeftDestPoint() { return posDestLeft_; }
-	void SetLeftDestPoint(std::string left) { posDestLeft_ = left; }
-	std::string GetTopDestPoint() { return posDestTop_; }
-	void SetTopDestPoint(std::string top) { posDestTop_ = top; }
-	std::string GetTransition() { return bTransition_; }
-	void SetTransition(std::string bTrans) { bTransition_ = bTrans; }
-	std::string GetWaitEnd() { return bWaitEnd_; }
-	void SetWaitEnd(std::string bWaitEnd) { bWaitEnd_ = bWaitEnd; }
+	std::string GetPriority() const { return pri_; }
+	void SetPriority(const std::string& pri) { pri_ = pri; }
+	std::string GetVisible() const { return bVisible_; }
+	void SetVisible(const std::string& bVisible) { bVisible_ = bVisible_; }
+	std::string GetLeftDestPoint() const { return posDestLeft_; }
+	void SetLeftDestPoint(const std::string& left) { posDestLeft_ = left; }
+	std::string GetTopDestPoint() const { return posDestTop_; }
+	void SetTopDestPoint(const std::string& top) { posDestTop_ = top; }
+	std::string GetTransition() const { return bTransition_; }
+	void SetTransition(const std::string& bTrans) { bTransition_ = bTrans; }
+	std::string GetWaitEnd() const { return bWaitEnd_; }
+	void SetWaitEnd(const std::string& bWaitEnd) { bWaitEnd_ = bWaitEnd; }
 
 protected:
 	std::string idObject_;
@@ -472,10 +472,10 @@ protected:
 class EventScriptCode_Sound : public EventScriptCode {
 public:
 	EventScriptCode_Sound();
-	int GetSoundType() { return typeSound_; }
+	int GetSoundType() const { return typeSound_; }
 	void SetSoundType(int type) { typeSound_ = type; }
-	std::string GetPath() { return path_; }
-	void SetPath(std::string path) { path_ = path; }
+	std::string GetPath() const { return path_; }
+	void SetPath(const std::string& path) { path_ = path; }
 
 private:
 	int typeSound_;
@@ -484,9 +484,9 @@ private:
 class EventScriptCode_If : public EventScriptCode, public EventScriptBlock {
 public:
 	EventScriptCode_If();
-	std::string GetParameter() { return param_; }
-	void SetParameter(std::string param) { param_ = param; }
-	int GetNextElsePosition() { return posNextElse_; }
+	std::string GetParameter() const { return param_; }
+	void SetParameter(const std::string& param) { param_ = param; }
+	int GetNextElsePosition() const { return posNextElse_; }
 	void SetNextElsePosition(int pos) { posNextElse_ = pos; }
 
 protected:
@@ -498,13 +498,13 @@ class EventScriptCode_Jump : public EventScriptCode {
 public:
 	EventScriptCode_Jump();
 
-	bool IsGoSub() { return bGoSub_; }
+	bool IsGoSub() const { return bGoSub_; }
 	void SetGosub(bool b) { bGoSub_ = b; }
 
-	std::string GetPath() { return path_; }
-	void SetPath(std::string path) { path_ = path; }
-	std::string GetName() { return name_; }
-	void SetName(std::string name) { name_ = name; }
+	std::string GetPath() const { return path_; }
+	void SetPath(const std::string& path) { path_ = path; }
+	std::string GetName() const { return name_; }
+	void SetName(const std::string& name) { name_ = name; }
 
 protected:
 	bool bGoSub_;
@@ -515,27 +515,27 @@ protected:
 class EventScriptCode_Script : public EventScriptCode {
 public:
 	EventScriptCode_Script();
-	std::string GetPath() { return path_; }
-	void SetPath(std::string path) { path_ = path; }
-	std::string GetMethod() { return method_; }
-	void SetMethod(std::string method) { method_ = method; }
-	std::string GetWaitEnd() { return bWaitEnd_; }
-	void SetWaitEnd(std::string bWait) { bWaitEnd_ = bWait; }
-	std::string GetTargetId() { return targetId_; }
-	void SetTargetId(std::string target) { targetId_ = target; }
-	std::string GetCode() { return code_; }
-	void SetCode(std::string code) { code_ = code; }
-	std::string GetId() { return id_; }
-	void SetId(std::string id) { id_ = id; }
-	std::vector<std::string> GetArgumentList() { return arg_; }
-	void SetArgument(int index, std::string arg)
+	std::string GetPath() const { return path_; }
+	void SetPath(const std::string& path) { path_ = path; }
+	std::string GetMethod() const { return method_; }
+	void SetMethod(const std::string& method) { method_ = method; }
+	std::string GetWaitEnd() const { return bWaitEnd_; }
+	void SetWaitEnd(const std::string& bWait) { bWaitEnd_ = bWait; }
+	std::string GetTargetId() const { return targetId_; }
+	void SetTargetId(const std::string& target) { targetId_ = target; }
+	std::string GetCode() const { return code_; }
+	void SetCode(const std::string& code) { code_ = code; }
+	std::string GetId() const { return id_; }
+	void SetId(const std::string& id) { id_ = id; }
+	std::vector<std::string> GetArgumentList() const { return arg_; }
+	void SetArgument(int index, const std::string& arg)
 	{
 		if (index >= arg_.size())
 			arg_.resize(index + 1);
 		arg_[index] = arg;
 	}
 
-	bool IsEndScript() { return bEndScript_; }
+	bool IsEndScript() const { return bEndScript_; }
 	void SetEndScript(bool bEnd) { bEndScript_ = bEnd; }
 
 private:
@@ -552,8 +552,8 @@ private:
 class EventScriptCode_End : public EventScriptCode {
 public:
 	EventScriptCode_End();
-	std::string GetArgument() { return arg_; }
-	void SetArgument(std::string arg) { arg_ = arg; }
+	std::string GetArgument() const { return arg_; }
+	void SetArgument(const std::string& arg) { arg_ = arg; }
 
 protected:
 	std::string arg_;
@@ -562,8 +562,8 @@ protected:
 class EventScriptCode_Battle : public EventScriptCode {
 public:
 	EventScriptCode_Battle();
-	std::string GetPath() { return path_; }
-	void SetPath(std::string path) { path_ = path; }
+	std::string GetPath() const { return path_; }
+	void SetPath(const std::string& path) { path_ = path; }
 
 protected:
 	std::string path_;
@@ -577,17 +577,17 @@ public:
 	EventScriptCodeExecuter(EventEngine* engine);
 	virtual ~EventScriptCodeExecuter();
 	virtual void Execute() = 0;
-	bool IsEnd() { return bEnd_; }
+	bool IsEnd() const { return bEnd_; }
 
 protected:
 	EventEngine* engine_;
 	bool bEnd_;
 
-	int _GetElementInteger(std::string value);
-	double _GetElementReal(std::string value);
-	bool _GetElementBoolean(std::string value);
-	std::string _GetElementString(std::string value);
-	bool _IsValieElement(std::string value);
+	int _GetElementInteger(const std::string& value);
+	double _GetElementReal(const std::string& value);
+	bool _GetElementBoolean(const std::string& value);
+	std::string _GetElementString(const std::string& value);
+	bool _IsValieElement(const std::string& value);
 };
 
 class EventScriptCodeExecuter_WaitClick : public EventScriptCodeExecuter {
@@ -695,7 +695,7 @@ public:
 	gstd::ref_count_ptr<DxButton> GetSaveButton() { return btnSave_; }
 	gstd::ref_count_ptr<DxButton> GetLoadButton() { return btnLoad_; }
 
-	bool IsTextVisible() { return bVisibleText_; }
+	bool IsTextVisible() const { return bVisibleText_; }
 	void SetTextVisible(bool bVisible) { bVisibleText_ = bVisible; }
 
 	void Read(gstd::RecordBuffer& record);
@@ -759,8 +759,8 @@ public:
 	void Work();
 	void Render();
 	virtual void RenderText();
-	std::wstring GetText() { return text_->GetText(); }
-	void SetText(std::wstring text) { text_->SetText(text); }
+	std::wstring GetText() const { return text_->GetText(); }
+	void SetText(const std::wstring& text) { text_->SetText(text); }
 
 private:
 	gstd::ref_count_ptr<DxText> text_;
@@ -804,9 +804,9 @@ class EventLogText {
 public:
 	EventLogText(EventEngine* engine);
 	virtual ~EventLogText();
-	void Add(std::string text, std::string name);
+	void Add(std::string text);
 
-	int GetInfoCount() { return listInfo_.size(); }
+	int GetInfoCount() const { return listInfo_.size(); }
 	gstd::ref_count_ptr<DxTextInfo> GetTextInfo(int pos) { return listInfo_[pos]; }
 
 private:
@@ -828,8 +828,8 @@ public:
 public:
 	EventValue() { type_ = TYPE_UNKNOWN; }
 	virtual ~EventValue(){};
-	int GetType() { return type_; }
-	double GetReal()
+	int GetType() const { return type_; }
+	double GetReal() const
 	{
 		double res = valueReal_;
 		if (IsBoolean())
@@ -838,7 +838,7 @@ public:
 			res = atof(valueString_.c_str());
 		return res;
 	}
-	bool GetBoolean()
+	bool GetBoolean() const
 	{
 		bool res = valueBoolean_;
 		if (IsReal())
@@ -847,7 +847,7 @@ public:
 			res = (valueString_ == "true" ? true : false);
 		return res;
 	}
-	std::string GetString()
+	std::string GetString() const
 	{
 		std::string res = valueString_;
 		if (IsReal())
@@ -856,9 +856,9 @@ public:
 			res = (valueBoolean_ ? "true" : "false");
 		return res;
 	}
-	bool IsReal() { return type_ == TYPE_REAL; }
-	bool IsBoolean() { return type_ == TYPE_BOOLEAN; }
-	bool IsString() { return type_ == TYPE_STRING; }
+	bool IsReal() const { return type_ == TYPE_REAL; }
+	bool IsBoolean() const { return type_ == TYPE_BOOLEAN; }
+	bool IsString() const { return type_ == TYPE_STRING; }
 
 	void SetReal(double v)
 	{
@@ -870,15 +870,15 @@ public:
 		type_ = TYPE_BOOLEAN;
 		valueBoolean_ = v;
 	}
-	void SetString(std::string str)
+	void SetString(const std::string& str)
 	{
 		type_ = TYPE_STRING;
 		valueString_ = str;
 	}
 
 	gstd::TextParser::Result ConvertToTextParserResult();
-	void Copy(gstd::TextParser::Result& val);
-	void Copy(EventValue& val);
+	void Copy(const gstd::TextParser::Result& val);
+	void Copy(const EventValue& val);
 
 	void Read(gstd::RecordBuffer& record);
 	void Write(gstd::RecordBuffer& record);
@@ -900,22 +900,22 @@ public:
 	void SetBlock(gstd::ref_count_ptr<EventScriptBlock> block);
 	gstd::ref_count_ptr<EventScriptSource> GetActiveSource() { return sourceActive_; }
 
-	int GetCurrentPosition() { return posCode_; }
+	int GetCurrentPosition() const { return posCode_; }
 	void SetCurrentPosition(int pos) { posCode_ = pos; }
 	gstd::ref_count_ptr<EventScriptCode> NextCode();
 	gstd::ref_count_ptr<EventScriptCode> GetCurrentCode();
 	bool HasNextCode();
 	void SetEnd() { bEnd_ = true; }
-	bool IsEnd() { return bEnd_; }
-	gstd::ref_count_ptr<EventValue> GetValue(std::string key);
-	void AddValue(std::string key, gstd::ref_count_ptr<EventValue> val);
-	void SetValue(std::string key, gstd::ref_count_ptr<EventValue> val);
+	bool IsEnd() const { return bEnd_; }
+	gstd::ref_count_ptr<EventValue> GetValue(const std::string& key);
+	void AddValue(const std::string& key, gstd::ref_count_ptr<EventValue> val);
+	void SetValue(const std::string& key, gstd::ref_count_ptr<EventValue> val);
 
-	int GetReturnPosition() { return posReturn_; }
+	int GetReturnPosition() const { return posReturn_; }
 	void SetReturnPosition(int pos) { posReturn_ = pos; }
 	bool IsInnerBlock();
 
-	bool IsAutoGlobal() { return bAutoGlobal_; }
+	bool IsAutoGlobal() const { return bAutoGlobal_; }
 	void SetAutoGlobal(bool bAuto) { bAutoGlobal_ = bAuto; }
 
 	//保存
@@ -935,10 +935,10 @@ protected:
 class EventValueParser : public gstd::TextParser {
 public:
 	EventValueParser(EventEngine* engine);
-	gstd::ref_count_ptr<EventValue> GetEventValue(std::string text);
+	gstd::ref_count_ptr<EventValue> GetEventValue(const std::string& text);
 protected:
 	EventEngine* engine_;
-	virtual Result _ParseIdentifer(std::vector<char>::iterator pos);
+	virtual Result _ParseIdentifer(std::vector<char>::iterator);
 	std::vector<std::string> _GetFuctionArgument();
 
 };
@@ -957,8 +957,8 @@ public:
 	EventImage();
 	virtual ~EventImage();
 	void Render(int layer);
-	int GetForegroundLayerIndex();
-	int GetBackgroundLayerIndex();
+	int GetForegroundLayerIndex() const;
+	int GetBackgroundLayerIndex() const;
 	void SwapForeBackLayerIndex();
 	gstd::ref_count_ptr<DxScriptObjectManager> GetObjectManager(int layer) { return objManager_[layer]; }
 
@@ -977,8 +977,8 @@ public:
 	void Work();
 
 	void SetNextEnable(bool bEnable) { bNextEnable_ = bEnable; }
-	bool IsNext();
-	bool IsSkip();
+	bool IsNext() const;
+	bool IsSkip() const;
 
 protected:
 	EventEngine* engine_;
@@ -996,7 +996,7 @@ public:
 	EventSound();
 	virtual ~EventSound();
 
-	void Play(int type, std::string path);
+	void Play(int type, const std::string& path);
 	void Delete(int type);
 
 	void Read(gstd::RecordBuffer& record);
@@ -1023,9 +1023,9 @@ public:
 
 	virtual void Work();
 	virtual void Render();
-	void SetSource(std::wstring path);
+	void SetSource(const std::wstring& path);
 
-	gstd::ref_count_ptr<EventScriptSource> GetSource(std::wstring path);
+	gstd::ref_count_ptr<EventScriptSource> GetSource(const std::wstring& path);
 	std::wstring GetSourcePath(gstd::ref_count_ptr<EventScriptSource> source);
 	virtual bool IsEnd();
 
@@ -1042,16 +1042,16 @@ public:
 
 	gstd::ref_count_ptr<gstd::ScriptEngineCache> GetScriptEngineCache() { return cacheScriptEngine_; }
 
-	bool IsCriticalFrame() { return bCriticalFrame_; }
+	bool IsCriticalFrame() const { return bCriticalFrame_; }
 
 	void SetState(int state);
-	int GetState() { return state_; }
+	int GetState() const { return state_; }
 	virtual void CheckStateChenge();
 
 	bool IsSaveEnable();
-	bool Load(std::wstring path);
+	bool Load(const std::wstring& path);
 	bool Load(gstd::RecordBuffer& record);
-	bool Save(std::wstring path);
+	bool Save(const std::wstring& path);
 	void Read(gstd::RecordBuffer& record);
 	void Write(gstd::RecordBuffer& record);
 
@@ -1083,7 +1083,7 @@ protected:
 	virtual int _RunCode(gstd::ref_count_ptr<EventFrame> frameActive, gstd::ref_count_ptr<EventScriptCode> code) { return RUN_RETURN_NONE; }
 	virtual void _RunScript();
 	virtual void _WorkWindow();
-	gstd::ref_count_ptr<EventScriptSource> _GetSource(std::wstring path);
+	gstd::ref_count_ptr<EventScriptSource> _GetSource(const std::wstring& path);
 };
 
 /**********************************************************
@@ -1094,21 +1094,21 @@ public:
 	DxScriptForEvent(EventEngine* engine);
 	~DxScriptForEvent();
 	void Clear();
-	virtual bool SetSourceFromFile(std::wstring path);
-	virtual void SetSource(std::string source);
+	virtual bool SetSourceFromFile(const std::wstring& path);
+	virtual void SetSource(const std::string& source);
 	virtual int AddObject(gstd::ref_count_ptr<DxScriptObjectBase>::unsync obj);
 	virtual void DeleteObject(int id);
 
-	std::string GetMethod() { return method_; }
-	void SetMethod(std::string method) { method_ = method; }
+	std::string GetMethod() const { return method_; }
+	void SetMethod(const std::string& method) { method_ = method; }
 
 	void EndScript() { bScriptEnd_ = true; }
-	bool IsScriptEnd() { return bScriptEnd_; }
+	bool IsScriptEnd() const { return bScriptEnd_; }
 
 	void SetTargetId(int target) { targetId_ = target; }
-	std::string GetScriptId() { return scriptId_; }
-	void SetScriptId(std::string id) { scriptId_ = id; }
-	std::string GetCode() { return code_; }
+	std::string GetScriptId() const { return scriptId_; }
+	void SetScriptId(const std::string& id) { scriptId_ = id; }
+	std::string GetCode() const { return code_; }
 
 	void AddArgumentValue(gstd::ref_count_ptr<EventValue> arg);
 

--- a/source/GcLib/directx/MetasequoiaMesh.cpp
+++ b/source/GcLib/directx/MetasequoiaMesh.cpp
@@ -371,7 +371,7 @@ bool MetasequoiaMesh::CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader>
 	}
 	return res;
 }
-bool MetasequoiaMesh::CreateFromFileInLoadThread(std::wstring path)
+bool MetasequoiaMesh::CreateFromFileInLoadThread(const std::wstring& path)
 {
 	return DxMesh::CreateFromFileInLoadThread(path, MESH_METASEQUOIA);
 }

--- a/source/GcLib/directx/MetasequoiaMesh.cpp
+++ b/source/GcLib/directx/MetasequoiaMesh.cpp
@@ -10,15 +10,10 @@ using namespace directx;
 **********************************************************/
 
 //MetasequoiaMeshData
-MetasequoiaMeshData::MetasequoiaMeshData()
-{
-}
-MetasequoiaMeshData::~MetasequoiaMeshData()
-{
-}
+MetasequoiaMeshData::MetasequoiaMeshData() = default;
+MetasequoiaMeshData::~MetasequoiaMeshData() = default;
 bool MetasequoiaMeshData::CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> reader)
 {
-	bool res = false;
 	path_ = reader->GetOriginalPath();
 	std::string text;
 	int size = reader->GetFileSize();
@@ -35,19 +30,17 @@ bool MetasequoiaMeshData::CreateFromFileReader(gstd::ref_count_ptr<gstd::FileRea
 				_ReadObject(scanner);
 			}
 		}
-
-		res = true;
 	} catch (gstd::wexception& e) {
 		Logger::WriteTop(StringUtility::Format(L"MetasequoiaMeshData読み込み失敗 %s %d", e.what(), scanner.GetCurrentLine()));
-		res = false;
+		return false;
 	}
-	return res;
+	return true;
 }
 void MetasequoiaMeshData::_ReadMaterial(gstd::Scanner& scanner)
 {
 	int countMaterial = scanner.Next().GetInteger();
 	material_.resize(countMaterial);
-	for (int iMat = 0; iMat < countMaterial; iMat++) {
+	for (int iMat = 0; iMat < countMaterial; ++iMat) {
 		material_[iMat] = new Material();
 	}
 	scanner.CheckType(scanner.Next(), Token::TK_OPENC);
@@ -63,7 +56,7 @@ void MetasequoiaMeshData::_ReadMaterial(gstd::Scanner& scanner)
 			break;
 
 		if (tok.GetType() == Token::TK_NEWLINE) {
-			posMat++;
+			++posMat;
 			if (material_.size() <= posMat)
 				break;
 			mat = material_[posMat].GetPointer();
@@ -78,7 +71,7 @@ void MetasequoiaMeshData::_ReadMaterial(gstd::Scanner& scanner)
 			color.a = scanner.Next().GetReal();
 			scanner.CheckType(scanner.Next(), Token::TK_CLOSEP);
 		} else if (tok.GetElement() == L"dif" || tok.GetElement() == L"amb" || tok.GetElement() == L"emi" || tok.GetElement() == L"spc") {
-			D3DCOLORVALUE* value = NULL;
+			D3DCOLORVALUE* value = nullptr;
 			if (tok.GetElement() == L"dif")
 				value = &mat->mat_.Diffuse;
 			else if (tok.GetElement() == L"amb")
@@ -90,7 +83,7 @@ void MetasequoiaMeshData::_ReadMaterial(gstd::Scanner& scanner)
 
 			scanner.CheckType(scanner.Next(), Token::TK_OPENP);
 			float num = scanner.Next().GetReal();
-			if (value != NULL) {
+			if (value != nullptr) {
 				value->a = color.a;
 				value->r = color.r * num;
 				value->g = color.g * num;
@@ -134,7 +127,7 @@ void MetasequoiaMeshData::_ReadObject(gstd::Scanner& scanner)
 			obj.vertices_.resize(count);
 			scanner.CheckType(scanner.Next(), Token::TK_OPENC);
 			scanner.CheckType(scanner.Next(), Token::TK_NEWLINE);
-			for (int iVert = 0; iVert < count; iVert++) {
+			for (int iVert = 0; iVert < count; ++iVert) {
 				obj.vertices_[iVert].x = scanner.Next().GetReal();
 				obj.vertices_[iVert].y = scanner.Next().GetReal();
 				obj.vertices_[iVert].z = -scanner.Next().GetReal();
@@ -148,7 +141,7 @@ void MetasequoiaMeshData::_ReadObject(gstd::Scanner& scanner)
 			scanner.CheckType(scanner.Next(), Token::TK_OPENC);
 			scanner.CheckType(scanner.Next(), Token::TK_NEWLINE);
 
-			for (int iFace = 0; iFace < countFace; iFace++) {
+			for (int iFace = 0; iFace < countFace; ++iFace) {
 				int countVert = scanner.Next().GetInteger();
 				obj.faces_[iFace].vertices_.resize(countVert);
 				MetasequoiaMeshData::Object::Face* face = &obj.faces_[iFace];
@@ -158,7 +151,7 @@ void MetasequoiaMeshData::_ReadObject(gstd::Scanner& scanner)
 						break;
 					if (tok.GetElement() == L"V") {
 						scanner.CheckType(scanner.Next(), Token::TK_OPENP);
-						for (int iVert = 0; iVert < countVert; iVert++)
+						for (int iVert = 0; iVert < countVert; ++iVert)
 							face->vertices_[iVert].indexVertex_ = scanner.Next().GetInteger();
 						scanner.CheckType(scanner.Next(), Token::TK_CLOSEP);
 					} else if (tok.GetElement() == L"M") {
@@ -167,7 +160,7 @@ void MetasequoiaMeshData::_ReadObject(gstd::Scanner& scanner)
 						scanner.CheckType(scanner.Next(), Token::TK_CLOSEP);
 					} else if (tok.GetElement() == L"UV") {
 						scanner.CheckType(scanner.Next(), Token::TK_OPENP);
-						for (int iVert = 0; iVert < countVert; iVert++) {
+						for (int iVert = 0; iVert < countVert; ++iVert) {
 							face->vertices_[iVert].tcoord_.x = scanner.Next().GetReal();
 							face->vertices_[iVert].tcoord_.y = scanner.Next().GetReal();
 						}
@@ -196,19 +189,17 @@ void MetasequoiaMeshData::_ReadObject(gstd::Scanner& scanner)
 		return;
 
 	//マテリアルごとに仕分けてオブジェクトを作成
-	std::map<int, std::list<MetasequoiaMeshData::Object::Face*>>::iterator itrMap;
-	for (itrMap = mapFace.begin(); itrMap != mapFace.end(); itrMap++) {
+	for (auto itrMap = mapFace.begin(); itrMap != mapFace.end(); ++itrMap) {
 		int indexMaterial = itrMap->first;
 		std::list<MetasequoiaMeshData::Object::Face*>& listFace = itrMap->second;
 
-		MetasequoiaMeshData::RenderObject* render = new MetasequoiaMeshData::RenderObject();
-		obj_.push_back(render);
+		auto* render = new MetasequoiaMeshData::RenderObject();
+		obj_.emplace_back(render);
 		if (indexMaterial >= 0)
 			render->material_ = material_[indexMaterial];
 
 		int countVert = 0;
-		std::list<MetasequoiaMeshData::Object::Face*>::iterator itrFace;
-		for (itrFace = listFace.begin(); itrFace != listFace.end(); itrFace++) {
+		for (auto itrFace = listFace.begin(); itrFace != listFace.end(); ++itrFace) {
 			MetasequoiaMeshData::Object::Face* face = *itrFace;
 			countVert += face->vertices_.size() == 3 ? 3 : 6;
 		}
@@ -217,7 +208,7 @@ void MetasequoiaMeshData::_ReadObject(gstd::Scanner& scanner)
 		listNormalData.resize(countVert);
 		render->SetVertexCount(countVert);
 		int posVert = 0;
-		for (itrFace = listFace.begin(); itrFace != listFace.end(); itrFace++) {
+		for (auto itrFace = listFace.begin(); itrFace != listFace.end(); ++itrFace) {
 			MetasequoiaMeshData::Object::Face* face = *itrFace;
 			if (face->vertices_.size() == 3) {
 				int indexVert[3] = {
@@ -273,7 +264,7 @@ void MetasequoiaMeshData::_ReadObject(gstd::Scanner& scanner)
 							obj.vertices_[indexVert[0]] - obj.vertices_[indexVert[2]]))
 				};
 
-				for (int iVert = 0; iVert < 6; iVert++) {
+				for (int iVert = 0; iVert < 6; ++iVert) {
 					int nxVertexIndex = posVert + iVert;
 					VERTEX_NX* vert = render->GetVertex(nxVertexIndex);
 
@@ -310,11 +301,8 @@ void MetasequoiaMeshData::_ReadObject(gstd::Scanner& scanner)
 				posVert += 6;
 			}
 		}
-
-		int countNormalData = listNormalData.size();
-		for (int iData = 0; iData < countNormalData; iData++) {
-			ref_count_ptr<NormalData> normalData = listNormalData[iData];
-			if (normalData != NULL) {
+		for (const auto& normalData : listNormalData) {
+			if (normalData != nullptr) {
 				int countVertexIndex = normalData->listIndex_.size();
 				for (int iVert = 0; iVert < countVertexIndex; iVert++) {
 					int nvVertexIndex = normalData->listIndex_[iVert];
@@ -331,8 +319,8 @@ void MetasequoiaMeshData::RenderObject::Render()
 {
 	IDirect3DDevice9* device = DirectGraphics::GetBase()->GetDevice();
 	MetasequoiaMeshData::Material* material = material_.GetPointer();
-	if (material != NULL) {
-		if (material->texture_ != NULL)
+	if (material != nullptr) {
+		if (material->texture_ != nullptr)
 			SetTexture(material->texture_);
 		D3DMATERIAL9 tMaterial = ColorAccess::SetColor(material->mat_, color_);
 		device->SetMaterial(&tMaterial);
@@ -347,27 +335,28 @@ bool MetasequoiaMesh::CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader>
 	bool res = false;
 	{
 		Lock lock(DxMeshManager::GetBase()->GetLock());
-		if (data_ != NULL)
+		if (data_ != nullptr)
 			Release();
 
 		std::wstring name = reader->GetOriginalPath();
 
 		data_ = _GetFromManager(name);
-		if (data_ == NULL) {
+		if (data_ == nullptr) {
 			if (!reader->Open())
 				throw gstd::wexception(L"ファイルが開けません");
 			data_ = new MetasequoiaMeshData();
 			data_->SetName(name);
-			MetasequoiaMeshData* data = (MetasequoiaMeshData*)data_.GetPointer();
+			auto* data = (MetasequoiaMeshData*)data_.GetPointer();
 			res = data->CreateFromFileReader(reader);
 			if (res) {
 				Logger::WriteTop(StringUtility::Format(L"メッシュを読み込みました[%s]", name.c_str()));
 				_AddManager(name, data_);
 			} else {
-				data_ = NULL;
+				data_ = nullptr;
 			}
-		} else
+		} else {
 			res = true;
+		}
 	}
 	return res;
 }
@@ -377,23 +366,23 @@ bool MetasequoiaMesh::CreateFromFileInLoadThread(const std::wstring& path)
 }
 std::wstring MetasequoiaMesh::GetPath()
 {
-	if (data_ == NULL)
+	if (data_ == nullptr)
 		return L"";
 	return ((MetasequoiaMeshData*)data_.GetPointer())->path_;
 }
 void MetasequoiaMesh::Render()
 {
-	if (data_ == NULL)
+	if (data_ == nullptr)
 		return;
 
-	MetasequoiaMeshData* data = (MetasequoiaMeshData*)data_.GetPointer();
+	auto* data = (MetasequoiaMeshData*)data_.GetPointer();
 
 	while (!data->bLoad_) {
 		::Sleep(1);
 	}
 
-	for (int iObj = 0; iObj < data->obj_.size(); iObj++) {
-		MetasequoiaMeshData::RenderObject* obj = (MetasequoiaMeshData::RenderObject*)data->obj_[iObj].GetPointer();
+	for (auto& iObj : data->obj_) {
+		auto* obj = (MetasequoiaMeshData::RenderObject*)iObj.GetPointer();
 		obj->SetShader(shader_);
 		obj->SetPosition(position_);
 		obj->SetAngle(angle_);
@@ -406,9 +395,9 @@ void MetasequoiaMesh::Render()
 std::vector<DxTriangle> MetasequoiaMesh::CreateIntersectionTriangles()
 {
 	std::vector<DxTriangle> res;
-	MetasequoiaMeshData* data = (MetasequoiaMeshData*)data_.GetPointer();
-	for (int iObj = 0; iObj < data->obj_.size(); iObj++) {
-		MetasequoiaMeshData::RenderObject* obj = (MetasequoiaMeshData::RenderObject*)data->obj_[iObj].GetPointer();
+	auto* data = (MetasequoiaMeshData*)data_.GetPointer();
+	for (auto& iObj : data->obj_) {
+		auto* obj = (MetasequoiaMeshData::RenderObject*)iObj.GetPointer();
 		int vertexCount = obj->GetVertexCount();
 		for (int iVert = 0; iVert < vertexCount - 2;) {
 			VERTEX_NX* nx1 = obj->GetVertex(iVert);

--- a/source/GcLib/directx/MetasequoiaMesh.hpp
+++ b/source/GcLib/directx/MetasequoiaMesh.hpp
@@ -96,7 +96,7 @@ public:
 	MetasequoiaMesh() {}
 	virtual ~MetasequoiaMesh() {}
 	virtual bool CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> reader);
-	virtual bool CreateFromFileInLoadThread(std::wstring path);
+	virtual bool CreateFromFileInLoadThread(const std::wstring& path);
 	virtual std::wstring GetPath();
 	virtual void Render();
 

--- a/source/GcLib/directx/MetasequoiaMesh.hpp
+++ b/source/GcLib/directx/MetasequoiaMesh.hpp
@@ -13,14 +13,13 @@ class MetasequoiaMeshData : public DxMeshData {
 	friend MetasequoiaMesh;
 
 public:
+	MetasequoiaMeshData();
+	~MetasequoiaMeshData() override;
+	bool CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> reader) override;
+
 	class Material;
 	class Object;
 	class RenderObject;
-
-public:
-	MetasequoiaMeshData();
-	~MetasequoiaMeshData();
-	bool CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> reader);
 
 protected:
 	std::wstring path_;
@@ -44,7 +43,7 @@ class MetasequoiaMeshData::Material {
 
 public:
 	Material() { ZeroMemory(&mat_, sizeof(D3DMATERIAL9)); };
-	virtual ~Material(){};
+	virtual ~Material() = default;
 
 protected:
 	std::wstring name_; //材質名
@@ -58,8 +57,8 @@ class MetasequoiaMeshData::Object {
 	friend MetasequoiaMeshData;
 
 public:
-	Object(){};
-	virtual ~Object(){};
+	Object() = default;
+	virtual ~Object() = default;
 
 protected:
 	struct Face {
@@ -82,9 +81,9 @@ class MetasequoiaMeshData::RenderObject : public RenderObjectNX {
 	friend MetasequoiaMeshData;
 
 public:
-	RenderObject(){};
-	virtual ~RenderObject(){};
-	virtual void Render();
+	RenderObject() = default;
+	~RenderObject() override = default;
+	void Render() override;
 
 protected:
 	gstd::ref_count_ptr<Material> material_;
@@ -93,12 +92,12 @@ protected:
 class MetasequoiaMesh : public DxMesh {
 protected:
 public:
-	MetasequoiaMesh() {}
-	virtual ~MetasequoiaMesh() {}
-	virtual bool CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> reader);
-	virtual bool CreateFromFileInLoadThread(const std::wstring& path);
-	virtual std::wstring GetPath();
-	virtual void Render();
+	MetasequoiaMesh() = default;
+	~MetasequoiaMesh() override = default;
+	bool CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> reader) override;
+	bool CreateFromFileInLoadThread(const std::wstring& path) override;
+	std::wstring GetPath() override;
+	void Render() override;
 
 	std::vector<DxTriangle> CreateIntersectionTriangles();
 };

--- a/source/GcLib/directx/RenderObject.cpp
+++ b/source/GcLib/directx/RenderObject.cpp
@@ -18,16 +18,16 @@ RenderBlock::RenderBlock()
 }
 RenderBlock::~RenderBlock()
 {
-	func_ = NULL;
-	obj_ = NULL;
+	func_ = nullptr;
+	obj_ = nullptr;
 }
 void RenderBlock::Render()
 {
-	RenderObject* obj = (RenderObject*)obj_.GetPointer();
+	auto* obj = (RenderObject*)obj_.GetPointer();
 	obj->SetPosition(position_);
 	obj->SetAngle(angle_);
 	obj->SetScale(scale_);
-	if (func_ != NULL)
+	if (func_ != nullptr)
 		func_->CallRenderStateFunction();
 	obj->Render();
 }
@@ -35,12 +35,8 @@ void RenderBlock::Render()
 /**********************************************************
 //RenderManager
 **********************************************************/
-RenderManager::RenderManager()
-{
-}
-RenderManager::~RenderManager()
-{
-}
+RenderManager::RenderManager() = default;
+RenderManager::~RenderManager() = default;
 void RenderManager::Render()
 {
 	DirectGraphics* graph = DirectGraphics::GetBase();
@@ -48,21 +44,19 @@ void RenderManager::Render()
 	//不透明
 	graph->SetZBufferEnable(true);
 	graph->SetZWriteEnalbe(true);
-	std::list<gstd::ref_count_ptr<RenderBlock>>::iterator itrOpaque;
-	for (itrOpaque = listBlockOpaque_.begin(); itrOpaque != listBlockOpaque_.end(); itrOpaque++) {
-		(*itrOpaque)->Render();
+	for (auto& opaqueBlock : listBlockOpaque_) {
+		opaqueBlock->Render();
 	}
 
 	//半透明
 	graph->SetZBufferEnable(true);
 	graph->SetZWriteEnalbe(false);
-	std::list<gstd::ref_count_ptr<RenderBlock>>::iterator itrTrans;
-	for (itrTrans = listBlockTranslucent_.begin(); itrTrans != listBlockTranslucent_.end(); itrTrans++) {
-		(*itrTrans)->CalculateZValue();
+	for (auto& translucentBlock : listBlockTranslucent_) {
+		translucentBlock->CalculateZValue();
 	}
 	listBlockTranslucent_.sort([](auto l, auto r) { return l->GetZValue() > r->GetZValue(); });
-	for (itrTrans = listBlockTranslucent_.begin(); itrTrans != listBlockTranslucent_.end(); itrTrans++) {
-		(*itrTrans)->Render();
+	for (auto& translucentBlock : listBlockTranslucent_) {
+		translucentBlock->Render();
 	}
 
 	listBlockOpaque_.clear();
@@ -70,7 +64,7 @@ void RenderManager::Render()
 }
 void RenderManager::AddBlock(gstd::ref_count_ptr<RenderBlock> block)
 {
-	if (block == NULL)
+	if (block == nullptr)
 		return;
 	if (block->IsTranslucent()) {
 		listBlockTranslucent_.push_back(block);
@@ -88,16 +82,11 @@ void RenderManager::AddBlock(gstd::ref_count_ptr<RenderBlocks> blocks)
 /**********************************************************
 //RenderStateFunction
 **********************************************************/
-RenderStateFunction::RenderStateFunction()
-{
-}
-RenderStateFunction::~RenderStateFunction()
-{
-}
+RenderStateFunction::RenderStateFunction() = default;
+RenderStateFunction::~RenderStateFunction() = default;
 void RenderStateFunction::CallRenderStateFunction()
 {
-	std::map<RenderStateFunction::FUNC_TYPE, gstd::ref_count_ptr<gstd::ByteBuffer>>::iterator itr;
-	for (itr = mapFuncRenderState_.begin(); itr != mapFuncRenderState_.end(); itr++) {
+	for (auto itr = mapFuncRenderState_.begin(); itr != mapFuncRenderState_.end(); ++itr) {
 		RenderStateFunction::FUNC_TYPE type = (*itr).first;
 		gstd::ByteBuffer* args = (*itr).second.GetPointer();
 		args->Seek(0);
@@ -113,7 +102,7 @@ void RenderStateFunction::CallRenderStateFunction()
 void RenderStateFunction::SetLightingEnable(bool bEnable)
 {
 	int sizeArgs = sizeof(bEnable);
-	gstd::ByteBuffer* args = new gstd::ByteBuffer();
+	auto* args = new gstd::ByteBuffer();
 	args->SetSize(sizeArgs);
 	args->WriteBoolean(bEnable);
 	mapFuncRenderState_[RenderStateFunction::FUNC_LIGHTING] = args;
@@ -121,7 +110,7 @@ void RenderStateFunction::SetLightingEnable(bool bEnable)
 void RenderStateFunction::SetCullingMode(DWORD mode)
 {
 	int sizeArgs = sizeof(mode);
-	gstd::ByteBuffer* args = new gstd::ByteBuffer();
+	auto* args = new gstd::ByteBuffer();
 	args->SetSize(sizeArgs);
 	args->WriteInteger(mode);
 	mapFuncRenderState_[RenderStateFunction::FUNC_CULLING] = args;
@@ -129,7 +118,7 @@ void RenderStateFunction::SetCullingMode(DWORD mode)
 void RenderStateFunction::SetZBufferEnable(bool bEnable)
 {
 	int sizeArgs = sizeof(bEnable);
-	gstd::ByteBuffer* args = new gstd::ByteBuffer();
+	auto* args = new gstd::ByteBuffer();
 	args->SetSize(sizeArgs);
 	args->WriteBoolean(bEnable);
 	mapFuncRenderState_[RenderStateFunction::FUNC_ZBUFFER_ENABLE] = args;
@@ -137,7 +126,7 @@ void RenderStateFunction::SetZBufferEnable(bool bEnable)
 void RenderStateFunction::SetZWriteEnalbe(bool bEnable)
 {
 	int sizeArgs = sizeof(bEnable);
-	gstd::ByteBuffer* args = new gstd::ByteBuffer();
+	auto* args = new gstd::ByteBuffer();
 	args->SetSize(sizeArgs);
 	args->WriteBoolean(bEnable);
 	mapFuncRenderState_[RenderStateFunction::FUNC_ZBUFFER_WRITE_ENABLE] = args;
@@ -145,7 +134,7 @@ void RenderStateFunction::SetZWriteEnalbe(bool bEnable)
 void RenderStateFunction::SetBlendMode(DWORD mode, int stage)
 {
 	int sizeArgs = sizeof(mode) + sizeof(stage);
-	gstd::ByteBuffer* args = new gstd::ByteBuffer();
+	auto* args = new gstd::ByteBuffer();
 	args->SetSize(sizeArgs);
 	args->WriteInteger(mode);
 	args->WriteInteger(stage);
@@ -154,7 +143,7 @@ void RenderStateFunction::SetBlendMode(DWORD mode, int stage)
 void RenderStateFunction::SetTextureFilter(DWORD mode, int stage)
 {
 	int sizeArgs = sizeof(mode) + sizeof(stage);
-	gstd::ByteBuffer* args = new gstd::ByteBuffer();
+	auto* args = new gstd::ByteBuffer();
 	args->SetSize(sizeArgs);
 	args->WriteInteger(mode);
 	args->WriteInteger(stage);
@@ -167,15 +156,15 @@ void RenderStateFunction::SetTextureFilter(DWORD mode, int stage)
 RenderObject::RenderObject()
 {
 	typePrimitive_ = D3DPT_TRIANGLELIST;
-	position_ = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
-	angle_ = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
-	scale_ = D3DXVECTOR3(1.0f, 1.0f, 1.0f);
-	posWeightCenter_ = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
+	position_ = D3DXVECTOR3(0.0F, 0.0F, 0.0F);
+	angle_ = D3DXVECTOR3(0.0F, 0.0F, 0.0F);
+	scale_ = D3DXVECTOR3(1.0F, 1.0F, 1.0F);
+	posWeightCenter_ = D3DXVECTOR3(0.0F, 0.0F, 0.0F);
 	D3DXMatrixIdentity(&matRelative_);
 
-	pVertexDecl_ = NULL;
-	pVertexBuffer_ = NULL;
-	pIndexBuffer_ = NULL;
+	pVertexDecl_ = nullptr;
+	pVertexBuffer_ = nullptr;
+	pIndexBuffer_ = nullptr;
 	bCoordinate2D_ = false;
 }
 RenderObject::~RenderObject()
@@ -184,15 +173,15 @@ RenderObject::~RenderObject()
 }
 void RenderObject::_ReleaseVertexBuffer()
 {
-	if (pIndexBuffer_ != NULL)
+	if (pIndexBuffer_ != nullptr)
 		pIndexBuffer_->Release();
-	if (pVertexBuffer_ != NULL)
+	if (pVertexBuffer_ != nullptr)
 		pVertexBuffer_->Release();
-	if (pVertexDecl_ != NULL)
+	if (pVertexDecl_ != nullptr)
 		pVertexDecl_->Release();
-	pVertexDecl_ = NULL;
-	pVertexBuffer_ = NULL;
-	pIndexBuffer_ = NULL;
+	pVertexDecl_ = nullptr;
+	pVertexBuffer_ = nullptr;
+	pIndexBuffer_ = nullptr;
 }
 void RenderObject::_RestoreVertexBuffer()
 {
@@ -202,7 +191,7 @@ int RenderObject::_GetPrimitiveCount() const
 {
 	int res = 0;
 	int count = GetVertexCount();
-	if (vertexIndices_.size() != 0)
+	if (!vertexIndices_.empty())
 		count = vertexIndices_.size();
 	switch (typePrimitive_) {
 	case D3DPT_POINTLIST: //ポイントリスト
@@ -231,26 +220,23 @@ D3DXMATRIX RenderObject::_CreateWorldTransformMaxtrix()
 {
 	D3DXMATRIX mat;
 	D3DXMatrixIdentity(&mat);
-	bool bPos = position_.x != 0.0f || position_.y != 0.0f || position_.z != 0.0f;
-	bool bAngle = angle_.x != 0.0f || angle_.y != 0.0f || angle_.z != 0.0f;
-	bool bScale = scale_.x != 1.0f || scale_.y != 1.0f || scale_.z != 1.0f;
-	if (bPos || bAngle || bScale) {
-		if (bScale) {
-			D3DXMATRIX matScale;
-			D3DXMatrixScaling(&matScale, scale_.x, scale_.y, scale_.z);
-			mat = mat * matScale;
-		}
-		if (bAngle) {
-			D3DXMATRIX matRot;
-			D3DXMatrixRotationYawPitchRoll(&matRot, D3DXToRadian(angle_.y), D3DXToRadian(angle_.x), D3DXToRadian(angle_.z));
-			mat = mat * matRot;
-		}
-
-		if (bPos) {
-			D3DXMATRIX matTrans;
-			D3DXMatrixTranslation(&matTrans, position_.x, position_.y, position_.z);
-			mat = mat * matTrans;
-		}
+	bool bPos = position_.x != 0.0F || position_.y != 0.0F || position_.z != 0.0F;
+	bool bAngle = angle_.x != 0.0F || angle_.y != 0.0F || angle_.z != 0.0F;
+	bool bScale = scale_.x != 1.0F || scale_.y != 1.0F || scale_.z != 1.0F;
+	if (bScale) {
+		D3DXMATRIX matScale;
+		D3DXMatrixScaling(&matScale, scale_.x, scale_.y, scale_.z);
+		mat = mat * matScale;
+	}
+	if (bAngle) {
+		D3DXMATRIX matRot;
+		D3DXMatrixRotationYawPitchRoll(&matRot, D3DXToRadian(angle_.y), D3DXToRadian(angle_.x), D3DXToRadian(angle_.z));
+		mat = mat * matRot;
+	}
+	if (bPos) {
+		D3DXMATRIX matTrans;
+		D3DXMatrixTranslation(&matTrans, position_.x, position_.y, position_.z);
+		mat = mat * matTrans;
 	}
 	mat = mat * matRelative_;
 
@@ -271,10 +257,10 @@ D3DXMATRIX RenderObject::_CreateWorldTransformMaxtrix()
 
 		D3DXMATRIX matViewPort;
 		D3DXMatrixIdentity(&matViewPort);
-		matViewPort._11 = width / 2.0f;
-		matViewPort._41 = width / 2.0f;
-		matViewPort._22 = -height / 2.0f;
-		matViewPort._42 = height / 2.0f;
+		matViewPort._11 = width / 2.0F;
+		matViewPort._41 = width / 2.0F;
+		matViewPort._22 = -height / 2.0F;
+		matViewPort._42 = height / 2.0F;
 
 		D3DXMATRIX matView;
 		device->GetTransform(D3DTS_VIEW, &matView);
@@ -283,18 +269,18 @@ D3DXMATRIX RenderObject::_CreateWorldTransformMaxtrix()
 
 		D3DXMATRIX matTrans;
 		D3DXMatrixIdentity(&matTrans);
-		D3DXMatrixTranslation(&matTrans, -width / 2.0f, -height / 2.0f, 0);
+		D3DXMatrixTranslation(&matTrans, -width / 2.0F, -height / 2.0F, 0);
 
 		D3DXMATRIX matScale;
 		D3DXMatrixIdentity(&matScale);
-		D3DXMatrixScaling(&matScale, 200.0f, 200.0f, -0.002f);
+		D3DXMatrixScaling(&matScale, 200.0F, 200.0F, -0.002F);
 
 		D3DXMATRIX matInvView;
 		D3DXMATRIX matInvProj;
 		D3DXMATRIX matInvViewPort;
-		D3DXMatrixInverse(&matInvView, NULL, &matView);
-		D3DXMatrixInverse(&matInvProj, NULL, &matProj);
-		D3DXMatrixInverse(&matInvViewPort, NULL, &matViewPort);
+		D3DXMatrixInverse(&matInvView, nullptr, &matView);
+		D3DXMatrixInverse(&matInvProj, nullptr, &matProj);
+		D3DXMatrixInverse(&matInvViewPort, nullptr, &matViewPort);
 
 		mat = mat * matTrans * matScale * matInvViewPort * matInvProj * matInvView;
 		mat._43 *= -1;
@@ -326,8 +312,8 @@ void RenderObject::_SetCoordinate2dDeviceMatrix()
 }
 void RenderObject::SetTexture(const Texture* texture, int stage)
 {
-	if (texture == NULL)
-		texture_[stage] = NULL;
+	if (texture == nullptr)
+		texture_[stage] = nullptr;
 	else {
 		if (stage >= texture_.size())
 			return;
@@ -336,8 +322,8 @@ void RenderObject::SetTexture(const Texture* texture, int stage)
 }
 void RenderObject::SetTexture(ref_count_ptr<Texture> texture, int stage)
 {
-	if (texture == NULL)
-		texture_[stage] = NULL;
+	if (texture == nullptr)
+		texture_[stage] = nullptr;
 	else {
 		if (stage >= texture_.size())
 			return;
@@ -346,7 +332,7 @@ void RenderObject::SetTexture(ref_count_ptr<Texture> texture, int stage)
 }
 void RenderObject::BeginShader()
 {
-	if (shader_ == NULL)
+	if (shader_ == nullptr)
 		return;
 
 	// if(pVertexDecl_ == NULL)
@@ -360,13 +346,13 @@ void RenderObject::BeginShader()
 }
 void RenderObject::EndShader()
 {
-	if (shader_ == NULL)
+	if (shader_ == nullptr)
 		return;
 	shader_->End();
 
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	IDirect3DDevice9* device = graphics->GetDevice();
-	device->SetVertexDeclaration(NULL);
+	device->SetVertexDeclaration(nullptr);
 }
 
 /**********************************************************
@@ -379,12 +365,10 @@ RenderObjectTLX::RenderObjectTLX()
 	strideVertexStreamZero_ = sizeof(VERTEX_TLX);
 	bPermitCamera_ = true;
 }
-RenderObjectTLX::~RenderObjectTLX()
-{
-}
+RenderObjectTLX::~RenderObjectTLX() = default;
 void RenderObjectTLX::_CreateVertexDeclaration()
 {
-	if (pVertexDecl_ != NULL)
+	if (pVertexDecl_ != nullptr)
 		return;
 
 	//D3DFVF_XYZRHW|D3DFVF_DIFFUSE|D3DFVF_TEX1
@@ -403,16 +387,16 @@ void RenderObjectTLX::Render()
 	DxCamera2D* camera = graphics->GetCamera2D().GetPointer();
 	IDirect3DDevice9* device = graphics->GetDevice();
 	ref_count_ptr<Texture>& texture = texture_[0];
-	if (texture != NULL)
+	if (texture != nullptr)
 		device->SetTexture(0, texture->GetD3DTexture());
 	else
-		device->SetTexture(0, NULL);
+		device->SetTexture(0, nullptr);
 	device->SetFVF(VERTEX_TLX::fvf);
 
 	//座標変換
-	bool bPos = position_.x != 0.0f || position_.y != 0.0f || position_.z != 0.0f;
-	bool bAngle = angle_.x != 0.0f || angle_.y != 0.0f || angle_.z != 0.0f;
-	bool bScale = scale_.x != 1.0f || scale_.y != 1.0f || scale_.z != 1.0f;
+	bool bPos = position_.x != 0.0F || position_.y != 0.0F || position_.z != 0.0F;
+	bool bAngle = angle_.x != 0.0F || angle_.y != 0.0F || angle_.z != 0.0F;
+	bool bScale = scale_.x != 1.0F || scale_.y != 1.0F || scale_.z != 1.0F;
 	bool bCamera = camera->IsEnable() && bPermitCamera_;
 	if (bPos || bAngle || bScale || bCamera) {
 		//座標変換有りなら、座標3D変換済みなため自前で変換をかける
@@ -444,16 +428,15 @@ void RenderObjectTLX::Render()
 
 		//各頂点と行列の積を計算する
 		int countVertex = GetVertexCount();
-		for (int iVert = 0; iVert < countVertex; iVert++) {
+		for (int iVert = 0; iVert < countVertex; ++iVert) {
 			int pos = iVert * strideVertexStreamZero_;
-			VERTEX_TLX* vert = (VERTEX_TLX*)vertCopy_.GetPointer(pos);
+			auto* vert = (VERTEX_TLX*)vertCopy_.GetPointer(pos);
 			D3DXVec3TransformCoord((D3DXVECTOR3*)&vert->position, (D3DXVECTOR3*)&vert->position, &mat);
 		}
 
 		//描画
 		BeginShader();
-		int oldSamplerState = 0;
-		if (vertexIndices_.size() == 0) {
+		if (vertexIndices_.empty()) {
 			device->DrawPrimitiveUP(typePrimitive_, _GetPrimitiveCount(), vertCopy_.GetPointer(), strideVertexStreamZero_);
 		} else {
 			device->DrawIndexedPrimitiveUP(typePrimitive_, 0,
@@ -468,7 +451,7 @@ void RenderObjectTLX::Render()
 	} else {
 		//座標変換無しならそのまま描画
 		BeginShader();
-		if (vertexIndices_.size() == 0) {
+		if (vertexIndices_.empty()) {
 			device->DrawPrimitiveUP(typePrimitive_, _GetPrimitiveCount(), vertex_.GetPointer(), strideVertexStreamZero_);
 		} else {
 			device->DrawIndexedPrimitiveUP(typePrimitive_, 0,
@@ -489,7 +472,7 @@ VERTEX_TLX* RenderObjectTLX::GetVertex(int index)
 {
 	int pos = index * strideVertexStreamZero_;
 	if (pos >= vertex_.GetSize())
-		return NULL;
+		return nullptr;
 	return (VERTEX_TLX*)vertex_.GetPointer(pos);
 }
 void RenderObjectTLX::SetVertex(int index, const VERTEX_TLX& vertex)
@@ -502,10 +485,10 @@ void RenderObjectTLX::SetVertex(int index, const VERTEX_TLX& vertex)
 void RenderObjectTLX::SetVertexPosition(int index, float x, float y, float z, float w)
 {
 	VERTEX_TLX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 
-	float bias = -0.5f;
+	float bias = -0.5F;
 	vertex->position.x = x + bias;
 	vertex->position.y = y + bias;
 	vertex->position.z = z;
@@ -514,7 +497,7 @@ void RenderObjectTLX::SetVertexPosition(int index, float x, float y, float z, fl
 void RenderObjectTLX::SetVertexUV(int index, float u, float v)
 {
 	VERTEX_TLX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	vertex->texcoord.x = u;
 	vertex->texcoord.y = v;
@@ -522,21 +505,21 @@ void RenderObjectTLX::SetVertexUV(int index, float u, float v)
 void RenderObjectTLX::SetVertexColor(int index, D3DCOLOR color)
 {
 	VERTEX_TLX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	vertex->diffuse_color = color;
 }
 void RenderObjectTLX::SetVertexColorARGB(int index, int a, int r, int g, int b)
 {
 	VERTEX_TLX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	vertex->diffuse_color = D3DCOLOR_ARGB(a, r, g, b);
 }
 void RenderObjectTLX::SetVertexAlpha(int index, int alpha)
 {
 	VERTEX_TLX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	D3DCOLOR& color = vertex->diffuse_color;
 	ColorAccess::SetColorA(color, alpha);
@@ -544,7 +527,7 @@ void RenderObjectTLX::SetVertexAlpha(int index, int alpha)
 void RenderObjectTLX::SetVertexColorRGB(int index, int r, int g, int b)
 {
 	VERTEX_TLX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	D3DCOLOR& color = vertex->diffuse_color;
 	ColorAccess::SetColorR(color, r);
@@ -556,13 +539,13 @@ void RenderObjectTLX::SetColorRGB(D3DCOLOR color)
 	int r = ColorAccess::GetColorR(color);
 	int g = ColorAccess::GetColorG(color);
 	int b = ColorAccess::GetColorB(color);
-	for (int iVert = 0; iVert < vertex_.GetSize(); iVert++) {
+	for (int iVert = 0; iVert < vertex_.GetSize(); ++iVert) {
 		SetVertexColorRGB(iVert, r, g, b);
 	}
 }
 void RenderObjectTLX::SetAlpha(int alpha)
 {
-	for (int iVert = 0; iVert < vertex_.GetSize(); iVert++) {
+	for (int iVert = 0; iVert < vertex_.GetSize(); ++iVert) {
 		SetVertexAlpha(iVert, alpha);
 	}
 }
@@ -575,12 +558,10 @@ RenderObjectLX::RenderObjectLX()
 	_SetTextureStageCount(1);
 	strideVertexStreamZero_ = sizeof(VERTEX_LX);
 }
-RenderObjectLX::~RenderObjectLX()
-{
-}
+RenderObjectLX::~RenderObjectLX() = default;
 void RenderObjectLX::_CreateVertexDeclaration()
 {
-	if (pVertexDecl_ != NULL)
+	if (pVertexDecl_ != nullptr)
 		return;
 
 	//D3DFVF_XYZ|D3DFVF_DIFFUSE|D3DFVF_TEX1
@@ -597,10 +578,10 @@ void RenderObjectLX::Render()
 {
 	IDirect3DDevice9* device = DirectGraphics::GetBase()->GetDevice();
 	ref_count_ptr<Texture>& texture = texture_[0];
-	if (texture != NULL)
+	if (texture != nullptr)
 		device->SetTexture(0, texture->GetD3DTexture());
 	else
-		device->SetTexture(0, NULL);
+		device->SetTexture(0, nullptr);
 
 	D3DXMATRIX mat = _CreateWorldTransformMaxtrix();
 	device->SetTransform(D3DTS_WORLD, &mat);
@@ -608,7 +589,7 @@ void RenderObjectLX::Render()
 	device->SetFVF(VERTEX_LX::fvf);
 
 	BeginShader();
-	if (vertexIndices_.size() == 0) {
+	if (vertexIndices_.empty()) {
 		device->DrawPrimitiveUP(typePrimitive_, _GetPrimitiveCount(), vertex_.GetPointer(), strideVertexStreamZero_);
 	} else {
 		device->DrawIndexedPrimitiveUP(typePrimitive_, 0,
@@ -628,7 +609,7 @@ VERTEX_LX* RenderObjectLX::GetVertex(int index)
 {
 	int pos = index * strideVertexStreamZero_;
 	if (pos >= vertex_.GetSize())
-		return NULL;
+		return nullptr;
 	return (VERTEX_LX*)vertex_.GetPointer(pos);
 }
 void RenderObjectLX::SetVertex(int index, VERTEX_LX& vertex)
@@ -641,10 +622,10 @@ void RenderObjectLX::SetVertex(int index, VERTEX_LX& vertex)
 void RenderObjectLX::SetVertexPosition(int index, float x, float y, float z)
 {
 	VERTEX_LX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 
-	float bias = -0.5f;
+	float bias = -0.5F;
 	vertex->position.x = x + bias;
 	vertex->position.y = y + bias;
 	vertex->position.z = z;
@@ -652,7 +633,7 @@ void RenderObjectLX::SetVertexPosition(int index, float x, float y, float z)
 void RenderObjectLX::SetVertexUV(int index, float u, float v)
 {
 	VERTEX_LX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	vertex->texcoord.x = u;
 	vertex->texcoord.y = v;
@@ -660,21 +641,21 @@ void RenderObjectLX::SetVertexUV(int index, float u, float v)
 void RenderObjectLX::SetVertexColor(int index, D3DCOLOR color)
 {
 	VERTEX_LX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	vertex->diffuse_color = color;
 }
 void RenderObjectLX::SetVertexColorARGB(int index, int a, int r, int g, int b)
 {
 	VERTEX_LX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	vertex->diffuse_color = D3DCOLOR_ARGB(a, r, g, b);
 }
 void RenderObjectLX::SetVertexAlpha(int index, int alpha)
 {
 	VERTEX_LX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	D3DCOLOR& color = vertex->diffuse_color;
 	ColorAccess::SetColorA(color, alpha);
@@ -682,7 +663,7 @@ void RenderObjectLX::SetVertexAlpha(int index, int alpha)
 void RenderObjectLX::SetVertexColorRGB(int index, int r, int g, int b)
 {
 	VERTEX_LX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	D3DCOLOR& color = vertex->diffuse_color;
 	ColorAccess::SetColorR(color, r);
@@ -694,13 +675,13 @@ void RenderObjectLX::SetColorRGB(D3DCOLOR color)
 	int r = ColorAccess::GetColorR(color);
 	int g = ColorAccess::GetColorG(color);
 	int b = ColorAccess::GetColorB(color);
-	for (int iVert = 0; iVert < vertex_.GetSize(); iVert++) {
+	for (int iVert = 0; iVert < vertex_.GetSize(); ++iVert) {
 		SetVertexColorRGB(iVert, r, g, b);
 	}
 }
 void RenderObjectLX::SetAlpha(int alpha)
 {
-	for (int iVert = 0; iVert < vertex_.GetSize(); iVert++) {
+	for (int iVert = 0; iVert < vertex_.GetSize(); ++iVert) {
 		SetVertexAlpha(iVert, alpha);
 	}
 }
@@ -712,12 +693,10 @@ RenderObjectNX::RenderObjectNX()
 	_SetTextureStageCount(1);
 	strideVertexStreamZero_ = sizeof(VERTEX_NX);
 }
-RenderObjectNX::~RenderObjectNX()
-{
-}
+RenderObjectNX::~RenderObjectNX() = default;
 void RenderObjectNX::_CreateVertexDeclaration()
 {
-	if (pVertexDecl_ != NULL)
+	if (pVertexDecl_ != nullptr)
 		return;
 
 	//D3DFVF_XYZ|D3DFVF_NORMAL|D3DFVF_TEX1
@@ -734,10 +713,10 @@ void RenderObjectNX::Render()
 {
 	IDirect3DDevice9* device = DirectGraphics::GetBase()->GetDevice();
 	ref_count_ptr<Texture>& texture = texture_[0];
-	if (texture != NULL)
+	if (texture != nullptr)
 		device->SetTexture(0, texture->GetD3DTexture());
 	else
-		device->SetTexture(0, NULL);
+		device->SetTexture(0, nullptr);
 
 	DWORD bFogEnable = FALSE;
 	D3DXMATRIX matView;
@@ -755,7 +734,7 @@ void RenderObjectNX::Render()
 
 	device->SetFVF(VERTEX_NX::fvf);
 	BeginShader();
-	if (vertexIndices_.size() == 0) {
+	if (vertexIndices_.empty()) {
 		device->DrawPrimitiveUP(typePrimitive_, _GetPrimitiveCount(), vertex_.GetPointer(), strideVertexStreamZero_);
 	} else {
 		device->DrawIndexedPrimitiveUP(typePrimitive_, 0,
@@ -775,7 +754,7 @@ VERTEX_NX* RenderObjectNX::GetVertex(int index)
 {
 	int pos = index * strideVertexStreamZero_;
 	if (pos >= vertex_.GetSize())
-		return NULL;
+		return nullptr;
 	return (VERTEX_NX*)vertex_.GetPointer(pos);
 }
 void RenderObjectNX::SetVertex(int index, const VERTEX_NX& vertex)
@@ -788,10 +767,10 @@ void RenderObjectNX::SetVertex(int index, const VERTEX_NX& vertex)
 void RenderObjectNX::SetVertexPosition(int index, float x, float y, float z)
 {
 	VERTEX_NX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 
-	float bias = -0.5f;
+	float bias = -0.5F;
 	vertex->position.x = x + bias;
 	vertex->position.y = y + bias;
 	vertex->position.z = z;
@@ -799,7 +778,7 @@ void RenderObjectNX::SetVertexPosition(int index, float x, float y, float z)
 void RenderObjectNX::SetVertexUV(int index, float u, float v)
 {
 	VERTEX_NX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	vertex->texcoord.x = u;
 	vertex->texcoord.y = v;
@@ -807,7 +786,7 @@ void RenderObjectNX::SetVertexUV(int index, float u, float v)
 void RenderObjectNX::SetVertexNormal(int index, float x, float y, float z)
 {
 	VERTEX_NX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	vertex->normal.x = x;
 	vertex->normal.y = y;
@@ -823,29 +802,27 @@ RenderObjectBNX::RenderObjectBNX()
 	color_ = D3DCOLOR_ARGB(255, 255, 255, 255);
 
 	_CreateVertexDeclaration();
-	materialBNX_.Diffuse.a = 1.0f;
-	materialBNX_.Diffuse.r = 1.0f;
-	materialBNX_.Diffuse.g = 1.0f;
-	materialBNX_.Diffuse.b = 1.0f;
-	materialBNX_.Ambient.a = 1.0f;
-	materialBNX_.Ambient.r = 1.0f;
-	materialBNX_.Ambient.g = 1.0f;
-	materialBNX_.Ambient.b = 1.0f;
-	materialBNX_.Specular.a = 1.0f;
-	materialBNX_.Specular.r = 1.0f;
-	materialBNX_.Specular.g = 1.0f;
-	materialBNX_.Specular.b = 1.0f;
-	materialBNX_.Emissive.a = 1.0f;
-	materialBNX_.Emissive.r = 1.0f;
-	materialBNX_.Emissive.g = 1.0f;
-	materialBNX_.Emissive.b = 1.0f;
+	materialBNX_.Diffuse.a = 1.0F;
+	materialBNX_.Diffuse.r = 1.0F;
+	materialBNX_.Diffuse.g = 1.0F;
+	materialBNX_.Diffuse.b = 1.0F;
+	materialBNX_.Ambient.a = 1.0F;
+	materialBNX_.Ambient.r = 1.0F;
+	materialBNX_.Ambient.g = 1.0F;
+	materialBNX_.Ambient.b = 1.0F;
+	materialBNX_.Specular.a = 1.0F;
+	materialBNX_.Specular.r = 1.0F;
+	materialBNX_.Specular.g = 1.0F;
+	materialBNX_.Specular.b = 1.0F;
+	materialBNX_.Emissive.a = 1.0F;
+	materialBNX_.Emissive.r = 1.0F;
+	materialBNX_.Emissive.g = 1.0F;
+	materialBNX_.Emissive.b = 1.0F;
 }
-RenderObjectBNX::~RenderObjectBNX()
-{
-}
+RenderObjectBNX::~RenderObjectBNX() = default;
 void RenderObjectBNX::_CreateVertexDeclaration()
 {
-	if (pVertexDecl_ != NULL)
+	if (pVertexDecl_ != nullptr)
 		return;
 	IDirect3DDevice9* device = DirectGraphics::GetBase()->GetDevice();
 	D3DVERTEXELEMENT9 element[] = {
@@ -862,7 +839,7 @@ void RenderObjectBNX::InitializeVertexBuffer()
 {
 	int countVertex = GetVertexCount();
 	IDirect3DDevice9* device = DirectGraphics::GetBase()->GetDevice();
-	device->CreateVertexBuffer(countVertex * sizeof(Vertex), 0, 0, D3DPOOL_MANAGED, &pVertexBuffer_, NULL);
+	device->CreateVertexBuffer(countVertex * sizeof(Vertex), 0, 0, D3DPOOL_MANAGED, &pVertexBuffer_, nullptr);
 
 	//コピー
 	_CopyVertexBufferOnInitialize();
@@ -870,7 +847,7 @@ void RenderObjectBNX::InitializeVertexBuffer()
 	int countIndex = vertexIndices_.size();
 	if (countIndex != 0) {
 		device->CreateIndexBuffer(sizeof(short) * countIndex,
-			D3DUSAGE_WRITEONLY, D3DFMT_INDEX16, D3DPOOL_MANAGED, &pIndexBuffer_, NULL);
+			D3DUSAGE_WRITEONLY, D3DFMT_INDEX16, D3DPOOL_MANAGED, &pIndexBuffer_, nullptr);
 
 		BYTE* bufIndex;
 		HRESULT hrLockIndex = pIndexBuffer_->Lock(0, 0, reinterpret_cast<void**>(&bufIndex), 0);
@@ -884,10 +861,10 @@ void RenderObjectBNX::Render()
 {
 	IDirect3DDevice9* device = DirectGraphics::GetBase()->GetDevice();
 	ref_count_ptr<Texture>& texture = texture_[0];
-	if (texture != NULL)
+	if (texture != nullptr)
 		device->SetTexture(0, texture->GetD3DTexture());
 	else
-		device->SetTexture(0, NULL);
+		device->SetTexture(0, nullptr);
 
 	DWORD bFogEnable = FALSE;
 	D3DXMATRIX matView;
@@ -905,7 +882,7 @@ void RenderObjectBNX::Render()
 		device->SetTransform(D3DTS_WORLD, &mat);
 
 		int sizeMatrix = matrix_->GetSize();
-		for (int iMatrix = 0; iMatrix < sizeMatrix; iMatrix++) {
+		for (int iMatrix = 0; iMatrix < sizeMatrix; ++iMatrix) {
 			D3DXMATRIX matrix = matrix_->GetMatrix(iMatrix) * mat;
 			device->SetTransform(D3DTS_WORLDMATRIX(iMatrix),
 				&matrix);
@@ -915,7 +892,7 @@ void RenderObjectBNX::Render()
 		device->SetRenderState(D3DRS_VERTEXBLEND, D3DVBF_1WEIGHTS);
 
 		device->SetFVF(VERTEX_B2NX::fvf);
-		if (vertexIndices_.size() == 0) {
+		if (vertexIndices_.empty()) {
 			device->DrawPrimitiveUP(typePrimitive_, _GetPrimitiveCount(), vertex_.GetPointer(), strideVertexStreamZero_);
 		} else {
 			device->DrawIndexedPrimitiveUP(typePrimitive_, 0,
@@ -929,7 +906,7 @@ void RenderObjectBNX::Render()
 	} else {
 		ShaderManager* manager = ShaderManager::GetBase();
 		ref_count_ptr<Shader> shader = manager->GetDefaultSkinnedMeshShader();
-		if (shader != NULL) {
+		if (shader != nullptr) {
 			shader->SetTechnique("BasicTec");
 
 			D3DXMATRIX matView;
@@ -943,15 +920,15 @@ void RenderObjectBNX::Render()
 			D3DLIGHT9 light;
 			device->GetLight(0, &light);
 			D3DCOLORVALUE diffuse = materialBNX_.Diffuse;
-			diffuse.r = min(diffuse.r + light.Diffuse.r, 1.0f);
-			diffuse.g = min(diffuse.g + light.Diffuse.g, 1.0f);
-			diffuse.b = min(diffuse.b + light.Diffuse.b, 1.0f);
+			diffuse.r = min(diffuse.r + light.Diffuse.r, 1.0F);
+			diffuse.g = min(diffuse.g + light.Diffuse.g, 1.0F);
+			diffuse.b = min(diffuse.b + light.Diffuse.b, 1.0F);
 			diffuse = ColorAccess::SetColor(diffuse, color_);
 
 			D3DCOLORVALUE ambient = materialBNX_.Ambient;
-			ambient.r = min(ambient.r + light.Ambient.r, 1.0f);
-			ambient.g = min(ambient.g + light.Ambient.g, 1.0f);
-			ambient.b = min(ambient.b + light.Ambient.b, 1.0f);
+			ambient.r = min(ambient.r + light.Ambient.r, 1.0F);
+			ambient.g = min(ambient.g + light.Ambient.g, 1.0F);
+			ambient.b = min(ambient.b + light.Ambient.b, 1.0F);
 			ambient = ColorAccess::SetColor(ambient, color_);
 
 			//ライト
@@ -977,12 +954,12 @@ void RenderObjectBNX::Render()
 			}
 			shader->SetMatrixArray("mWorldMatrixArray", listMatrix);
 
-			unsigned int numPass = shader->Begin();
+			shader->Begin();
 
 			device->SetVertexDeclaration(pVertexDecl_);
 			device->SetStreamSource(0, pVertexBuffer_, 0, sizeof(Vertex));
-			if (vertexIndices_.size() == 0) {
-				device->SetIndices(NULL);
+			if (vertexIndices_.empty()) {
+				device->SetIndices(nullptr);
 				device->DrawPrimitive(typePrimitive_, 0, _GetPrimitiveCount());
 			} else {
 				device->SetIndices(pIndexBuffer_);
@@ -996,9 +973,9 @@ void RenderObjectBNX::Render()
 			Logger::WriteTop(StringUtility::Format(L"Shader error[%s]", "DEFAULT"));
 		}
 
-		device->SetVertexDeclaration(NULL);
-		device->SetIndices(NULL);
-		device->SetTexture(0, NULL);
+		device->SetVertexDeclaration(nullptr);
+		device->SetIndices(nullptr);
+		device->SetTexture(0, nullptr);
 	}
 
 	if (bCoordinate2D_) {
@@ -1015,16 +992,14 @@ RenderObjectB2NX::RenderObjectB2NX()
 {
 	strideVertexStreamZero_ = sizeof(VERTEX_B2NX);
 }
-RenderObjectB2NX::~RenderObjectB2NX()
-{
-}
+RenderObjectB2NX::~RenderObjectB2NX() = default;
 void RenderObjectB2NX::_CopyVertexBufferOnInitialize()
 {
 	int countVertex = GetVertexCount();
 	Vertex* bufVertex;
 	HRESULT hrLockVertex = pVertexBuffer_->Lock(0, 0, reinterpret_cast<void**>(&bufVertex), D3DLOCK_NOSYSLOCK);
 	if (!FAILED(hrLockVertex)) {
-		for (int iVert = 0; iVert < countVertex; iVert++) {
+		for (int iVert = 0; iVert < countVertex; ++iVert) {
 			Vertex* dest = &bufVertex[iVert];
 			VERTEX_B2NX* src = GetVertex(iVert);
 			ZeroMemory(dest, sizeof(Vertex));
@@ -1033,13 +1008,13 @@ void RenderObjectB2NX::_CopyVertexBufferOnInitialize()
 			dest->normal = src->normal;
 			dest->texcoord = src->texcoord;
 
-			for (int iBlend = 0; iBlend < 2; iBlend++) {
+			for (int iBlend = 0; iBlend < 2; ++iBlend) {
 				int indexBlend = BitAccess::GetByte(src->blendIndex, iBlend * 8);
 				dest->blendIndex[iBlend] = indexBlend;
 			}
 
 			dest->blendRate[0] = src->blendRate;
-			dest->blendRate[1] = 1.0f - dest->blendRate[0];
+			dest->blendRate[1] = 1.0F - dest->blendRate[0];
 		}
 		pVertexBuffer_->Unlock();
 	}
@@ -1051,7 +1026,7 @@ void RenderObjectB2NX::CalculateWeightCenter()
 	double yTotal = 0;
 	double zTotal = 0;
 	int countVert = GetVertexCount();
-	for (int iVert = 0; iVert < countVert; iVert++) {
+	for (int iVert = 0; iVert < countVert; ++iVert) {
 		VERTEX_B2NX* vertex = GetVertex(iVert);
 		xTotal += vertex->position.x;
 		yTotal += vertex->position.y;
@@ -1068,7 +1043,7 @@ VERTEX_B2NX* RenderObjectB2NX::GetVertex(int index)
 {
 	int pos = index * strideVertexStreamZero_;
 	if (pos >= vertex_.GetSize())
-		return NULL;
+		return nullptr;
 	return (VERTEX_B2NX*)vertex_.GetPointer(pos);
 }
 void RenderObjectB2NX::SetVertex(int index, VERTEX_B2NX& vertex)
@@ -1081,10 +1056,10 @@ void RenderObjectB2NX::SetVertex(int index, VERTEX_B2NX& vertex)
 void RenderObjectB2NX::SetVertexPosition(int index, float x, float y, float z)
 {
 	VERTEX_B2NX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 
-	float bias = -0.5f;
+	float bias = -0.5F;
 	vertex->position.x = x + bias;
 	vertex->position.y = y + bias;
 	vertex->position.z = z;
@@ -1092,7 +1067,7 @@ void RenderObjectB2NX::SetVertexPosition(int index, float x, float y, float z)
 void RenderObjectB2NX::SetVertexUV(int index, float u, float v)
 {
 	VERTEX_B2NX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	vertex->texcoord.x = u;
 	vertex->texcoord.y = v;
@@ -1100,7 +1075,7 @@ void RenderObjectB2NX::SetVertexUV(int index, float u, float v)
 void RenderObjectB2NX::SetVertexBlend(int index, int pos, BYTE indexBlend, float rate)
 {
 	VERTEX_B2NX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	BitAccess::SetByte(vertex->blendIndex, pos * 8, indexBlend);
 	if (pos == 0)
@@ -1109,7 +1084,7 @@ void RenderObjectB2NX::SetVertexBlend(int index, int pos, BYTE indexBlend, float
 void RenderObjectB2NX::SetVertexNormal(int index, float x, float y, float z)
 {
 	VERTEX_B2NX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	vertex->normal.x = x;
 	vertex->normal.y = y;
@@ -1117,15 +1092,11 @@ void RenderObjectB2NX::SetVertexNormal(int index, float x, float y, float z)
 }
 
 //RenderObjectB2NXBlock
-RenderObjectB2NXBlock::RenderObjectB2NXBlock()
-{
-}
-RenderObjectB2NXBlock::~RenderObjectB2NXBlock()
-{
-}
+RenderObjectB2NXBlock::RenderObjectB2NXBlock() = default;
+RenderObjectB2NXBlock::~RenderObjectB2NXBlock() = default;
 void RenderObjectB2NXBlock::Render()
 {
-	RenderObjectB2NX* obj = (RenderObjectB2NX*)obj_.GetPointer();
+	auto* obj = (RenderObjectB2NX*)obj_.GetPointer();
 	obj->SetMatrix(matrix_);
 	RenderBlock::Render();
 }
@@ -1137,16 +1108,14 @@ RenderObjectB4NX::RenderObjectB4NX()
 {
 	strideVertexStreamZero_ = sizeof(VERTEX_B4NX);
 }
-RenderObjectB4NX::~RenderObjectB4NX()
-{
-}
+RenderObjectB4NX::~RenderObjectB4NX() = default;
 void RenderObjectB4NX::_CopyVertexBufferOnInitialize()
 {
 	int countVertex = GetVertexCount();
 	Vertex* bufVertex;
 	HRESULT hrLockVertex = pVertexBuffer_->Lock(0, 0, reinterpret_cast<void**>(&bufVertex), D3DLOCK_NOSYSLOCK);
 	if (!FAILED(hrLockVertex)) {
-		for (int iVert = 0; iVert < countVertex; iVert++) {
+		for (int iVert = 0; iVert < countVertex; ++iVert) {
 			Vertex* dest = &bufVertex[iVert];
 			VERTEX_B4NX* src = GetVertex(iVert);
 			ZeroMemory(dest, sizeof(Vertex));
@@ -1155,13 +1124,13 @@ void RenderObjectB4NX::_CopyVertexBufferOnInitialize()
 			dest->normal = src->normal;
 			dest->texcoord = src->texcoord;
 
-			for (int iBlend = 0; iBlend < 4; iBlend++) {
+			for (int iBlend = 0; iBlend < 4; ++iBlend) {
 				int indexBlend = BitAccess::GetByte(src->blendIndex, iBlend * 8);
 				dest->blendIndex[iBlend] = indexBlend;
 			}
 
-			float lastRate = 1.0f;
-			for (int iRate = 0; iRate < 3; iRate++) {
+			float lastRate = 1.0F;
+			for (int iRate = 0; iRate < 3; ++iRate) {
 				float rate = src->blendRate[iRate];
 				dest->blendRate[iRate] = rate;
 				lastRate -= rate;
@@ -1178,7 +1147,7 @@ void RenderObjectB4NX::CalculateWeightCenter()
 	double yTotal = 0;
 	double zTotal = 0;
 	int countVert = GetVertexCount();
-	for (int iVert = 0; iVert < countVert; iVert++) {
+	for (int iVert = 0; iVert < countVert; ++iVert) {
 		VERTEX_B4NX* vertex = GetVertex(iVert);
 		xTotal += vertex->position.x;
 		yTotal += vertex->position.y;
@@ -1195,7 +1164,7 @@ VERTEX_B4NX* RenderObjectB4NX::GetVertex(int index)
 {
 	int pos = index * strideVertexStreamZero_;
 	if (pos >= vertex_.GetSize())
-		return NULL;
+		return nullptr;
 	return (VERTEX_B4NX*)vertex_.GetPointer(pos);
 }
 void RenderObjectB4NX::SetVertex(int index, const VERTEX_B4NX& vertex)
@@ -1208,10 +1177,10 @@ void RenderObjectB4NX::SetVertex(int index, const VERTEX_B4NX& vertex)
 void RenderObjectB4NX::SetVertexPosition(int index, float x, float y, float z)
 {
 	VERTEX_B4NX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 
-	float bias = -0.5f;
+	float bias = -0.5F;
 	vertex->position.x = x + bias;
 	vertex->position.y = y + bias;
 	vertex->position.z = z;
@@ -1219,7 +1188,7 @@ void RenderObjectB4NX::SetVertexPosition(int index, float x, float y, float z)
 void RenderObjectB4NX::SetVertexUV(int index, float u, float v)
 {
 	VERTEX_B4NX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	vertex->texcoord.x = u;
 	vertex->texcoord.y = v;
@@ -1227,7 +1196,7 @@ void RenderObjectB4NX::SetVertexUV(int index, float u, float v)
 void RenderObjectB4NX::SetVertexBlend(int index, int pos, BYTE indexBlend, float rate)
 {
 	VERTEX_B4NX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	BitAccess::SetByte(vertex->blendIndex, pos * 8, indexBlend);
 	if (pos <= 2)
@@ -1236,7 +1205,7 @@ void RenderObjectB4NX::SetVertexBlend(int index, int pos, BYTE indexBlend, float
 void RenderObjectB4NX::SetVertexNormal(int index, float x, float y, float z)
 {
 	VERTEX_B4NX* vertex = GetVertex(index);
-	if (vertex == NULL)
+	if (vertex == nullptr)
 		return;
 	vertex->normal.x = x;
 	vertex->normal.y = y;
@@ -1244,15 +1213,11 @@ void RenderObjectB4NX::SetVertexNormal(int index, float x, float y, float z)
 }
 
 //RenderObjectB4NXBlock
-RenderObjectB4NXBlock::RenderObjectB4NXBlock()
-{
-}
-RenderObjectB4NXBlock::~RenderObjectB4NXBlock()
-{
-}
+RenderObjectB4NXBlock::RenderObjectB4NXBlock() = default;
+RenderObjectB4NXBlock::~RenderObjectB4NXBlock() = default;
 void RenderObjectB4NXBlock::Render()
 {
-	RenderObjectB4NX* obj = (RenderObjectB4NX*)obj_.GetPointer();
+	auto* obj = (RenderObjectB4NX*)obj_.GetPointer();
 	obj->SetMatrix(matrix_);
 	RenderBlock::Render();
 }
@@ -1266,16 +1231,14 @@ Sprite2D::Sprite2D()
 	SetVertexCount(4); //左上、右上、左下、右下
 	SetPrimitiveType(D3DPT_TRIANGLESTRIP);
 }
-Sprite2D::~Sprite2D()
-{
-}
+Sprite2D::~Sprite2D() = default;
 void Sprite2D::Copy(const Sprite2D* src)
 {
 	typePrimitive_ = src->typePrimitive_;
 	strideVertexStreamZero_ = src->strideVertexStreamZero_;
 	vertex_.Copy(src->vertex_);
 	vertexIndices_ = src->vertexIndices_;
-	for (int iTex = 0; iTex < texture_.size(); iTex++) {
+	for (int iTex = 0; iTex < texture_.size(); ++iTex) {
 		texture_[iTex] = src->texture_[iTex];
 	}
 
@@ -1289,7 +1252,7 @@ void Sprite2D::Copy(const Sprite2D* src)
 void Sprite2D::SetSourceRect(const RECT_D& rcSrc)
 {
 	ref_count_ptr<Texture>& texture = texture_[0];
-	if (texture == NULL)
+	if (texture == nullptr)
 		return;
 	const int width = texture->GetWidth();
 	const int height = texture->GetHeight();
@@ -1311,7 +1274,7 @@ void Sprite2D::SetDestinationRect(const RECT_D& rcDest)
 void Sprite2D::SetDestinationCenter()
 {
 	ref_count_ptr<Texture>& texture = texture_[0];
-	if (texture == NULL || GetVertexCount() < 4)
+	if (texture == nullptr || GetVertexCount() < 4)
 		return;
 	const int width = texture->GetWidth();
 	const int height = texture->GetHeight();
@@ -1334,7 +1297,7 @@ void Sprite2D::SetVertex(const RECT_D& rcSrc, const RECT_D& rcDest, D3DCOLOR col
 }
 RECT_D Sprite2D::GetDestinationRect()
 {
-	float bias = -0.5f;
+	float bias = -0.5F;
 
 	RECT_D rect;
 	VERTEX_TLX* vertexLeftTop = GetVertex(0);
@@ -1363,16 +1326,16 @@ void SpriteList2D::Render()
 	DxCamera2D* camera = graphics->GetCamera2D().GetPointer();
 	IDirect3DDevice9* device = graphics->GetDevice();
 	ref_count_ptr<Texture>& texture = texture_[0];
-	if (texture != NULL)
+	if (texture != nullptr)
 		device->SetTexture(0, texture->GetD3DTexture());
 	else
-		device->SetTexture(0, NULL);
+		device->SetTexture(0, nullptr);
 	device->SetFVF(VERTEX_TLX::fvf);
 
 	//座標変換
-	bool bPos = position_.x != 0.0f || position_.y != 0.0f || position_.z != 0.0f;
-	bool bAngle = angle_.x != 0.0f || angle_.y != 0.0f || angle_.z != 0.0f;
-	bool bScale = scale_.x != 1.0f || scale_.y != 1.0f || scale_.z != 1.0f;
+	bool bPos = position_.x != 0.0F || position_.y != 0.0F || position_.z != 0.0F;
+	bool bAngle = angle_.x != 0.0F || angle_.y != 0.0F || angle_.z != 0.0F;
+	bool bScale = scale_.x != 1.0F || scale_.y != 1.0F || scale_.z != 1.0F;
 	bool bCamera = camera->IsEnable() && bPermitCamera_;
 	if (bPos || bAngle || bScale || bCamera) {
 		//座標変換有りなら、座標3D変換済みなため自前で変換をかける
@@ -1409,15 +1372,13 @@ void SpriteList2D::Render()
 		int countVertex = GetVertexCount();
 		for (int iVert = 0; iVert < countVertex; iVert++) {
 			int pos = iVert * strideVertexStreamZero_;
-			VERTEX_TLX* vert = (VERTEX_TLX*)vertCopy_.GetPointer(pos);
+			auto* vert = (VERTEX_TLX*)vertCopy_.GetPointer(pos);
 			D3DXVec3TransformCoord((D3DXVECTOR3*)&vert->position, (D3DXVECTOR3*)&vert->position, &mat);
 		}
 
 		//描画
-		int oldSamplerState = 0;
-
 		BeginShader();
-		if (vertexIndices_.size() == 0) {
+		if (vertexIndices_.empty()) {
 			device->DrawPrimitiveUP(typePrimitive_, _GetPrimitiveCount(), vertCopy_.GetPointer(), strideVertexStreamZero_);
 		} else {
 			device->DrawIndexedPrimitiveUP(typePrimitive_, 0,
@@ -1432,7 +1393,7 @@ void SpriteList2D::Render()
 	} else {
 		//座標変換無しならそのまま描画
 		BeginShader();
-		if (vertexIndices_.size() == 0) {
+		if (vertexIndices_.empty()) {
 			device->DrawPrimitiveUP(typePrimitive_, _GetPrimitiveCount(), vertex_.GetPointer(), strideVertexStreamZero_);
 		} else {
 			device->DrawIndexedPrimitiveUP(typePrimitive_, 0,
@@ -1445,9 +1406,7 @@ void SpriteList2D::Render()
 }
 int SpriteList2D::GetVertexCount() const
 {
-	int res = countRenderVertex_;
-	res = min(countRenderVertex_, vertex_.GetSize() / strideVertexStreamZero_);
-	return res;
+	return min(countRenderVertex_, vertex_.GetSize() / strideVertexStreamZero_);
 }
 void SpriteList2D::_AddVertex(VERTEX_TLX& vertex)
 {
@@ -1460,7 +1419,7 @@ void SpriteList2D::_AddVertex(VERTEX_TLX& vertex)
 		memcpy(vertex_.GetPointer(), buffer.GetPointer(), buffer.GetSize());
 	}
 	SetVertex(countRenderVertex_, vertex);
-	countRenderVertex_++;
+	++countRenderVertex_;
 }
 void SpriteList2D::AddVertex()
 {
@@ -1468,7 +1427,7 @@ void SpriteList2D::AddVertex()
 		return;
 
 	ref_count_ptr<Texture>& texture = texture_[0];
-	if (texture == NULL)
+	if (texture == nullptr)
 		return;
 
 	int width = texture->GetWidth();
@@ -1478,9 +1437,9 @@ void SpriteList2D::AddVertex()
 	D3DXMatrixIdentity(&mat);
 
 	DirectGraphics* graphics = DirectGraphics::GetBase();
-	bool bPos = position_.x != 0.0f || position_.y != 0.0f || position_.z != 0.0f;
-	bool bAngle = angle_.x != 0.0f || angle_.y != 0.0f || angle_.z != 0.0f;
-	bool bScale = scale_.x != 1.0f || scale_.y != 1.0f || scale_.z != 1.0f;
+	bool bPos = position_.x != 0.0F || position_.y != 0.0F || position_.z != 0.0F;
+	bool bAngle = angle_.x != 0.0F || angle_.y != 0.0F || angle_.z != 0.0F;
+	bool bScale = scale_.x != 1.0F || scale_.y != 1.0F || scale_.z != 1.0F;
 
 	if (bScale) {
 		D3DXMATRIX matScale;
@@ -1503,13 +1462,13 @@ void SpriteList2D::AddVertex()
 	float srcY[] = { (float)rcSrc_.top, (float)rcSrc_.top, (float)rcSrc_.bottom, (float)rcSrc_.bottom };
 	int destX[] = { (int)rcDest_.left, (int)rcDest_.right, (int)rcDest_.left, (int)rcDest_.right };
 	int destY[] = { (int)rcDest_.top, (int)rcDest_.top, (int)rcDest_.bottom, (int)rcDest_.bottom };
-	for (int iVert = 0; iVert < 4; iVert++) {
+	for (int iVert = 0; iVert < 4; ++iVert) {
 		VERTEX_TLX& vert = verts[iVert];
 
 		vert.texcoord.x = srcX[iVert] / width;
 		vert.texcoord.y = srcY[iVert] / height;
 
-		float bias = -0.5f;
+		float bias = -0.5F;
 		vert.position.x = destX[iVert] + bias;
 		vert.position.y = destY[iVert] + bias;
 		vert.position.z = 1.0;
@@ -1529,7 +1488,7 @@ void SpriteList2D::AddVertex()
 void SpriteList2D::SetDestinationCenter()
 {
 	ref_count_ptr<Texture>& texture = texture_[0];
-	if (texture == NULL)
+	if (texture == nullptr)
 		return;
 	int width = texture->GetWidth();
 	int height = texture->GetHeight();
@@ -1547,9 +1506,9 @@ void SpriteList2D::CloseVertex()
 {
 	bCloseVertexList_ = true;
 
-	position_ = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
-	angle_ = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
-	scale_ = D3DXVECTOR3(1.0f, 1.0f, 1.0f);
+	position_ = D3DXVECTOR3(0.0F, 0.0F, 0.0F);
+	angle_ = D3DXVECTOR3(0.0F, 0.0F, 0.0F);
+	scale_ = D3DXVECTOR3(1.0F, 1.0F, 1.0F);
 }
 
 /**********************************************************
@@ -1561,16 +1520,14 @@ Sprite3D::Sprite3D()
 	SetPrimitiveType(D3DPT_TRIANGLESTRIP);
 	bBillboard_ = false;
 }
-Sprite3D::~Sprite3D()
-{
-}
+Sprite3D::~Sprite3D() = default;
 D3DXMATRIX Sprite3D::_CreateWorldTransformMaxtrix()
 {
 	D3DXMATRIX mat;
 	D3DXMatrixIdentity(&mat);
-	bool bPos = position_.x != 0.0f || position_.y != 0.0f || position_.z != 0.0f;
-	bool bAngle = angle_.x != 0.0f || angle_.y != 0.0f || angle_.z != 0.0f;
-	bool bScale = scale_.x != 1.0f || scale_.y != 1.0f || scale_.z != 1.0f;
+	bool bPos = position_.x != 0.0F || position_.y != 0.0F || position_.z != 0.0F;
+	bool bAngle = angle_.x != 0.0F || angle_.y != 0.0F || angle_.z != 0.0F;
+	bool bScale = scale_.x != 1.0F || scale_.y != 1.0F || scale_.z != 1.0F;
 	if (bPos || bAngle || bScale || bBillboard_) {
 		if (bScale) {
 			D3DXMATRIX matScale;
@@ -1623,7 +1580,7 @@ D3DXMATRIX Sprite3D::_CreateWorldTransformMaxtrix()
 void Sprite3D::SetSourceRect(const RECT_D& rcSrc)
 {
 	ref_count_ptr<Texture>& texture = texture_[0];
-	if (texture == NULL)
+	if (texture == nullptr)
 		return;
 	int width = texture->GetWidth();
 	int height = texture->GetHeight();
@@ -1681,9 +1638,7 @@ TrajectoryObject3D::TrajectoryObject3D()
 	countComplement_ = 8;
 	color_ = D3DCOLOR_ARGB(255, 255, 255, 255);
 }
-TrajectoryObject3D::~TrajectoryObject3D()
-{
-}
+TrajectoryObject3D::~TrajectoryObject3D() = default;
 D3DXMATRIX TrajectoryObject3D::_CreateWorldTransformMaxtrix()
 {
 	D3DXMATRIX mat;
@@ -1707,17 +1662,15 @@ void TrajectoryObject3D::Render()
 
 	int width = 1;
 	gstd::ref_count_ptr<Texture> texture = texture_[0];
-	if (texture != NULL) {
+	if (texture != nullptr) {
 		width = texture->GetWidth();
 	}
 
 	float dWidth = 1.0 / width / listData_.size();
 	int iData = 0;
-	std::list<Data>::iterator itr;
-	for (itr = listData_.begin(); itr != listData_.end(); itr++, iData++) {
-		Data data = (*itr);
+	for (auto& data : listData_) {
 		int alpha = data.alpha;
-		for (int iPos = 0; iPos < 2; iPos++) {
+		for (int iPos = 0; iPos < 2; ++iPos) {
 			int index = iData * 2 + iPos;
 			D3DXVECTOR3& pos = iPos == 0 ? data.pos1 : data.pos2;
 			float u = dWidth * iData;
@@ -1731,6 +1684,7 @@ void TrajectoryObject3D::Render()
 			float b = ColorAccess::GetColorB(color_) * alpha / 255;
 			SetVertexColorARGB(index, alpha, r, g, b);
 		}
+		++iData;
 	}
 	RenderObjectLX::Render();
 }
@@ -1792,15 +1746,13 @@ DxMeshData::DxMeshData()
 	manager_ = DxMeshManager::GetBase();
 	bLoad_ = true;
 }
-DxMeshData::~DxMeshData()
-{
-}
+DxMeshData::~DxMeshData() = default;
 
 DxMesh::DxMesh()
 {
-	position_ = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
-	angle_ = D3DXVECTOR3(0.0f, 0.0f, 0.0f);
-	scale_ = D3DXVECTOR3(1.0f, 1.0f, 1.0f);
+	position_ = D3DXVECTOR3(0.0F, 0.0F, 0.0F);
+	angle_ = D3DXVECTOR3(0.0F, 0.0F, 0.0F);
+	scale_ = D3DXVECTOR3(1.0F, 1.0F, 1.0F);
 	color_ = D3DCOLOR_ARGB(255, 255, 255, 255);
 	bCoordinate2D_ = false;
 }
@@ -1821,7 +1773,7 @@ void DxMesh::Release()
 	{
 		DxMeshManager* manager = DxMeshManager::GetBase();
 		Lock lock(manager->GetLock());
-		if (data_ != NULL) {
+		if (data_ != nullptr) {
 			if (manager->IsDataExists(data_->GetName())) {
 				int countRef = data_.GetReferenceCount();
 				//自身とDxMeshManager内の数だけになったら削除
@@ -1829,7 +1781,7 @@ void DxMesh::Release()
 					manager->_ReleaseMeshData(data_->GetName());
 				}
 			}
-			data_ = NULL;
+			data_ = nullptr;
 		}
 	}
 }
@@ -1838,7 +1790,7 @@ bool DxMesh::CreateFromFile(const std::wstring& _path)
 	std::wstring path = PathProperty::GetUnique(_path);
 	ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
 	try {
-		if (reader == NULL)
+		if (reader == nullptr)
 			throw gstd::wexception(L"ファイルが見つかりません");
 	} catch (gstd::wexception& e) {
 		std::wstring str = StringUtility::Format(L"DxMesh：メッシュ読み込み失敗[%s]\n\t%s", path.c_str(), e.what());
@@ -1851,16 +1803,16 @@ bool DxMesh::CreateFromFileInLoadThread(const std::wstring& path, int type)
 {
 	{
 		Lock lock(DxMeshManager::GetBase()->GetLock());
-		if (data_ != NULL)
+		if (data_ != nullptr)
 			Release();
 		DxMeshManager* manager = DxMeshManager::GetBase();
 		ref_count_ptr<DxMesh> mesh = manager->CreateFromFileInLoadThread(path, type);
-		if (mesh != NULL) {
+		if (mesh != nullptr) {
 			data_ = mesh->data_;
 		}
 
 	}
-	return data_ != NULL;
+	return data_ != nullptr;
 }
 void DxMesh::SetColorRGB(D3DCOLOR color)
 {
@@ -1878,16 +1830,14 @@ void DxMesh::SetAlpha(int alpha)
 /**********************************************************
 //DxMeshManager
 **********************************************************/
-DxMeshManager* DxMeshManager::thisBase_ = NULL;
-DxMeshManager::DxMeshManager()
-{
-}
+DxMeshManager* DxMeshManager::thisBase_ = nullptr;
+DxMeshManager::DxMeshManager() = default;
 DxMeshManager::~DxMeshManager()
 {
 	this->Clear();
 	FileManager::GetBase()->RemoveLoadThreadListener(this);
-	panelInfo_ = NULL;
-	thisBase_ = NULL;
+	panelInfo_ = nullptr;
+	thisBase_ = nullptr;
 }
 bool DxMeshManager::Initialize()
 {
@@ -1916,7 +1866,7 @@ void DxMeshManager::_AddMeshData(const std::wstring& name, gstd::ref_count_ptr<D
 }
 gstd::ref_count_ptr<DxMeshData> DxMeshManager::_GetMeshData(const std::wstring& name)
 {
-	gstd::ref_count_ptr<DxMeshData> res = NULL;
+	gstd::ref_count_ptr<DxMeshData> res = nullptr;
 	{
 		Lock lock(lock_);
 		if (IsDataExists(name)) {
@@ -1975,7 +1925,7 @@ gstd::ref_count_ptr<DxMesh> DxMeshManager::CreateFromFileInLoadThread(const std:
 			else if (type == MESH_METASEQUOIA)
 				res = new MetasequoiaMesh();
 			if (!IsDataExists(path)) {
-				ref_count_ptr<DxMeshData> data = NULL;
+				ref_count_ptr<DxMeshData> data = nullptr;
 				if (type == MESH_ELFREINA)
 					data = new ElfreinaMeshData();
 				else if (type == MESH_METASEQUOIA)
@@ -2001,7 +1951,7 @@ void DxMeshManager::CallFromLoadThread(ref_count_ptr<FileManager::LoadThreadEven
 	{
 		Lock lock(lock_);
 		ref_count_ptr<DxMesh> mesh = ref_count_ptr<DxMesh>::DownCast(event->GetSource());
-		if (mesh == NULL)
+		if (mesh == nullptr)
 			return;
 
 		ref_count_ptr<DxMeshData> data = mesh->data_;
@@ -2010,7 +1960,7 @@ void DxMeshManager::CallFromLoadThread(ref_count_ptr<FileManager::LoadThreadEven
 
 		bool res = false;
 		ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-		if (reader != NULL && reader->Open()) {
+		if (reader != nullptr && reader->Open()) {
 			res = data->CreateFromFileReader(reader);
 		}
 		if (res) {
@@ -2064,7 +2014,7 @@ void DxMeshInfoPanel::_Run()
 {
 	while (GetStatus() == RUN) {
 		DxMeshManager* manager = DxMeshManager::GetBase();
-		if (manager != NULL)
+		if (manager != nullptr)
 			Update(manager);
 		Sleep(timeUpdateInterval_);
 	}
@@ -2102,7 +2052,7 @@ void DxMeshInfoPanel::Update(DxMeshManager* manager)
 	for (int iRow = 0; iRow < wndListView_.GetRowCount();) {
 		std::wstring key = wndListView_.GetText(iRow, ROW_ADDRESS);
 		if (setKey.find(key) != setKey.end())
-			iRow++;
+			++iRow;
 		else
 			wndListView_.DeleteRow(iRow);
 	}

--- a/source/GcLib/directx/RenderObject.hpp
+++ b/source/GcLib/directx/RenderObject.hpp
@@ -16,7 +16,7 @@ class RenderManager;
 **********************************************************/
 struct VERTEX_TL {
 	//座標3D変換済み、ライティング済み
-	VERTEX_TL() {}
+	VERTEX_TL() = default;
 	VERTEX_TL(D3DXVECTOR4 pos, D3DCOLOR dcol)
 		: position(pos)
 		, diffuse_color(dcol)
@@ -29,7 +29,7 @@ struct VERTEX_TL {
 
 struct VERTEX_TLX {
 	//座標3D変換済み、ライティング済み、テクスチャ有り
-	VERTEX_TLX() {}
+	VERTEX_TLX() = default;
 	VERTEX_TLX(D3DXVECTOR4 pos, D3DCOLOR diffcol, D3DXVECTOR2 tex)
 		: position(pos)
 		, diffuse_color(diffcol)
@@ -44,7 +44,7 @@ struct VERTEX_TLX {
 
 struct VERTEX_L {
 	//ライティング済み
-	VERTEX_L() {}
+	VERTEX_L() = default;
 	VERTEX_L(D3DXVECTOR3 pos, D3DCOLOR col)
 		: position(pos)
 		, diffuse_color(col)
@@ -57,7 +57,7 @@ struct VERTEX_L {
 
 struct VERTEX_LX {
 	//ライティング済み、テクスチャ有り
-	VERTEX_LX() {}
+	VERTEX_LX() = default;
 	VERTEX_LX(D3DXVECTOR3 pos, D3DCOLOR diffcol, D3DXVECTOR2 tex)
 		: position(pos)
 		, diffuse_color(diffcol)
@@ -72,7 +72,7 @@ struct VERTEX_LX {
 
 struct VERTEX_N {
 	//未ライティング
-	VERTEX_N() {}
+	VERTEX_N() = default;
 	VERTEX_N(D3DXVECTOR3 pos, D3DXVECTOR3 n)
 		: position(pos)
 		, normal(n)
@@ -85,7 +85,7 @@ struct VERTEX_N {
 
 struct VERTEX_NX {
 	//未ライティング、テクスチャ有り
-	VERTEX_NX() {}
+	VERTEX_NX() = default;
 	VERTEX_NX(D3DXVECTOR3 pos, D3DXVECTOR3 n, D3DXVECTOR2 tc)
 		: position(pos)
 		, normal(n)
@@ -99,7 +99,7 @@ struct VERTEX_NX {
 };
 
 struct VERTEX_NXG {
-	VERTEX_NXG() {}
+	VERTEX_NXG() = default;
 	VERTEX_NXG(D3DXVECTOR3& pos, D3DXVECTOR3& n, D3DXVECTOR2& tc)
 		: position(pos)
 		, normal(n)
@@ -115,7 +115,7 @@ struct VERTEX_NXG {
 
 struct VERTEX_B1NX {
 	//未ライティング、テクスチャ有り、頂点ブレンド1
-	VERTEX_B1NX() {}
+	VERTEX_B1NX() = default;
 	VERTEX_B1NX(D3DXVECTOR3 pos, DWORD bi, D3DXVECTOR3 n, D3DXVECTOR2 tc)
 		: position(pos)
 		, normal(n)
@@ -132,7 +132,7 @@ struct VERTEX_B1NX {
 
 struct VERTEX_B2NX {
 	//未ライティング、テクスチャ有り、頂点ブレンド2
-	VERTEX_B2NX() {}
+	VERTEX_B2NX() = default;
 	VERTEX_B2NX(D3DXVECTOR3 pos, float rate, BYTE index1, BYTE index2, D3DXVECTOR3 n, D3DXVECTOR2 tc)
 		: position(pos)
 		, normal(n)
@@ -152,15 +152,15 @@ struct VERTEX_B2NX {
 
 struct VERTEX_B4NX {
 	//未ライティング、テクスチャ有り、頂点ブレンド4
-	VERTEX_B4NX() {}
-	VERTEX_B4NX(D3DXVECTOR3 pos, float rate[3], BYTE index[4], D3DXVECTOR3 n, D3DXVECTOR2 tc)
+	VERTEX_B4NX() = default;
+	VERTEX_B4NX(D3DXVECTOR3 pos, const float rate[3], BYTE index[4], D3DXVECTOR3 n, D3DXVECTOR2 tc)
 		: position(pos)
 		, normal(n)
 		, texcoord(tc)
 	{
-		for (int iRate = 0; iRate < 3; iRate++)
+		for (int iRate = 0; iRate < 3; ++iRate)
 			blendRate[iRate] = rate[iRate];
-		for (int iIndex = 0; iIndex < 4; iIndex++)
+		for (int iIndex = 0; iIndex < 4; ++iIndex)
 			gstd::BitAccess::SetByte(blendIndex, 8 * iIndex, index[iIndex]);
 	}
 	D3DXVECTOR3 position;
@@ -208,8 +208,8 @@ protected:
 
 class RenderBlocks {
 public:
-	RenderBlocks(){};
-	virtual ~RenderBlocks(){};
+	RenderBlocks() = default;
+	virtual ~RenderBlocks() = default;
 	void Add(gstd::ref_count_ptr<RenderBlock> block) { listBlock_.push_back(block); }
 	std::list<gstd::ref_count_ptr<RenderBlock>>& GetList() { return listBlock_; }
 
@@ -272,12 +272,12 @@ private:
 
 class Matrices {
 public:
-	Matrices(){};
-	virtual ~Matrices(){};
+	Matrices() = default;
+	virtual ~Matrices() = default;
 	void SetSize(int size)
 	{
 		matrix_.resize(size);
-		for (int iMat = 0; iMat < size; iMat++) {
+		for (int iMat = 0; iMat < size; ++iMat) {
 			D3DXMatrixIdentity(&matrix_[iMat]);
 		}
 	}
@@ -331,14 +331,14 @@ public:
 	void SetY(float y) { position_.y = y; }
 	void SetZ(float z) { position_.z = z; }
 	void SetAngle(const D3DXVECTOR3& angle) { angle_ = angle; }
-	void SetAngleXYZ(float angx = 0.0f, float angy = 0.0f, float angz = 0.0f)
+	void SetAngleXYZ(float angx = 0.0F, float angy = 0.0F, float angz = 0.0F)
 	{
 		angle_.x = angx;
 		angle_.y = angy;
 		angle_.z = angz;
 	}
 	void SetScale(const D3DXVECTOR3& scale) { scale_ = scale; }
-	void SetScaleXYZ(float sx = 1.0f, float sy = 1.0f, float sz = 1.0f)
+	void SetScaleXYZ(float sx = 1.0F, float sy = 1.0F, float sz = 1.0F)
 	{
 		scale_.x = sx;
 		scale_.y = sy;
@@ -383,8 +383,8 @@ protected:
 	void _SetTextureStageCount(int count)
 	{
 		texture_.resize(count);
-		for (int i = 0; i < count; i++)
-			texture_[i] = NULL;
+		for (auto& texture : texture_)
+			texture = nullptr;
 	}
 	virtual D3DXMATRIX _CreateWorldTransformMaxtrix(); //position_,angle_,scale_から作成
 	void _SetCoordinate2dDeviceMatrix();
@@ -398,14 +398,14 @@ protected:
 class RenderObjectTLX : public RenderObject {
 public:
 	RenderObjectTLX();
-	~RenderObjectTLX();
-	virtual void Render();
-	virtual void SetVertexCount(int count);
+	~RenderObjectTLX() override;
+	void Render() override;
+	void SetVertexCount(int count) override;
 
 	//頂点設定
 	VERTEX_TLX* GetVertex(int index);
 	void SetVertex(int index, const VERTEX_TLX& vertex);
-	void SetVertexPosition(int index, float x, float y, float z = 1.0f, float w = 1.0f);
+	void SetVertexPosition(int index, float x, float y, float z = 1.0F, float w = 1.0F);
 	void SetVertexUV(int index, float u, float v);
 	void SetVertexColor(int index, D3DCOLOR color);
 	void SetVertexColorARGB(int index, int a, int r, int g, int b);
@@ -422,7 +422,7 @@ protected:
 	bool bPermitCamera_;
 	gstd::ByteBuffer vertCopy_;
 
-	virtual void _CreateVertexDeclaration();
+	void _CreateVertexDeclaration() override;
 };
 
 /**********************************************************
@@ -433,9 +433,9 @@ protected:
 class RenderObjectLX : public RenderObject {
 public:
 	RenderObjectLX();
-	~RenderObjectLX();
-	virtual void Render();
-	virtual void SetVertexCount(int count);
+	~RenderObjectLX() override;
+	void Render() override;
+	void SetVertexCount(int count) override;
 
 	//頂点設定
 	VERTEX_LX* GetVertex(int index);
@@ -450,7 +450,7 @@ public:
 	void SetAlpha(int alpha);
 
 protected:
-	virtual void _CreateVertexDeclaration();
+	void _CreateVertexDeclaration() override;
 };
 
 /**********************************************************
@@ -460,8 +460,8 @@ protected:
 class RenderObjectNX : public RenderObject {
 public:
 	RenderObjectNX();
-	~RenderObjectNX();
-	virtual void Render();
+	~RenderObjectNX() override;
+	void Render() override;
 
 	//頂点設定
 	VERTEX_NX* GetVertex(int index);
@@ -473,7 +473,7 @@ public:
 
 protected:
 	D3DCOLOR color_;
-	virtual void _CreateVertexDeclaration();
+	void _CreateVertexDeclaration() override;
 };
 
 /**********************************************************
@@ -494,9 +494,9 @@ public:
 
 public:
 	RenderObjectBNX();
-	~RenderObjectBNX();
-	virtual void InitializeVertexBuffer();
-	virtual void Render();
+	~RenderObjectBNX() override;
+	void InitializeVertexBuffer() override;
+	void Render() override;
 
 	//描画用設定
 	void SetMatrix(gstd::ref_count_ptr<Matrices> matrix) { matrix_ = matrix; }
@@ -506,7 +506,7 @@ protected:
 	gstd::ref_count_ptr<Matrices> matrix_;
 	D3DCOLOR color_;
 	D3DMATERIAL9 materialBNX_;
-	virtual void _CreateVertexDeclaration();
+	void _CreateVertexDeclaration() override;
 	virtual void _CopyVertexBufferOnInitialize() = 0;
 };
 
@@ -530,9 +530,9 @@ protected:
 class RenderObjectB2NX : public RenderObjectBNX {
 public:
 	RenderObjectB2NX();
-	~RenderObjectB2NX();
+	~RenderObjectB2NX() override;
 
-	virtual void CalculateWeightCenter();
+	void CalculateWeightCenter() override;
 
 	//頂点設定
 	VERTEX_B2NX* GetVertex(int index);
@@ -543,14 +543,14 @@ public:
 	void SetVertexNormal(int index, float x, float y, float z);
 
 protected:
-	virtual void _CopyVertexBufferOnInitialize();
+	void _CopyVertexBufferOnInitialize() override;
 };
 
 class RenderObjectB2NXBlock : public RenderObjectBNXBlock {
 public:
 	RenderObjectB2NXBlock();
-	virtual ~RenderObjectB2NXBlock();
-	virtual void Render();
+	~RenderObjectB2NXBlock() override;
+	void Render() override;
 };
 
 /**********************************************************
@@ -562,9 +562,9 @@ public:
 class RenderObjectB4NX : public RenderObjectBNX {
 public:
 	RenderObjectB4NX();
-	~RenderObjectB4NX();
+	~RenderObjectB4NX() override;
 
-	virtual void CalculateWeightCenter();
+	void CalculateWeightCenter() override;
 
 	//頂点設定
 	VERTEX_B4NX* GetVertex(int index);
@@ -575,14 +575,14 @@ public:
 	void SetVertexNormal(int index, float x, float y, float z);
 
 protected:
-	virtual void _CopyVertexBufferOnInitialize();
+	void _CopyVertexBufferOnInitialize() override;
 };
 
 class RenderObjectB4NXBlock : public RenderObjectBNXBlock {
 public:
 	RenderObjectB4NXBlock();
-	virtual ~RenderObjectB4NXBlock();
-	virtual void Render();
+	~RenderObjectB4NXBlock() override;
+	void Render() override;
 };
 
 /**********************************************************
@@ -592,7 +592,7 @@ public:
 class Sprite2D : public RenderObjectTLX {
 public:
 	Sprite2D();
-	~Sprite2D();
+	~Sprite2D() override;
 	void Copy(const Sprite2D* src);
 	void SetSourceRect(const RECT_D& rcSrc);
 	void SetDestinationRect(const RECT_D& rcDest);
@@ -609,8 +609,8 @@ public:
 class SpriteList2D : public RenderObjectTLX {
 public:
 	SpriteList2D();
-	virtual int GetVertexCount() const;
-	virtual void Render();
+	int GetVertexCount() const override;
+	void Render() override;
 	void ClearVertexCount()
 	{
 		countRenderVertex_ = 0;
@@ -640,7 +640,7 @@ private:
 class Sprite3D : public RenderObjectLX {
 public:
 	Sprite3D();
-	~Sprite3D();
+	~Sprite3D() override;
 	void SetSourceRect(const RECT_D& rcSrc);
 	void SetDestinationRect(const RECT_D& rcDest);
 	void SetVertex(const RECT_D& rcSrc, const RECT_D& rcDest, D3DCOLOR color = D3DCOLOR_ARGB(255, 255, 255, 255));
@@ -650,7 +650,7 @@ public:
 
 protected:
 	bool bBillboard_;
-	virtual D3DXMATRIX _CreateWorldTransformMaxtrix();
+	D3DXMATRIX _CreateWorldTransformMaxtrix() override;
 };
 
 /**********************************************************
@@ -660,9 +660,9 @@ protected:
 class TrajectoryObject3D : public RenderObjectLX {
 public:
 	TrajectoryObject3D();
-	~TrajectoryObject3D();
+	~TrajectoryObject3D() override;
 	virtual void Work();
-	virtual void Render();
+	void Render() override;
 	void SetInitialLine(D3DXVECTOR3 pos1, D3DXVECTOR3 pos2);
 	void AddPoint(D3DXMATRIX mat);
 	void SetAlphaVariation(int diff) { diffAlpha_ = diff; }
@@ -684,7 +684,7 @@ protected:
 	Data dataLast1_;
 	Data dataLast2_;
 	std::list<Data> listData_;
-	virtual D3DXMATRIX _CreateWorldTransformMaxtrix();
+	D3DXMATRIX _CreateWorldTransformMaxtrix() override;
 
 };
 
@@ -704,7 +704,7 @@ public:
 public:
 	DxMeshData();
 	virtual ~DxMeshData();
-	void SetName(std::wstring name) { name_ = name; }
+	void SetName(const std::wstring& name) { name_ = name; }
 	std::wstring& GetName() { return name_; }
 	virtual bool CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> reader) = 0;
 
@@ -719,7 +719,7 @@ public:
 
 public:
 	DxMesh();
-	virtual ~DxMesh();
+	~DxMesh() override;
 	virtual void Release();
 	bool CreateFromFile(const std::wstring& _path);
 	virtual bool CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> reader) = 0;
@@ -740,14 +740,14 @@ public:
 	void SetY(float y) { position_.y = y; }
 	void SetZ(float z) { position_.z = z; }
 	void SetAngle(D3DXVECTOR3 angle) { angle_ = angle; }
-	void SetAngleXYZ(float angx = 0.0f, float angy = 0.0f, float angz = 0.0f)
+	void SetAngleXYZ(float angx = 0.0F, float angy = 0.0F, float angz = 0.0F)
 	{
 		angle_.x = angx;
 		angle_.y = angy;
 		angle_.z = angz;
 	}
 	void SetScale(D3DXVECTOR3 scale) { scale_ = scale; }
-	void SetScaleXYZ(float sx = 1.0f, float sy = 1.0f, float sz = 1.0f)
+	void SetScaleXYZ(float sx = 1.0F, float sy = 1.0F, float sz = 1.0F)
 	{
 		scale_.x = sx;
 		scale_.y = sy;
@@ -761,7 +761,7 @@ public:
 	bool IsCoordinate2D() const { return bCoordinate2D_; }
 	void SetCoordinate2D(bool b) { bCoordinate2D_ = b; }
 
-	gstd::ref_count_ptr<RenderBlocks> CreateRenderBlocks() { return NULL; }
+	gstd::ref_count_ptr<RenderBlocks> CreateRenderBlocks() { return nullptr; }
 	virtual D3DXMATRIX GetAnimationMatrix(const std::wstring& nameAnime, double time, const std::wstring& nameBone)
 	{
 		D3DXMATRIX mat;
@@ -795,7 +795,7 @@ class DxMeshManager : public gstd::FileManager::LoadThreadListener {
 
 public:
 	DxMeshManager();
-	virtual ~DxMeshManager();
+	~DxMeshManager() override;
 	static DxMeshManager* GetBase() { return thisBase_; }
 	bool Initialize();
 	gstd::CriticalSection& GetLock() { return lock_; }
@@ -806,7 +806,7 @@ public:
 	virtual bool IsDataExists(const std::wstring& name);
 
 	gstd::ref_count_ptr<DxMesh> CreateFromFileInLoadThread(const std::wstring& path, int type);
-	virtual void CallFromLoadThread(gstd::ref_count_ptr<gstd::FileManager::LoadThreadEvent> event);
+	void CallFromLoadThread(gstd::ref_count_ptr<gstd::FileManager::LoadThreadEvent> event) override;
 
 	void SetInfoPanel(gstd::ref_count_ptr<DxMeshInfoPanel> panel) { panelInfo_ = panel; }
 
@@ -827,8 +827,8 @@ private:
 class DxMeshInfoPanel : public gstd::WindowLogger::Panel, public gstd::Thread {
 public:
 	DxMeshInfoPanel();
-	~DxMeshInfoPanel();
-	virtual void LocateParts();
+	~DxMeshInfoPanel() override;
+	void LocateParts() override;
 	virtual void Update(DxMeshManager* manager);
 
 protected:
@@ -840,8 +840,8 @@ protected:
 	};
 	int timeUpdateInterval_;
 	gstd::WListView wndListView_;
-	virtual bool _AddedLogger(HWND hTab);
-	void _Run();
+	bool _AddedLogger(HWND hTab) override;
+	void _Run() override;
 };
 
 } // namespace directx

--- a/source/GcLib/directx/RenderObject.hpp
+++ b/source/GcLib/directx/RenderObject.hpp
@@ -45,7 +45,7 @@ struct VERTEX_TLX {
 struct VERTEX_L {
 	//ライティング済み
 	VERTEX_L() {}
-	VERTEX_L(const D3DXVECTOR3& pos, const D3DCOLOR& col)
+	VERTEX_L(D3DXVECTOR3 pos, D3DCOLOR col)
 		: position(pos)
 		, diffuse_color(col)
 	{
@@ -58,7 +58,7 @@ struct VERTEX_L {
 struct VERTEX_LX {
 	//ライティング済み、テクスチャ有り
 	VERTEX_LX() {}
-	VERTEX_LX(D3DXVECTOR3& pos, D3DCOLOR& diffcol, D3DXVECTOR2 tex)
+	VERTEX_LX(D3DXVECTOR3 pos, D3DCOLOR diffcol, D3DXVECTOR2 tex)
 		: position(pos)
 		, diffuse_color(diffcol)
 		, texcoord(tex)
@@ -86,7 +86,7 @@ struct VERTEX_N {
 struct VERTEX_NX {
 	//未ライティング、テクスチャ有り
 	VERTEX_NX() {}
-	VERTEX_NX(D3DXVECTOR3& pos, D3DXVECTOR3& n, D3DXVECTOR2& tc)
+	VERTEX_NX(D3DXVECTOR3 pos, D3DXVECTOR3 n, D3DXVECTOR2 tc)
 		: position(pos)
 		, normal(n)
 		, texcoord(tc)
@@ -116,7 +116,7 @@ struct VERTEX_NXG {
 struct VERTEX_B1NX {
 	//未ライティング、テクスチャ有り、頂点ブレンド1
 	VERTEX_B1NX() {}
-	VERTEX_B1NX(D3DXVECTOR3& pos, DWORD bi, D3DXVECTOR3& n, D3DXVECTOR2& tc)
+	VERTEX_B1NX(D3DXVECTOR3 pos, DWORD bi, D3DXVECTOR3 n, D3DXVECTOR2 tc)
 		: position(pos)
 		, normal(n)
 		, texcoord(tc)
@@ -133,7 +133,7 @@ struct VERTEX_B1NX {
 struct VERTEX_B2NX {
 	//未ライティング、テクスチャ有り、頂点ブレンド2
 	VERTEX_B2NX() {}
-	VERTEX_B2NX(D3DXVECTOR3& pos, float rate, BYTE index1, BYTE index2, D3DXVECTOR3& n, D3DXVECTOR2& tc)
+	VERTEX_B2NX(D3DXVECTOR3 pos, float rate, BYTE index1, BYTE index2, D3DXVECTOR3 n, D3DXVECTOR2 tc)
 		: position(pos)
 		, normal(n)
 		, texcoord(tc)
@@ -153,7 +153,7 @@ struct VERTEX_B2NX {
 struct VERTEX_B4NX {
 	//未ライティング、テクスチャ有り、頂点ブレンド4
 	VERTEX_B4NX() {}
-	VERTEX_B4NX(D3DXVECTOR3& pos, float rate[3], BYTE index[4], D3DXVECTOR3& n, D3DXVECTOR2& tc)
+	VERTEX_B4NX(D3DXVECTOR3 pos, float rate[3], BYTE index[4], D3DXVECTOR3 n, D3DXVECTOR2 tc)
 		: position(pos)
 		, normal(n)
 		, texcoord(tc)
@@ -186,7 +186,7 @@ public:
 	virtual void Render();
 
 	virtual void CalculateZValue() = 0;
-	float GetZValue() { return posSortKey_; }
+	float GetZValue() const { return posSortKey_; }
 	void SetZValue(float pos) { posSortKey_ = pos; }
 	virtual bool IsTranslucent() = 0; //Zソート対象に使用
 
@@ -226,8 +226,6 @@ protected:
 //順に描画する
 **********************************************************/
 class RenderManager {
-	class ComparatorRenderBlockTranslucent;
-
 public:
 	RenderManager();
 	virtual ~RenderManager();
@@ -238,14 +236,6 @@ public:
 protected:
 	std::list<gstd::ref_count_ptr<RenderBlock>> listBlockOpaque_;
 	std::list<gstd::ref_count_ptr<RenderBlock>> listBlockTranslucent_;
-};
-
-class RenderManager::ComparatorRenderBlockTranslucent {
-public:
-	bool operator()(gstd::ref_count_ptr<RenderBlock> l, gstd::ref_count_ptr<RenderBlock> r)
-	{
-		return l->GetZValue() > r->GetZValue();
-	}
 };
 
 /**********************************************************
@@ -291,7 +281,7 @@ public:
 			D3DXMatrixIdentity(&matrix_[iMat]);
 		}
 	}
-	int GetSize() { return matrix_.size(); }
+	int GetSize() const { return matrix_.size(); }
 	void SetMatrix(int index, D3DXMATRIX& mat) { matrix_[index] = mat; }
 	D3DXMATRIX& GetMatrix(int index) { return matrix_[index]; }
 
@@ -313,7 +303,7 @@ public:
 	virtual void Render() = 0;
 	virtual void InitializeVertexBuffer() {}
 	virtual void CalculateWeightCenter() {}
-	D3DXVECTOR3 GetWeightCenter() { return posWeightCenter_; }
+	D3DXVECTOR3 GetWeightCenter() const { return posWeightCenter_; }
 	gstd::ref_count_ptr<Texture> GetTexture(int pos = 0) { return texture_[pos]; }
 
 	void SetRalativeMatrix(D3DXMATRIX mat) { matRelative_ = mat; }
@@ -325,12 +315,12 @@ public:
 		vertex_.SetSize(count * strideVertexStreamZero_);
 		ZeroMemory(vertex_.GetPointer(), vertex_.GetSize());
 	}
-	virtual int GetVertexCount() { return vertex_.GetSize() / strideVertexStreamZero_; }
-	void SetVertexIndicies(std::vector<short>& indecies) { vertexIndices_ = indecies; }
+	virtual int GetVertexCount() const { return vertex_.GetSize() / strideVertexStreamZero_; }
+	void SetVertexIndicies(const std::vector<short>& indices) { vertexIndices_ = indices; }
 	gstd::ByteBuffer* GetVertexPointer() { return &vertex_; }
 
 	//描画用設定
-	void SetPosition(D3DXVECTOR3& pos) { position_ = pos; }
+	void SetPosition(const D3DXVECTOR3& pos) { position_ = pos; }
 	void SetPosition(float x, float y, float z)
 	{
 		position_.x = x;
@@ -340,24 +330,24 @@ public:
 	void SetX(float x) { position_.x = x; }
 	void SetY(float y) { position_.y = y; }
 	void SetZ(float z) { position_.z = z; }
-	void SetAngle(D3DXVECTOR3& angle) { angle_ = angle; }
+	void SetAngle(const D3DXVECTOR3& angle) { angle_ = angle; }
 	void SetAngleXYZ(float angx = 0.0f, float angy = 0.0f, float angz = 0.0f)
 	{
 		angle_.x = angx;
 		angle_.y = angy;
 		angle_.z = angz;
 	}
-	void SetScale(D3DXVECTOR3& scale) { scale_ = scale; }
+	void SetScale(const D3DXVECTOR3& scale) { scale_ = scale; }
 	void SetScaleXYZ(float sx = 1.0f, float sy = 1.0f, float sz = 1.0f)
 	{
 		scale_.x = sx;
 		scale_.y = sy;
 		scale_.z = sz;
 	}
-	void SetTexture(Texture* texture, int stage = 0); //テクスチャ設定
+	void SetTexture(const Texture* texture, int stage = 0); //テクスチャ設定
 	void SetTexture(gstd::ref_count_ptr<Texture> texture, int stage = 0); //テクスチャ設定
 
-	bool IsCoordinate2D() { return bCoordinate2D_; }
+	bool IsCoordinate2D() const { return bCoordinate2D_; }
 	void SetCoordinate2D(bool b) { bCoordinate2D_ = b; }
 
 	gstd::ref_count_ptr<Shader> GetShader() { return shader_; }
@@ -389,7 +379,7 @@ protected:
 	virtual void _RestoreVertexBuffer();
 	virtual void _CreateVertexDeclaration() {}
 
-	int _GetPrimitiveCount();
+	int _GetPrimitiveCount() const;
 	void _SetTextureStageCount(int count)
 	{
 		texture_.resize(count);
@@ -414,7 +404,7 @@ public:
 
 	//頂点設定
 	VERTEX_TLX* GetVertex(int index);
-	void SetVertex(int index, VERTEX_TLX& vertex);
+	void SetVertex(int index, const VERTEX_TLX& vertex);
 	void SetVertexPosition(int index, float x, float y, float z = 1.0f, float w = 1.0f);
 	void SetVertexUV(int index, float u, float v);
 	void SetVertexColor(int index, D3DCOLOR color);
@@ -425,7 +415,7 @@ public:
 	void SetAlpha(int alpha);
 
 	//カメラ
-	bool IsPermitCamera() { return bPermitCamera_; }
+	bool IsPermitCamera() const { return bPermitCamera_; }
 	void SetPermitCamera(bool bPermit) { bPermitCamera_ = bPermit; }
 
 protected:
@@ -475,7 +465,7 @@ public:
 
 	//頂点設定
 	VERTEX_NX* GetVertex(int index);
-	void SetVertex(int index, VERTEX_NX& vertex);
+	void SetVertex(int index, const VERTEX_NX& vertex);
 	void SetVertexPosition(int index, float x, float y, float z);
 	void SetVertexUV(int index, float u, float v);
 	void SetVertexNormal(int index, float x, float y, float z);
@@ -524,7 +514,7 @@ class RenderObjectBNXBlock : public RenderBlock {
 public:
 	void SetMatrix(gstd::ref_count_ptr<Matrices> matrix) { matrix_ = matrix; }
 	void SetColor(D3DCOLOR color) { color_ = color; }
-	bool IsTranslucent() { return ColorAccess::GetColorA(color_) != 255; }
+	bool IsTranslucent() const { return ColorAccess::GetColorA(color_) != 255; }
 
 protected:
 	gstd::ref_count_ptr<Matrices> matrix_;
@@ -578,7 +568,7 @@ public:
 
 	//頂点設定
 	VERTEX_B4NX* GetVertex(int index);
-	void SetVertex(int index, VERTEX_B4NX& vertex);
+	void SetVertex(int index, const VERTEX_B4NX& vertex);
 	void SetVertexPosition(int index, float x, float y, float z);
 	void SetVertexUV(int index, float u, float v);
 	void SetVertexBlend(int index, int pos, BYTE indexBlend, float rate);
@@ -603,11 +593,11 @@ class Sprite2D : public RenderObjectTLX {
 public:
 	Sprite2D();
 	~Sprite2D();
-	void Copy(Sprite2D* src);
-	void SetSourceRect(RECT_D& rcSrc);
-	void SetDestinationRect(RECT_D& rcDest);
+	void Copy(const Sprite2D* src);
+	void SetSourceRect(const RECT_D& rcSrc);
+	void SetDestinationRect(const RECT_D& rcDest);
 	void SetDestinationCenter();
-	void SetVertex(RECT_D& rcSrc, RECT_D& rcDest, D3DCOLOR color = D3DCOLOR_ARGB(255, 255, 255, 255));
+	void SetVertex(const RECT_D& rcSrc, const RECT_D& rcDest, D3DCOLOR color = D3DCOLOR_ARGB(255, 255, 255, 255));
 
 	RECT_D GetDestinationRect();
 };
@@ -619,7 +609,7 @@ public:
 class SpriteList2D : public RenderObjectTLX {
 public:
 	SpriteList2D();
-	virtual int GetVertexCount();
+	virtual int GetVertexCount() const;
 	virtual void Render();
 	void ClearVertexCount()
 	{
@@ -627,10 +617,10 @@ public:
 		bCloseVertexList_ = false;
 	}
 	void AddVertex();
-	void SetSourceRect(RECT_D& rcSrc) { rcSrc_ = rcSrc; }
-	void SetDestinationRect(RECT_D& rcDest) { rcDest_ = rcDest; }
+	void SetSourceRect(const RECT_D& rcSrc) { rcSrc_ = rcSrc; }
+	void SetDestinationRect(const RECT_D& rcDest) { rcDest_ = rcDest; }
 	void SetDestinationCenter();
-	D3DCOLOR GetColor() { return color_; }
+	D3DCOLOR GetColor() const { return color_; }
 	void SetColor(D3DCOLOR color) { color_ = color; }
 	void CloseVertex();
 
@@ -651,11 +641,11 @@ class Sprite3D : public RenderObjectLX {
 public:
 	Sprite3D();
 	~Sprite3D();
-	void SetSourceRect(RECT_D& rcSrc);
-	void SetDestinationRect(RECT_D& rcDest);
-	void SetVertex(RECT_D& rcSrc, RECT_D& rcDest, D3DCOLOR color = D3DCOLOR_ARGB(255, 255, 255, 255));
-	void SetSourceDestRect(RECT_D& rcSrc);
-	void SetVertex(RECT_D& rcSrc, D3DCOLOR color = D3DCOLOR_ARGB(255, 255, 255, 255));
+	void SetSourceRect(const RECT_D& rcSrc);
+	void SetDestinationRect(const RECT_D& rcDest);
+	void SetVertex(const RECT_D& rcSrc, const RECT_D& rcDest, D3DCOLOR color = D3DCOLOR_ARGB(255, 255, 255, 255));
+	void SetSourceDestRect(const RECT_D& rcSrc);
+	void SetVertex(const RECT_D& rcSrc, D3DCOLOR color = D3DCOLOR_ARGB(255, 255, 255, 255));
 	void SetBillboardEnable(bool bEnable) { bBillboard_ = bEnable; }
 
 protected:
@@ -731,14 +721,14 @@ public:
 	DxMesh();
 	virtual ~DxMesh();
 	virtual void Release();
-	bool CreateFromFile(std::wstring path);
+	bool CreateFromFile(const std::wstring& _path);
 	virtual bool CreateFromFileReader(gstd::ref_count_ptr<gstd::FileReader> reader) = 0;
-	virtual bool CreateFromFileInLoadThread(std::wstring path, int type);
-	virtual bool CreateFromFileInLoadThread(std::wstring path) = 0;
+	virtual bool CreateFromFileInLoadThread(const std::wstring& path, int type);
+	virtual bool CreateFromFileInLoadThread(const std::wstring& path) = 0;
 	virtual std::wstring GetPath() = 0;
 
 	virtual void Render() = 0;
-	virtual void Render(std::wstring nameAnime, int time) { Render(); }
+	virtual void Render(const std::wstring& nameAnime, int time) { Render(); }
 	void SetPosition(D3DXVECTOR3 pos) { position_ = pos; }
 	void SetPosition(float x, float y, float z)
 	{
@@ -768,11 +758,11 @@ public:
 	void SetColorRGB(D3DCOLOR color);
 	void SetAlpha(int alpha);
 
-	bool IsCoordinate2D() { return bCoordinate2D_; }
+	bool IsCoordinate2D() const { return bCoordinate2D_; }
 	void SetCoordinate2D(bool b) { bCoordinate2D_ = b; }
 
 	gstd::ref_count_ptr<RenderBlocks> CreateRenderBlocks() { return NULL; }
-	virtual D3DXMATRIX GetAnimationMatrix(std::wstring nameAnime, double time, std::wstring nameBone)
+	virtual D3DXMATRIX GetAnimationMatrix(const std::wstring& nameAnime, double time, const std::wstring& nameBone)
 	{
 		D3DXMATRIX mat;
 		D3DXMatrixIdentity(&mat);
@@ -790,7 +780,7 @@ protected:
 	gstd::ref_count_ptr<Shader> shader_;
 
 	gstd::ref_count_ptr<DxMeshData> data_;
-	gstd::ref_count_ptr<DxMeshData> _GetFromManager(std::wstring name);
+	gstd::ref_count_ptr<DxMeshData> _GetFromManager(const std::wstring& name);
 	void _AddManager(std::wstring name, gstd::ref_count_ptr<DxMeshData> data);
 };
 
@@ -811,11 +801,11 @@ public:
 	gstd::CriticalSection& GetLock() { return lock_; }
 
 	virtual void Clear();
-	virtual void Add(std::wstring name, gstd::ref_count_ptr<DxMesh> mesh); //参照を保持します
-	virtual void Release(std::wstring name); //保持している参照を解放します
-	virtual bool IsDataExists(std::wstring name);
+	virtual void Add(const std::wstring& name, gstd::ref_count_ptr<DxMesh> mesh); //参照を保持します
+	virtual void Release(const std::wstring& name); //保持している参照を解放します
+	virtual bool IsDataExists(const std::wstring& name);
 
-	gstd::ref_count_ptr<DxMesh> CreateFromFileInLoadThread(std::wstring path, int type);
+	gstd::ref_count_ptr<DxMesh> CreateFromFileInLoadThread(const std::wstring& path, int type);
 	virtual void CallFromLoadThread(gstd::ref_count_ptr<gstd::FileManager::LoadThreadEvent> event);
 
 	void SetInfoPanel(gstd::ref_count_ptr<DxMeshInfoPanel> panel) { panelInfo_ = panel; }
@@ -826,9 +816,9 @@ protected:
 	std::map<std::wstring, gstd::ref_count_ptr<DxMeshData>> mapMeshData_;
 	gstd::ref_count_ptr<DxMeshInfoPanel> panelInfo_;
 
-	void _AddMeshData(std::wstring name, gstd::ref_count_ptr<DxMeshData> data);
-	gstd::ref_count_ptr<DxMeshData> _GetMeshData(std::wstring name);
-	void _ReleaseMeshData(std::wstring name);
+	void _AddMeshData(const std::wstring& name, gstd::ref_count_ptr<DxMeshData> data);
+	gstd::ref_count_ptr<DxMeshData> _GetMeshData(const std::wstring& name);
+	void _ReleaseMeshData(const std::wstring& name);
 
 private:
 	static DxMeshManager* thisBase_;

--- a/source/GcLib/directx/ScriptManager.cpp
+++ b/source/GcLib/directx/ScriptManager.cpp
@@ -161,7 +161,7 @@ int ScriptManager::GetAllScriptThreadCount()
 	}
 	return res;
 }
-void ScriptManager::TerminateScriptAll(std::wstring message)
+void ScriptManager::TerminateScriptAll(const std::wstring& message)
 {
 	{
 		Lock lock(lock_);
@@ -171,7 +171,7 @@ void ScriptManager::TerminateScriptAll(std::wstring message)
 		}
 	}
 }
-_int64 ScriptManager::_LoadScript(std::wstring path, ref_count_ptr<ManagedScript> script)
+_int64 ScriptManager::_LoadScript(const std::wstring& path, ref_count_ptr<ManagedScript> script)
 {
 	_int64 res = 0;
 
@@ -190,7 +190,7 @@ _int64 ScriptManager::_LoadScript(std::wstring path, ref_count_ptr<ManagedScript
 
 	return res;
 }
-_int64 ScriptManager::LoadScript(std::wstring path, ref_count_ptr<ManagedScript> script)
+_int64 ScriptManager::LoadScript(const std::wstring& path, ref_count_ptr<ManagedScript> script)
 {
 	_int64 res = 0;
 	{
@@ -200,13 +200,13 @@ _int64 ScriptManager::LoadScript(std::wstring path, ref_count_ptr<ManagedScript>
 	}
 	return res;
 }
-_int64 ScriptManager::LoadScript(std::wstring path, int type)
+_int64 ScriptManager::LoadScript(const std::wstring& path, int type)
 {
 	ref_count_ptr<ManagedScript> script = Create(type);
 	_int64 res = LoadScript(path, script);
 	return res;
 }
-_int64 ScriptManager::LoadScriptInThread(std::wstring path, ref_count_ptr<ManagedScript> script)
+_int64 ScriptManager::LoadScriptInThread(const std::wstring& path, ref_count_ptr<ManagedScript> script)
 {
 	_int64 res = 0;
 	{
@@ -220,7 +220,7 @@ _int64 ScriptManager::LoadScriptInThread(std::wstring path, ref_count_ptr<Manage
 	}
 	return res;
 }
-_int64 ScriptManager::LoadScriptInThread(std::wstring path, int type)
+_int64 ScriptManager::LoadScriptInThread(const std::wstring& path, int type)
 {
 	ref_count_ptr<ManagedScript> script = Create(type);
 	_int64 res = LoadScriptInThread(path, script);
@@ -242,7 +242,7 @@ void ScriptManager::CallFromLoadThread(gstd::ref_count_ptr<gstd::FileManager::Lo
 		SetError(e.what());
 	}
 }
-void ScriptManager::RequestEventAll(int type, std::vector<gstd::value>& listValue)
+void ScriptManager::RequestEventAll(int type, const std::vector<gstd::value>& listValue)
 {
 	{
 		std::list<ref_count_ptr<ManagedScript>>::iterator itrScript = listScriptRun_.begin();
@@ -331,7 +331,7 @@ void ManagedScript::SetScriptManager(ScriptManager* manager)
 	mainThreadID_ = scriptManager_->GetMainThreadID();
 	idScript_ = scriptManager_->IssueScriptID();
 }
-gstd::value ManagedScript::RequestEvent(int type, std::vector<gstd::value>& listValue)
+gstd::value ManagedScript::RequestEvent(int type, const std::vector<gstd::value>& listValue)
 {
 	gstd::value res;
 	std::string event = "Event";

--- a/source/GcLib/directx/ScriptManager.hpp
+++ b/source/GcLib/directx/ScriptManager.hpp
@@ -23,10 +23,10 @@ public:
 	virtual void Work(int targetType);
 	virtual void Render();
 
-	virtual void SetError(std::wstring error) { error_ = error; }
-	virtual bool IsError() { return error_ != L""; }
+	virtual void SetError(const std::wstring& error) { error_ = error; }
+	virtual bool IsError() const { return error_ != L""; }
 
-	int GetMainThreadID() { return mainThreadID_; }
+	int GetMainThreadID() const { return mainThreadID_; }
 	_int64 IssueScriptID()
 	{
 		{
@@ -41,23 +41,25 @@ public:
 	void CloseScript(_int64 id);
 	void CloseScriptOnType(int type);
 	bool IsCloseScript(_int64 id);
-	int IsHasCloseScliptWork() { return bHasCloseScriptWork_; }
+	int IsHasCloseScliptWork() const { return bHasCloseScriptWork_; }
 	int GetAllScriptThreadCount();
-	void TerminateScriptAll(std::wstring message);
+	void TerminateScriptAll(const std::wstring& message);
 
-	_int64 LoadScript(std::wstring path, gstd::ref_count_ptr<ManagedScript> script);
-	_int64 LoadScript(std::wstring path, int type);
-	_int64 LoadScriptInThread(std::wstring path, gstd::ref_count_ptr<ManagedScript> script);
-	_int64 LoadScriptInThread(std::wstring path, int type);
+	_int64 LoadScript(const std::wstring& path, gstd::ref_count_ptr<ManagedScript> script);
+	_int64 LoadScript(const std::wstring& path, int type);
+	_int64 LoadScriptInThread(const std::wstring& path, gstd::ref_count_ptr<ManagedScript> script);
+	_int64 LoadScriptInThread(const std::wstring& path, int type);
 	virtual void CallFromLoadThread(gstd::ref_count_ptr<gstd::FileManager::LoadThreadEvent> event);
 
 	virtual gstd::ref_count_ptr<ManagedScript> Create(int type) = 0;
-	virtual void RequestEventAll(int type, std::vector<gstd::value>& listValue = std::vector<gstd::value>());
+	virtual void RequestEventAll(int type, const std::vector<gstd::value>& listValue = std::vector<gstd::value>());
 	gstd::value GetScriptResult(_int64 idScript);
 	void AddRelativeScriptManager(gstd::ref_count_weak_ptr<ScriptManager> manager) { listRelativeManager_.push_back(manager); }
 	static void AddRelativeScriptManagerMutual(gstd::ref_count_weak_ptr<ScriptManager> manager1, gstd::ref_count_weak_ptr<ScriptManager> manager2);
 
 protected:
+	_int64 _LoadScript(const std::wstring& path, gstd::ref_count_ptr<ManagedScript> script);
+
 	gstd::CriticalSection lock_;
 	static _int64 idScript_;
 	bool bHasCloseScriptWork_;
@@ -69,8 +71,6 @@ protected:
 	std::list<gstd::ref_count_weak_ptr<ScriptManager>> listRelativeManager_;
 
 	int mainThreadID_;
-
-	_int64 _LoadScript(std::wstring path, gstd::ref_count_ptr<ManagedScript> script);
 };
 
 /**********************************************************
@@ -95,14 +95,14 @@ public:
 	virtual void SetScriptParameter(gstd::ref_count_ptr<ManagedScriptParameter> param) { scriptParam_ = param; }
 	gstd::ref_count_ptr<ManagedScriptParameter> GetScriptParameter() { return scriptParam_; }
 
-	int GetScriptType() { return typeScript_; }
-	bool IsLoad() { return bLoad_; }
-	bool IsEndScript() { return bEndScript_; }
+	int GetScriptType() const { return typeScript_; }
+	bool IsLoad() const { return bLoad_; }
+	bool IsEndScript() const { return bEndScript_; }
 	void SetEndScript() { bEndScript_ = true; }
-	bool IsAutoDeleteObject() { return bAutoDeleteObject_; }
+	bool IsAutoDeleteObject() const { return bAutoDeleteObject_; }
 	void SetAutoDeleteObject(bool bEneble) { bAutoDeleteObject_ = bEneble; }
 
-	gstd::value RequestEvent(int type, std::vector<gstd::value>& listValue = std::vector<gstd::value>());
+	gstd::value RequestEvent(int type, const std::vector<gstd::value>& listValue = std::vector<gstd::value>());
 
 	//制御共通関数：共通データ
 	static gstd::value Func_SaveCommonDataAreaA1(gstd::script_machine* machine, int argc, gstd::value const* argv);

--- a/source/GcLib/directx/ScriptManager.hpp
+++ b/source/GcLib/directx/ScriptManager.hpp
@@ -18,68 +18,66 @@ public:
 
 public:
 	ScriptManager();
-	virtual ~ScriptManager();
+	~ScriptManager() override;
 	virtual void Work();
 	virtual void Work(int targetType);
 	virtual void Render();
 
 	virtual void SetError(const std::wstring& error) { error_ = error; }
-	virtual bool IsError() const { return error_ != L""; }
+	virtual bool IsError() const { return !error_.empty(); }
 
 	int GetMainThreadID() const { return mainThreadID_; }
-	_int64 IssueScriptID()
+	int64_t IssueScriptID()
 	{
-		{
-			gstd::Lock lock(lock_);
-			idScript_++;
-			return idScript_;
-		}
+		gstd::Lock lock(lock_);
+		++idScript_;
+		return idScript_;
 	}
 
-	gstd::ref_count_ptr<ManagedScript> GetScript(_int64 id);
-	void StartScript(_int64 id);
-	void CloseScript(_int64 id);
+	gstd::ref_count_ptr<ManagedScript> GetScript(int64_t id);
+	void StartScript(int64_t id);
+	void CloseScript(int64_t id);
 	void CloseScriptOnType(int type);
-	bool IsCloseScript(_int64 id);
-	int IsHasCloseScliptWork() const { return bHasCloseScriptWork_; }
-	int GetAllScriptThreadCount();
+	bool IsCloseScript(int64_t id);
+	bool IsHasCloseScriptWork() const { return bHasCloseScriptWork_; }
+	int GetAllScriptThreadCount() const;
 	void TerminateScriptAll(const std::wstring& message);
 
-	_int64 LoadScript(const std::wstring& path, gstd::ref_count_ptr<ManagedScript> script);
-	_int64 LoadScript(const std::wstring& path, int type);
-	_int64 LoadScriptInThread(const std::wstring& path, gstd::ref_count_ptr<ManagedScript> script);
-	_int64 LoadScriptInThread(const std::wstring& path, int type);
-	virtual void CallFromLoadThread(gstd::ref_count_ptr<gstd::FileManager::LoadThreadEvent> event);
+	int64_t LoadScript(const std::wstring& path, gstd::ref_count_ptr<ManagedScript> script);
+	int64_t LoadScript(const std::wstring& path, int type);
+	int64_t LoadScriptInThread(const std::wstring& path, gstd::ref_count_ptr<ManagedScript> script);
+	int64_t LoadScriptInThread(const std::wstring& path, int type);
+	void CallFromLoadThread(gstd::ref_count_ptr<gstd::FileManager::LoadThreadEvent> event) override;
 
 	virtual gstd::ref_count_ptr<ManagedScript> Create(int type) = 0;
 	virtual void RequestEventAll(int type, const std::vector<gstd::value>& listValue = std::vector<gstd::value>());
-	gstd::value GetScriptResult(_int64 idScript);
+	gstd::value GetScriptResult(int64_t idScript);
 	void AddRelativeScriptManager(gstd::ref_count_weak_ptr<ScriptManager> manager) { listRelativeManager_.push_back(manager); }
 	static void AddRelativeScriptManagerMutual(gstd::ref_count_weak_ptr<ScriptManager> manager1, gstd::ref_count_weak_ptr<ScriptManager> manager2);
 
 protected:
-	_int64 _LoadScript(const std::wstring& path, gstd::ref_count_ptr<ManagedScript> script);
+	int64_t _LoadScript(const std::wstring& path, gstd::ref_count_ptr<ManagedScript> script);
 
-	gstd::CriticalSection lock_;
-	static _int64 idScript_;
+	mutable gstd::CriticalSection lock_;
+	static int64_t idScript_;
 	bool bHasCloseScriptWork_;
 
 	std::wstring error_;
-	std::map<_int64, gstd::ref_count_ptr<ManagedScript>> mapScriptLoad_;
+	std::map<int64_t, gstd::ref_count_ptr<ManagedScript>> mapScriptLoad_;
 	std::list<gstd::ref_count_ptr<ManagedScript>> listScriptRun_;
-	std::map<_int64, gstd::value> mapClosedScriptResult_;
+	std::map<int64_t, gstd::value> mapClosedScriptResult_;
 	std::list<gstd::ref_count_weak_ptr<ScriptManager>> listRelativeManager_;
 
 	int mainThreadID_;
 };
 
 /**********************************************************
-	//ManagedScript
-	**********************************************************/
+//ManagedScript
+**********************************************************/
 class ManagedScriptParameter {
 public:
-	ManagedScriptParameter() {}
-	virtual ~ManagedScriptParameter() {}
+	ManagedScriptParameter() = default;
+	virtual ~ManagedScriptParameter() = default;
 };
 class ManagedScript : public DxScript, public gstd::FileManager::LoadObject {
 	friend ScriptManager;

--- a/source/GcLib/directx/Shader.cpp
+++ b/source/GcLib/directx/Shader.cpp
@@ -9,23 +9,19 @@ using namespace directx;
 **********************************************************/
 ShaderData::ShaderData()
 {
-	manager_ = NULL;
+	manager_ = nullptr;
 	bLoad_ = false;
-	effect_ = NULL;
+	effect_ = nullptr;
 	bText_ = false;
 }
-ShaderData::~ShaderData()
-{
-}
+ShaderData::~ShaderData() = default;
 
 /**********************************************************
 //ShaderManager
 **********************************************************/
 const std::wstring NAME_DEFAULT_SKINNED_MESH = L"__NAME_DEFAULT_SKINNED_MESH__";
-ShaderManager* ShaderManager::thisBase_ = NULL;
-ShaderManager::ShaderManager()
-{
-}
+ShaderManager* ShaderManager::thisBase_ = nullptr;
+ShaderManager::ShaderManager() = default;
 ShaderManager::~ShaderManager()
 {
 	DirectGraphics* graphics = DirectGraphics::GetBase();
@@ -35,7 +31,7 @@ ShaderManager::~ShaderManager()
 }
 bool ShaderManager::Initialize()
 {
-	if (thisBase_ != NULL)
+	if (thisBase_ != nullptr)
 		return false;
 
 	bool res = true;
@@ -99,7 +95,7 @@ bool ShaderManager::_CreateFromFile(const std::wstring& _Path)
 
 	std::wstring path = PathProperty::GetUnique(_Path);
 	ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-	if (reader == NULL || !reader->Open()) {
+	if (reader == nullptr || !reader->Open()) {
 		std::wstring log = StringUtility::Format(L"Shader読み込み失敗(Shader Load Failed)：\r\n%s", path.c_str());
 		Logger::WriteTop(log);
 		lastError_ = log;
@@ -118,7 +114,7 @@ bool ShaderManager::_CreateFromFile(const std::wstring& _Path)
 	gstd::ref_count_ptr<ShaderData> data(new ShaderData());
 
 	DirectGraphics* graphics = DirectGraphics::GetBase();
-	ID3DXBuffer* pErr = NULL;
+	ID3DXBuffer* pErr = nullptr;
 	HRESULT hr = D3DXCreateEffect(
 		graphics->GetDevice(),
 		source.c_str(),
@@ -132,8 +128,8 @@ bool ShaderManager::_CreateFromFile(const std::wstring& _Path)
 	bool res = true;
 	if (FAILED(hr)) {
 		res = false;
-		std::wstring err = L"";
-		if (pErr != NULL) {
+		std::wstring err;
+		if (pErr != nullptr) {
 			char* cText = (char*)pErr->GetBufferPointer();
 			err = StringUtility::ConvertMultiToWide(cText);
 		}
@@ -162,7 +158,7 @@ bool ShaderManager::_CreateFromText(const std::string& source)
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 
 	gstd::ref_count_ptr<ShaderData> data(new ShaderData());
-	ID3DXBuffer* pErr = NULL;
+	ID3DXBuffer* pErr = nullptr;
 	HRESULT hr = D3DXCreateEffect(
 		graphics->GetDevice(),
 		source.c_str(),
@@ -177,7 +173,7 @@ bool ShaderManager::_CreateFromText(const std::string& source)
 	if (FAILED(hr)) {
 		res = false;
 		char* err = "";
-		if (pErr != NULL)
+		if (pErr != nullptr)
 			err = (char*)pErr->GetBufferPointer();
 		std::wstring log = StringUtility::Format(L"Shader読み込み失敗(Load Shader Failed)：\r\n%s\r\n[%s]", tStr.c_str(), err);
 		Logger::WriteTop(log);
@@ -202,20 +198,20 @@ std::wstring ShaderManager::_GetTextSourceID(const std::string& source)
 }
 void ShaderManager::_BeginShader(Shader* shader, int pass)
 {
-	Shader* lastShader = NULL;
-	if (listExecuteShader_.size() > 0) {
+	Shader* lastShader = nullptr;
+	if (!listExecuteShader_.empty()) {
 		lastShader = *listExecuteShader_.rbegin();
 	}
 
-	if (shader != NULL && shader != lastShader) {
-		if (lastShader != NULL) {
+	if (shader != nullptr && shader != lastShader) {
+		if (lastShader != nullptr) {
 			lastShader->_EndPass();
 			lastShader->_End();
 		}
 
 		shader->_Begin();
 		shader->_BeginPass(pass);
-	} else if (shader == NULL && lastShader != NULL) {
+	} else if (shader == nullptr && lastShader != nullptr) {
 		lastShader->_EndPass();
 		lastShader->_End();
 	}
@@ -223,8 +219,8 @@ void ShaderManager::_BeginShader(Shader* shader, int pass)
 }
 void ShaderManager::_EndShader(Shader* shader)
 {
-	Shader* preShader = NULL;
-	if (listExecuteShader_.size() > 0) {
+	Shader* preShader = nullptr;
+	if (!listExecuteShader_.empty()) {
 		preShader = *listExecuteShader_.rbegin();
 		listExecuteShader_.pop_back();
 	}
@@ -232,8 +228,8 @@ void ShaderManager::_EndShader(Shader* shader)
 	if (shader != preShader)
 		throw gstd::wexception(L"EndShader異常");
 
-	preShader = NULL;
-	if (listExecuteShader_.size() > 0) {
+	preShader = nullptr;
+	if (!listExecuteShader_.empty()) {
 		preShader = *listExecuteShader_.rbegin();
 	}
 
@@ -243,7 +239,7 @@ void ShaderManager::_EndShader(Shader* shader)
 	shader->_EndPass();
 	shader->_End();
 
-	if (preShader != NULL) {
+	if (preShader != nullptr) {
 		shader->_Begin();
 		shader->_BeginPass();
 	}
@@ -251,85 +247,66 @@ void ShaderManager::_EndShader(Shader* shader)
 
 void ShaderManager::ReleaseDxResource()
 {
-	std::map<std::wstring, gstd::ref_count_ptr<Shader>>::iterator itrMap;
-	{
-		for (itrMap = mapShader_.begin(); itrMap != mapShader_.end(); itrMap++) {
-			std::wstring name = itrMap->first;
-			Shader* data = (itrMap->second).GetPointer();
-			data->ReleaseDxResource();
-		}
+	for (auto itrMap = mapShader_.begin(); itrMap != mapShader_.end(); ++itrMap) {
+		std::wstring name = itrMap->first;
+		Shader* data = (itrMap->second).GetPointer();
+		data->ReleaseDxResource();
 	}
 }
 void ShaderManager::RestoreDxResource()
 {
-	std::map<std::wstring, gstd::ref_count_ptr<Shader>>::iterator itrMap;
-	{
-		for (itrMap = mapShader_.begin(); itrMap != mapShader_.end(); itrMap++) {
-			std::wstring name = itrMap->first;
-			Shader* data = (itrMap->second).GetPointer();
-			data->RestoreDxResource();
-		}
+	for (auto itrMap = mapShader_.begin(); itrMap != mapShader_.end(); ++itrMap) {
+		std::wstring name = itrMap->first;
+		Shader* data = (itrMap->second).GetPointer();
+		data->RestoreDxResource();
 	}
 }
 
-bool ShaderManager::IsDataExists(const std::wstring& name)
+bool ShaderManager::IsDataExists(const std::wstring& name) const
 {
-	bool res = false;
-	{
 		Lock lock(lock_);
-		res = mapShaderData_.find(name) != mapShaderData_.end();
-	}
-	return res;
+		return mapShaderData_.find(name) != mapShaderData_.end();
 }
 gstd::ref_count_ptr<ShaderData> ShaderManager::GetShaderData(const std::wstring& name)
 {
-	gstd::ref_count_ptr<ShaderData> res;
-	{
-		Lock lock(lock_);
-		bool bExist = mapShaderData_.find(name) != mapShaderData_.end();
-		if (bExist) {
-			res = mapShaderData_[name];
-		}
+	Lock lock(lock_);
+	auto shaderDataItr = mapShaderData_.find(name);
+	if (shaderDataItr != mapShaderData_.end()) {
+		return shaderDataItr->second;
 	}
-	return res;
+	return nullptr;
 }
 gstd::ref_count_ptr<Shader> ShaderManager::CreateFromFile(const std::wstring& _Path)
 {
+	Lock lock(lock_);
 	std::wstring path = PathProperty::GetUnique(_Path);
-	gstd::ref_count_ptr<Shader> res;
-	{
-		Lock lock(lock_);
-		bool bExist = mapShader_.find(path) != mapShader_.end();
-		if (bExist) {
-			res = mapShader_[path];
-		} else {
-			bool bSuccess = _CreateFromFile(path);
-			if (bSuccess) {
-				res = new Shader();
-				res->data_ = mapShaderData_[path];
-			}
+	auto shaderItr = mapShader_.find(path);
+	if (shaderItr != mapShader_.end()) {
+		return shaderItr->second;
+	} else {
+		if (_CreateFromFile(path)) {
+			gstd::ref_count_ptr<Shader> res = new Shader();
+			res->data_ = mapShaderData_[path];
+			return res;
 		}
 	}
-	return res;
+	return nullptr;
 }
 gstd::ref_count_ptr<Shader> ShaderManager::CreateFromText(const std::string& source)
 {
-	gstd::ref_count_ptr<Shader> res;
-	{
-		Lock lock(lock_);
-		std::wstring id = _GetTextSourceID(source);
-		bool bExist = mapShader_.find(id) != mapShader_.end();
-		if (bExist) {
-			res = mapShader_[id];
-		} else {
-			bool bSuccess = _CreateFromText(source);
-			if (bSuccess) {
-				res = new Shader();
-				res->data_ = mapShaderData_[id];
-			}
+	Lock lock(lock_);
+	std::wstring id = _GetTextSourceID(source);
+	auto shaderItr = mapShader_.find(id);
+	if (shaderItr != mapShader_.end()) {
+		return shaderItr->second;
+	} else {
+		if (_CreateFromText(source) == true) {
+			gstd::ref_count_ptr<Shader> res = new Shader();
+			res->data_ = mapShaderData_[id];
+			return res;
 		}
 	}
-	return res;
+	return nullptr;
 }
 gstd::ref_count_ptr<Shader> ShaderManager::CreateFromFileInLoadThread(const std::wstring& path)
 {
@@ -341,48 +318,38 @@ void ShaderManager::CallFromLoadThread(gstd::ref_count_ptr<gstd::FileManager::Lo
 
 void ShaderManager::AddShader(const std::wstring& name, gstd::ref_count_ptr<Shader> shader)
 {
-	{
-		Lock lock(lock_);
-		mapShader_[name] = shader;
-	}
+	Lock lock(lock_);
+	mapShader_[name] = shader;
 }
 void ShaderManager::DeleteShader(const std::wstring& name)
 {
-	{
-		Lock lock(lock_);
-		mapShader_.erase(name);
-	}
+	Lock lock(lock_);
+	mapShader_.erase(name);
 }
 gstd::ref_count_ptr<Shader> ShaderManager::GetShader(const std::wstring& name)
 {
-	gstd::ref_count_ptr<Shader> res;
-	{
-		Lock lock(lock_);
-		bool bExist = mapShader_.find(name) != mapShader_.end();
-		if (bExist) {
-			res = mapShader_[name];
-		}
+	Lock lock(lock_);
+	auto shaderItr = mapShader_.find(name);
+	if (shaderItr != mapShader_.end()) {
+		return shaderItr->second;
 	}
-	return res;
+	return nullptr;
 }
 gstd::ref_count_ptr<Shader> ShaderManager::GetDefaultSkinnedMeshShader()
 {
-	gstd::ref_count_ptr<Shader> res = GetShader(NAME_DEFAULT_SKINNED_MESH);
-	return res;
+	return GetShader(NAME_DEFAULT_SKINNED_MESH);
 }
 void ShaderManager::CheckExecutingShaderZero() const
 {
-	if (listExecuteShader_.size() > 0)
+	if (!listExecuteShader_.empty())
 		throw gstd::wexception(L"CheckExecutingShaderZero");
 }
 std::wstring ShaderManager::GetLastError()
 {
-	std::wstring res;
 	{
 		Lock lock(lock_);
-		res = lastError_;
+		return lastError_;
 	}
-	return res;
 }
 
 /**********************************************************
@@ -393,9 +360,7 @@ ShaderParameter::ShaderParameter()
 	type_ = TYPE_UNKNOWN;
 	value_ = new ByteBuffer();
 }
-ShaderParameter::~ShaderParameter()
-{
-}
+ShaderParameter::~ShaderParameter() = default;
 void ShaderParameter::SetMatrix(D3DXMATRIX& matrix)
 {
 	type_ = TYPE_MATRIX;
@@ -405,8 +370,7 @@ void ShaderParameter::SetMatrix(D3DXMATRIX& matrix)
 }
 D3DXMATRIX ShaderParameter::GetMatrix()
 {
-	D3DXMATRIX res = (D3DXMATRIX&)*value_->GetPointer();
-	return res;
+	return (D3DXMATRIX&)*value_->GetPointer();
 }
 void ShaderParameter::SetMatrixArray(std::vector<D3DXMATRIX>& listMatrix)
 {
@@ -419,14 +383,14 @@ void ShaderParameter::SetMatrixArray(std::vector<D3DXMATRIX>& listMatrix)
 std::vector<D3DXMATRIX> ShaderParameter::GetMatrixArray()
 {
 	int count = value_->GetSize() / sizeof(D3DMATRIX);
-	std::vector<D3DXMATRIX> res(count);
+	std::vector<D3DXMATRIX> matrixArray(count);
 
 	value_->Seek(0);
-	for (auto& matrix : res) {
+	for (auto& matrix : matrixArray) {
 		value_->Read(&matrix.m, sizeof(D3DMATRIX));
 	}
 
-	return res;
+	return matrixArray;
 }
 void ShaderParameter::SetVector(D3DXVECTOR4& vector)
 {
@@ -437,8 +401,7 @@ void ShaderParameter::SetVector(D3DXVECTOR4& vector)
 }
 D3DXVECTOR4 ShaderParameter::GetVector()
 {
-	D3DXVECTOR4 res = (D3DXVECTOR4&)*value_->GetPointer();
-	return res;
+	return (D3DXVECTOR4&)*value_->GetPointer();
 }
 void ShaderParameter::SetFloat(float value)
 {
@@ -449,8 +412,7 @@ void ShaderParameter::SetFloat(float value)
 }
 float ShaderParameter::GetFloat()
 {
-	float res = (float&)*value_->GetPointer();
-	return res;
+	return (float&)*value_->GetPointer();
 }
 void ShaderParameter::SetFloatArray(std::vector<float>& values)
 {
@@ -461,13 +423,12 @@ void ShaderParameter::SetFloatArray(std::vector<float>& values)
 }
 std::vector<float> ShaderParameter::GetFloatArray()
 {
-	std::vector<float> res;
 	int count = value_->GetSize() / sizeof(float);
-	res.resize(count);
+	std::vector<float> floatArray(count);
 
 	value_->Seek(0);
-	value_->Read(&res[0], value_->GetSize());
-	return res;
+	value_->Read(&floatArray[0], value_->GetSize());
+	return floatArray;
 }
 void ShaderParameter::SetTexture(const gstd::ref_count_ptr<Texture> texture)
 {
@@ -484,7 +445,7 @@ gstd::ref_count_ptr<Texture> ShaderParameter::GetTexture()
 **********************************************************/
 Shader::Shader()
 {
-	data_ = NULL;
+	data_ = nullptr;
 	// bLoadShader_ = false;
 	// pVertexShader_ = NULL;
 	// pPixelShader_ = NULL;
@@ -508,25 +469,24 @@ void Shader::Release()
 	// 	pPixelShader_->Release();
 	{
 		Lock lock(ShaderManager::GetBase()->GetLock());
-		if (data_ != NULL) {
+		if (data_ != nullptr) {
 			ShaderManager* manager = data_->manager_;
-			if (manager != NULL && manager->IsDataExists(data_->name_)) {
+			if (manager != nullptr && manager->IsDataExists(data_->name_)) {
 				int countRef = data_.GetReferenceCount();
 				//自身とTextureManager内の数だけになったら削除
 				if (countRef == 2) {
 					manager->_ReleaseShaderData(data_->name_);
 				}
 			}
-			data_ = NULL;
+			data_ = nullptr;
 		}
 	}
 }
 
-int Shader::Begin(int pass)
+void Shader::Begin(int pass)
 {
 	ShaderManager* manager = ShaderManager::GetBase();
 	manager->_BeginShader(this, pass);
-	return 1;
 }
 void Shader::End()
 {
@@ -536,66 +496,55 @@ void Shader::End()
 
 ID3DXEffect* Shader::GetEffect()
 {
-	ID3DXEffect* res = NULL;
-	if (data_ != NULL)
+	ID3DXEffect* res = nullptr;
+	if (data_ != nullptr)
 		res = data_->effect_;
 	return res;
 }
 void Shader::ReleaseDxResource()
 {
 	ID3DXEffect* effect = GetEffect();
-	if (effect == NULL)
+	if (effect == nullptr)
 		return;
 	effect->OnLostDevice();
 }
 void Shader::RestoreDxResource()
 {
 	ID3DXEffect* effect = GetEffect();
-	if (effect == NULL)
+	if (effect == nullptr)
 		return;
 	effect->OnResetDevice();
 }
 bool Shader::CreateFromFile(const std::wstring& _Path)
 {
+	Lock lock(ShaderManager::GetBase()->GetLock());
 	std::wstring path = PathProperty::GetUnique(_Path);
-
-	bool res = false;
-	{
-		Lock lock(ShaderManager::GetBase()->GetLock());
-		if (data_ != NULL)
-			Release();
-		ShaderManager* manager = ShaderManager::GetBase();
-		ref_count_ptr<Shader> shader = manager->CreateFromFile(path);
-		if (shader != NULL) {
-			data_ = shader->data_;
-		}
-		res = data_ != NULL;
+	if (data_ != nullptr)
+		Release();
+	ShaderManager* manager = ShaderManager::GetBase();
+	ref_count_ptr<Shader> shader = manager->CreateFromFile(path);
+	if (shader != nullptr) {
+		data_ = shader->data_;
 	}
-
-	return res;
+	return (data_ != nullptr);
 }
 bool Shader::CreateFromText(const std::string& source)
 {
-	bool res = false;
-	{
-		Lock lock(ShaderManager::GetBase()->GetLock());
-		if (data_ != NULL)
-			Release();
-		ShaderManager* manager = ShaderManager::GetBase();
-		ref_count_ptr<Shader> shader = manager->CreateFromText(source);
-		if (shader != NULL) {
-			data_ = shader->data_;
-		}
-		res = data_ != NULL;
+	Lock lock(ShaderManager::GetBase()->GetLock());
+	if (data_ != nullptr)
+		Release();
+	ShaderManager* manager = ShaderManager::GetBase();
+	ref_count_ptr<Shader> shader = manager->CreateFromText(source);
+	if (shader != nullptr) {
+		data_ = shader->data_;
 	}
-
-	return res;
+	return (data_ != nullptr);
 }
 
 int Shader::_Begin()
 {
 	ID3DXEffect* effect = GetEffect();
-	if (effect == NULL)
+	if (effect == nullptr)
 		return 0;
 	_SetupParameter();
 
@@ -606,14 +555,14 @@ int Shader::_Begin()
 void Shader::_End()
 {
 	ID3DXEffect* effect = GetEffect();
-	if (effect == NULL)
+	if (effect == nullptr)
 		return;
 	effect->End();
 }
 void Shader::_BeginPass(int pass)
 {
 	ID3DXEffect* effect = GetEffect();
-	if (effect == NULL)
+	if (effect == nullptr)
 		return;
 	effect->BeginPass(pass);
 	/*
@@ -640,7 +589,7 @@ void Shader::_BeginPass(int pass)
 void Shader::_EndPass()
 {
 	ID3DXEffect* effect = GetEffect();
-	if (effect == NULL)
+	if (effect == nullptr)
 		return;
 	effect->EndPass();
 
@@ -654,7 +603,7 @@ void Shader::_EndPass()
 bool Shader::_SetupParameter()
 {
 	ID3DXEffect* effect = GetEffect();
-	if (effect == NULL)
+	if (effect == nullptr)
 		return false;
 	HRESULT hr = effect->SetTechnique(technique_.c_str());
 	if (FAILED(hr))
@@ -707,9 +656,9 @@ gstd::ref_count_ptr<ShaderParameter> Shader::_GetParameter(const std::string& na
 {
 	bool bFind = mapParam_.find(name) != mapParam_.end();
 	if (!bFind && !bCreate)
-		return NULL;
+		return nullptr;
 
-	gstd::ref_count_ptr<ShaderParameter> res = NULL;
+	gstd::ref_count_ptr<ShaderParameter> res = nullptr;
 	if (!bFind) {
 		res = new ShaderParameter();
 		mapParam_[name] = res;
@@ -722,7 +671,7 @@ gstd::ref_count_ptr<ShaderParameter> Shader::_GetParameter(const std::string& na
 bool Shader::SetTechnique(const std::string& name)
 {
 	// ID3DXEffect* effect = GetEffect();
-	// if (effect == NULL)
+	// if (effect == nullptr)
 	// 	return false;
 	// effect->SetTechnique(name.c_str());
 
@@ -732,7 +681,7 @@ bool Shader::SetTechnique(const std::string& name)
 bool Shader::SetMatrix(const std::string& name, D3DXMATRIX& matrix)
 {
 	// ID3DXEffect* effect = GetEffect();
-	// if (effect == NULL)
+	// if (effect == nullptr)
 	// 	return false;
 	// effect->SetMatrix(name.c_str(), &matrix);
 
@@ -744,7 +693,7 @@ bool Shader::SetMatrix(const std::string& name, D3DXMATRIX& matrix)
 bool Shader::SetMatrixArray(const std::string& name, std::vector<D3DXMATRIX>& matrix)
 {
 	// ID3DXEffect* effect = GetEffect();
-	// if (effect == NULL)
+	// if (effect == nullptr)
 	// 	return false;
 	// effect->SetMatrixArray(name.c_str(), &matrix[0], matrix.size());
 
@@ -756,7 +705,7 @@ bool Shader::SetMatrixArray(const std::string& name, std::vector<D3DXMATRIX>& ma
 bool Shader::SetVector(const std::string& name, D3DXVECTOR4& vector)
 {
 	// ID3DXEffect* effect = GetEffect();
-	// if (effect == NULL)
+	// if (effect == nullptr)
 	// 	return false;
 	// effect->SetVector(name.c_str(), &vector);
 
@@ -766,10 +715,10 @@ bool Shader::SetVector(const std::string& name, D3DXVECTOR4& vector)
 }
 bool Shader::SetFloat(const std::string& name, float value)
 {
-	//ID3DXEffect* effect = GetEffect();
-	//if (effect == NULL)
+	// ID3DXEffect* effect = GetEffect();
+	// if (effect == nullptr)
 	// 	return false;
-	//effect->SetFloat(name.c_str(), value);
+	// effect->SetFloat(name.c_str(), value);
 
 	gstd::ref_count_ptr<ShaderParameter> param = _GetParameter(name, true);
 	param->SetFloat(value);

--- a/source/GcLib/directx/Shader.hpp
+++ b/source/GcLib/directx/Shader.hpp
@@ -23,7 +23,7 @@ class ShaderData {
 public:
 	ShaderData();
 	virtual ~ShaderData();
-	std::wstring GetName() { return name_; }
+	std::wstring GetName() const { return name_; }
 
 private:
 	ShaderManager* manager_;
@@ -53,19 +53,19 @@ public:
 	void ReleaseDxResource();
 	void RestoreDxResource();
 
-	virtual bool IsDataExists(std::wstring name);
-	gstd::ref_count_ptr<ShaderData> GetShaderData(std::wstring name);
-	gstd::ref_count_ptr<Shader> CreateFromFile(std::wstring path); //読み込みます。ShaderDataは保持しますが、Shaderは保持しません。
-	gstd::ref_count_ptr<Shader> CreateFromText(std::string source); //読み込みます。ShaderDataは保持しますが、Shaderは保持しません。
-	gstd::ref_count_ptr<Shader> CreateFromFileInLoadThread(std::wstring path);
+	virtual bool IsDataExists(const std::wstring& name);
+	gstd::ref_count_ptr<ShaderData> GetShaderData(const std::wstring& name);
+	gstd::ref_count_ptr<Shader> CreateFromFile(const std::wstring& path); //読み込みます。ShaderDataは保持しますが、Shaderは保持しません。
+	gstd::ref_count_ptr<Shader> CreateFromText(const std::string& source); //読み込みます。ShaderDataは保持しますが、Shaderは保持しません。
+	gstd::ref_count_ptr<Shader> CreateFromFileInLoadThread(const std::wstring& path);
 	virtual void CallFromLoadThread(gstd::ref_count_ptr<gstd::FileManager::LoadThreadEvent> event);
 
-	void AddShader(std::wstring name, gstd::ref_count_ptr<Shader> shader);
-	void DeleteShader(std::wstring name);
-	gstd::ref_count_ptr<Shader> GetShader(std::wstring name);
+	void AddShader(const std::wstring& name, gstd::ref_count_ptr<Shader> shader);
+	void DeleteShader(const std::wstring& name);
+	gstd::ref_count_ptr<Shader> GetShader(const std::wstring& name);
 	gstd::ref_count_ptr<Shader> GetDefaultSkinnedMeshShader();
 
-	void CheckExecutingShaderZero();
+	void CheckExecutingShaderZero() const;
 	std::wstring GetLastError();
 
 protected:
@@ -76,12 +76,12 @@ protected:
 	std::list<Shader*> listExecuteShader_;
 	std::wstring lastError_;
 
-	void _ReleaseShaderData(std::wstring name);
-	bool _CreateFromFile(std::wstring path);
-	bool _CreateFromText(std::string& source);
+	void _ReleaseShaderData(const std::wstring& name);
+	bool _CreateFromFile(const std::wstring& path);
+	bool _CreateFromText(const std::string& source);
 	void _BeginShader(Shader* shader, int pass);
 	void _EndShader(Shader* shader);
-	static std::wstring _GetTextSourceID(std::string& source);
+	static std::wstring _GetTextSourceID(const std::string& source);
 
 private:
 	static ShaderManager* thisBase_;
@@ -106,7 +106,7 @@ public:
 	ShaderParameter();
 	virtual ~ShaderParameter();
 
-	int GetType() { return type_; }
+	int GetType() const { return type_; }
 	void SetMatrix(D3DXMATRIX& matrix);
 	D3DXMATRIX GetMatrix();
 	void SetMatrixArray(std::vector<D3DXMATRIX>& matrix);
@@ -117,7 +117,7 @@ public:
 	float GetFloat();
 	void SetFloatArray(std::vector<float>& values);
 	std::vector<float> GetFloatArray();
-	void SetTexture(gstd::ref_count_ptr<Texture> texture);
+	void SetTexture(const gstd::ref_count_ptr<Texture> texture);
 	gstd::ref_count_ptr<Texture> GetTexture();
 
 private:
@@ -134,7 +134,7 @@ class Shader {
 
 public:
 	Shader();
-	Shader(Shader* shader);
+	Shader(const Shader* shader);
 	virtual ~Shader();
 	void Release();
 
@@ -145,17 +145,17 @@ public:
 	void ReleaseDxResource();
 	void RestoreDxResource();
 
-	bool CreateFromFile(std::wstring path);
-	bool CreateFromText(std::string& source);
-	bool IsLoad() { return data_ != NULL && data_->bLoad_; }
+	bool CreateFromFile(const std::wstring& path);
+	bool CreateFromText(const std::string& source);
+	bool IsLoad() const { return data_ != NULL && data_->bLoad_; }
 
-	bool SetTechnique(std::string name);
-	bool SetMatrix(std::string name, D3DXMATRIX& matrix);
-	bool SetMatrixArray(std::string name, std::vector<D3DXMATRIX>& matrix);
-	bool SetVector(std::string name, D3DXVECTOR4& vector);
-	bool SetFloat(std::string name, float value);
-	bool SetFloatArray(std::string name, std::vector<float>& values);
-	bool SetTexture(std::string name, gstd::ref_count_ptr<Texture> texture);
+	bool SetTechnique(const std::string& name);
+	bool SetMatrix(const std::string& name, D3DXMATRIX& matrix);
+	bool SetMatrixArray(const std::string& name, std::vector<D3DXMATRIX>& matrix);
+	bool SetVector(const std::string& name, D3DXVECTOR4& vector);
+	bool SetFloat(const std::string& name, float value);
+	bool SetFloatArray(const std::string& name, std::vector<float>& values);
+	bool SetTexture(const std::string& name, gstd::ref_count_ptr<Texture> texture);
 
 protected:
 	gstd::ref_count_ptr<ShaderData> data_;
@@ -168,7 +168,7 @@ protected:
 	std::map<std::string, gstd::ref_count_ptr<ShaderParameter>> mapParam_;
 
 	ShaderData* _GetShaderData() { return data_.GetPointer(); }
-	gstd::ref_count_ptr<ShaderParameter> _GetParameter(std::string name, bool bCreate);
+	gstd::ref_count_ptr<ShaderParameter> _GetParameter(const std::string& name, bool bCreate);
 
 	int _Begin();
 	void _End();

--- a/source/GcLib/directx/Shader.hpp
+++ b/source/GcLib/directx/Shader.hpp
@@ -42,18 +42,18 @@ class ShaderManager : public DirectGraphicsListener {
 
 public:
 	ShaderManager();
-	virtual ~ShaderManager();
+	~ShaderManager() override;
 	static ShaderManager* GetBase() { return thisBase_; }
 	virtual bool Initialize();
 	gstd::CriticalSection& GetLock() { return lock_; }
 	void Clear();
 
-	virtual void ReleaseDirectGraphics() { ReleaseDxResource(); }
-	virtual void RestoreDirectGraphics() { RestoreDxResource(); }
+	void ReleaseDirectGraphics() override { ReleaseDxResource(); }
+	void RestoreDirectGraphics() override { RestoreDxResource(); }
 	void ReleaseDxResource();
 	void RestoreDxResource();
 
-	virtual bool IsDataExists(const std::wstring& name);
+	virtual bool IsDataExists(const std::wstring& name) const;
 	gstd::ref_count_ptr<ShaderData> GetShaderData(const std::wstring& name);
 	gstd::ref_count_ptr<Shader> CreateFromFile(const std::wstring& path); //読み込みます。ShaderDataは保持しますが、Shaderは保持しません。
 	gstd::ref_count_ptr<Shader> CreateFromText(const std::string& source); //読み込みます。ShaderDataは保持しますが、Shaderは保持しません。
@@ -69,7 +69,7 @@ public:
 	std::wstring GetLastError();
 
 protected:
-	gstd::CriticalSection lock_;
+	mutable gstd::CriticalSection lock_;
 	std::map<std::wstring, gstd::ref_count_ptr<Shader>> mapShader_;
 	std::map<std::wstring, gstd::ref_count_ptr<ShaderData>> mapShaderData_;
 
@@ -117,7 +117,7 @@ public:
 	float GetFloat();
 	void SetFloatArray(std::vector<float>& values);
 	std::vector<float> GetFloatArray();
-	void SetTexture(const gstd::ref_count_ptr<Texture> texture);
+	void SetTexture(gstd::ref_count_ptr<Texture> texture);
 	gstd::ref_count_ptr<Texture> GetTexture();
 
 private:
@@ -138,7 +138,7 @@ public:
 	virtual ~Shader();
 	void Release();
 
-	int Begin(int pass = 0);
+	void Begin(int pass = 0);
 	void End();
 
 	ID3DXEffect* GetEffect();
@@ -147,7 +147,7 @@ public:
 
 	bool CreateFromFile(const std::wstring& path);
 	bool CreateFromText(const std::string& source);
-	bool IsLoad() const { return data_ != NULL && data_->bLoad_; }
+	bool IsLoad() const { return data_ != nullptr && data_->bLoad_; }
 
 	bool SetTechnique(const std::string& name);
 	bool SetMatrix(const std::string& name, D3DXMATRIX& matrix);

--- a/source/GcLib/directx/Texture.cpp
+++ b/source/GcLib/directx/Texture.cpp
@@ -34,7 +34,7 @@ TextureData::~TextureData()
 Texture::Texture()
 {
 }
-Texture::Texture(Texture* texture)
+Texture::Texture(const Texture* texture)
 {
 	{
 		Lock lock(TextureManager::GetBase()->GetLock());
@@ -198,23 +198,23 @@ IDirect3DSurface9* Texture::GetD3DZBuffer()
 	}
 	return res;
 }
-int Texture::GetWidth()
+int Texture::GetWidth() const
 {
 	int res = 0;
 	{
 		Lock lock(TextureManager::GetBase()->GetLock());
-		TextureData* data = _GetTextureData();
+		const TextureData* data = _GetTextureData();
 		if (data != NULL)
 			res = data->infoImage_.Width;
 	}
 	return res;
 }
-int Texture::GetHeight()
+int Texture::GetHeight() const
 {
 	int res = 0;
 	{
 		Lock lock(TextureManager::GetBase()->GetLock());
-		TextureData* data = _GetTextureData();
+		const TextureData* data = _GetTextureData();
 		if (data != NULL)
 			res = data->infoImage_.Height;
 	}

--- a/source/GcLib/directx/Texture.cpp
+++ b/source/GcLib/directx/Texture.cpp
@@ -9,10 +9,10 @@ using namespace directx;
 **********************************************************/
 TextureData::TextureData()
 {
-	manager_ = NULL;
-	pTexture_ = NULL;
-	lpRenderSurface_ = NULL;
-	lpRenderZ_ = NULL;
+	manager_ = nullptr;
+	pTexture_ = nullptr;
+	lpRenderSurface_ = nullptr;
+	lpRenderZ_ = nullptr;
 	bLoad_ = true;
 
 	ZeroMemory(&infoImage_, sizeof(D3DXIMAGE_INFO));
@@ -20,20 +20,18 @@ TextureData::TextureData()
 }
 TextureData::~TextureData()
 {
-	if (pTexture_ != NULL)
+	if (pTexture_ != nullptr)
 		pTexture_->Release();
-	if (lpRenderSurface_ != NULL)
+	if (lpRenderSurface_ != nullptr)
 		lpRenderSurface_->Release();
-	if (lpRenderZ_ != NULL)
+	if (lpRenderZ_ != nullptr)
 		lpRenderZ_->Release();
 }
 
 /**********************************************************
 //Texture
 **********************************************************/
-Texture::Texture()
-{
-}
+Texture::Texture() = default;
 Texture::Texture(const Texture* texture)
 {
 	{
@@ -49,185 +47,148 @@ void Texture::Release()
 {
 	{
 		Lock lock(TextureManager::GetBase()->GetLock());
-		if (data_ != NULL) {
+		if (data_ != nullptr) {
 			TextureManager* manager = data_->manager_;
-			if (manager != NULL && manager->IsDataExists(data_->name_)) {
+			if (manager != nullptr && manager->IsDataExists(data_->name_)) {
 				int countRef = data_.GetReferenceCount();
 				//自身とTextureManager内の数だけになったら削除
 				if (countRef == 2) {
 					manager->_ReleaseTextureData(data_->name_);
 				}
 			}
-			data_ = NULL;
+			data_ = nullptr;
 		}
 	}
 }
 std::wstring Texture::GetName()
 {
-	std::wstring res = L"";
-	{
-		Lock lock(TextureManager::GetBase()->GetLock());
-		if (data_ != NULL)
-			res = data_->GetName();
-	}
-	return res;
+	Lock lock(TextureManager::GetBase()->GetLock());
+	if (data_ != nullptr)
+		return data_->GetName();
+	return L"";
 }
-bool Texture::CreateFromFile(std::wstring path)
+bool Texture::CreateFromFile(const std::wstring& _Path)
 {
-	path = PathProperty::GetUnique(path);
-
-	bool res = false;
-	{
-		Lock lock(TextureManager::GetBase()->GetLock());
-		if (data_ != NULL)
-			Release();
-		TextureManager* manager = TextureManager::GetBase();
-		ref_count_ptr<Texture> texture = manager->CreateFromFile(path);
-		if (texture != NULL) {
-			data_ = texture->data_;
-		}
-		res = data_ != NULL;
+	Lock lock(TextureManager::GetBase()->GetLock());
+	std::wstring path = PathProperty::GetUnique(_Path);
+	if (data_ != nullptr)
+		Release();
+	TextureManager* manager = TextureManager::GetBase();
+	ref_count_ptr<Texture> texture = manager->CreateFromFile(path);
+	if (texture != nullptr) {
+		data_ = texture->data_;
 	}
-
-	return res;
+	return (data_ != nullptr);
 }
 
-bool Texture::CreateRenderTarget(std::wstring name)
+bool Texture::CreateRenderTarget(const std::wstring& name)
 {
-	bool res = false;
-	{
-		Lock lock(TextureManager::GetBase()->GetLock());
-		if (data_ != NULL)
-			Release();
-		TextureManager* manager = TextureManager::GetBase();
-		ref_count_ptr<Texture> texture = manager->CreateRenderTarget(name);
-		if (texture != NULL) {
-			data_ = texture->data_;
-		}
-		res = data_ != NULL;
+	Lock lock(TextureManager::GetBase()->GetLock());
+	if (data_ != nullptr)
+		Release();
+	TextureManager* manager = TextureManager::GetBase();
+	ref_count_ptr<Texture> texture = manager->CreateRenderTarget(name);
+	if (texture != nullptr) {
+		data_ = texture->data_;
 	}
-	return res;
+	return (data_ != nullptr);
 }
-bool Texture::CreateFromFileInLoadThread(std::wstring path, bool bLoadImageInfo)
+bool Texture::CreateFromFileInLoadThread(const std::wstring& _Path, bool bLoadImageInfo)
 {
-	path = PathProperty::GetUnique(path);
-
-	bool res = false;
-	{
-		Lock lock(TextureManager::GetBase()->GetLock());
-		if (data_ != NULL)
-			Release();
-		TextureManager* manager = TextureManager::GetBase();
-		ref_count_ptr<Texture> texture = manager->CreateFromFileInLoadThread(path, bLoadImageInfo);
-		if (texture != NULL) {
-			data_ = texture->data_;
-		}
-		res = data_ != NULL;
+	std::wstring path = PathProperty::GetUnique(_Path);
+	Lock lock(TextureManager::GetBase()->GetLock());
+	if (data_ != nullptr)
+		Release();
+	TextureManager* manager = TextureManager::GetBase();
+	ref_count_ptr<Texture> texture = manager->CreateFromFileInLoadThread(path, bLoadImageInfo);
+	if (texture != nullptr) {
+		data_ = texture->data_;
 	}
-
-	return res;
+	return (data_ != nullptr);
 }
 void Texture::SetTexture(IDirect3DTexture9* pTexture)
 {
-	{
-		Lock lock(TextureManager::GetBase()->GetLock());
-		if (data_ != NULL)
-			Release();
-		TextureData* textureData = new TextureData();
-		textureData->pTexture_ = pTexture;
-		D3DSURFACE_DESC desc;
-		pTexture->GetLevelDesc(0, &desc);
+	Lock lock(TextureManager::GetBase()->GetLock());
+	if (data_ != nullptr)
+		Release();
+	auto* textureData = new TextureData();
+	textureData->pTexture_ = pTexture;
+	D3DSURFACE_DESC desc;
+	pTexture->GetLevelDesc(0, &desc);
 
-		D3DXIMAGE_INFO* infoImage = &textureData->infoImage_;
-		infoImage->Width = desc.Width;
-		infoImage->Height = desc.Height;
-		infoImage->Format = desc.Format;
-		infoImage->ImageFileFormat = D3DXIFF_BMP;
-		infoImage->ResourceType = D3DRTYPE_TEXTURE;
-		data_ = textureData;
-	}
+	D3DXIMAGE_INFO* infoImage = &textureData->infoImage_;
+	infoImage->Width = desc.Width;
+	infoImage->Height = desc.Height;
+	infoImage->Format = desc.Format;
+	infoImage->ImageFileFormat = D3DXIFF_BMP;
+	infoImage->ResourceType = D3DRTYPE_TEXTURE;
+	data_ = textureData;
 }
 
 IDirect3DTexture9* Texture::GetD3DTexture()
 {
-	IDirect3DTexture9* res = NULL;
-	{
-		bool bWait = true;
-		int time = timeGetTime();
-		while (bWait) {
-			Lock lock(TextureManager::GetBase()->GetLock());
-			if (data_ != NULL) {
-				bWait = !data_->bLoad_;
-				if (!bWait)
-					res = _GetTextureData()->pTexture_;
+	IDirect3DTexture9* res = nullptr;
+	bool bWait = true;
+	int time = timeGetTime();
+	while (bWait) {
+		Lock lock(TextureManager::GetBase()->GetLock());
+		if (data_ != nullptr) {
+			bWait = !data_->bLoad_;
+			if (!bWait)
+				res = _GetTextureData()->pTexture_;
 
-				if (bWait && abs((int)(timeGetTime() - time)) > 10000) {
-					//一定時間たってもだめだったらロック？
-					std::wstring path = data_->GetName();
-					Logger::WriteTop(
-						StringUtility::Format(L"テクスチャ読み込みを行えていません。ロック？ ：%s", path.c_str()));
-					data_->bLoad_ = true;
-					break;
-				}
-			} else
+			if (bWait && abs((int)(timeGetTime() - time)) > 10000) {
+				//一定時間たってもだめだったらロック？
+				std::wstring path = data_->GetName();
+				Logger::WriteTop(
+					StringUtility::Format(L"テクスチャ読み込みを行えていません。ロック？ ：%s", path.c_str()));
+				data_->bLoad_ = true;
 				break;
+			}
+		} else
+			break;
 
-			if (bWait)
-				::Sleep(1);
-		}
+		if (bWait)
+			::Sleep(1);
 	}
 	return res;
 }
 IDirect3DSurface9* Texture::GetD3DSurface()
 {
-	IDirect3DSurface9* res = NULL;
-	{
-		Lock lock(TextureManager::GetBase()->GetLock());
-		if (data_ != NULL)
-			res = _GetTextureData()->lpRenderSurface_;
-	}
-	return res;
+	Lock lock(TextureManager::GetBase()->GetLock());
+	if (data_ != nullptr)
+		return _GetTextureData()->lpRenderSurface_;
+	return nullptr;
 }
 IDirect3DSurface9* Texture::GetD3DZBuffer()
 {
-	IDirect3DSurface9* res = NULL;
-	{
-		Lock lock(TextureManager::GetBase()->GetLock());
-		if (data_ != NULL)
-			res = _GetTextureData()->lpRenderZ_;
-	}
-	return res;
+	Lock lock(TextureManager::GetBase()->GetLock());
+	if (data_ != nullptr)
+		return _GetTextureData()->lpRenderZ_;
+	return nullptr;
 }
 int Texture::GetWidth() const
 {
-	int res = 0;
-	{
-		Lock lock(TextureManager::GetBase()->GetLock());
-		const TextureData* data = _GetTextureData();
-		if (data != NULL)
-			res = data->infoImage_.Width;
-	}
-	return res;
+	Lock lock(TextureManager::GetBase()->GetLock());
+	const TextureData* data = _GetTextureData();
+	if (data != nullptr)
+		return data->infoImage_.Width;
+	return 0;
 }
 int Texture::GetHeight() const
 {
-	int res = 0;
-	{
-		Lock lock(TextureManager::GetBase()->GetLock());
-		const TextureData* data = _GetTextureData();
-		if (data != NULL)
-			res = data->infoImage_.Height;
-	}
-	return res;
+	Lock lock(TextureManager::GetBase()->GetLock());
+	const TextureData* data = _GetTextureData();
+	if (data != nullptr)
+		return data->infoImage_.Height;
+	return 0;
 }
 /**********************************************************
 //TextureManager
 **********************************************************/
 const std::wstring TextureManager::TARGET_TRANSITION = L"__RENDERTARGET_TRANSITION__";
-TextureManager* TextureManager::thisBase_ = NULL;
-TextureManager::TextureManager()
-{
-}
+TextureManager* TextureManager::thisBase_ = nullptr;
+TextureManager::TextureManager() = default;
 TextureManager::~TextureManager()
 {
 	DirectGraphics* graphics = DirectGraphics::GetBase();
@@ -236,12 +197,13 @@ TextureManager::~TextureManager()
 
 	FileManager::GetBase()->RemoveLoadThreadListener(this);
 
-	panelInfo_ = NULL;
-	thisBase_ = NULL;
+	panelInfo_ = nullptr;
+	thisBase_ = nullptr;
 }
+
 bool TextureManager::Initialize()
 {
-	if (thisBase_ != NULL)
+	if (thisBase_ != nullptr)
 		return false;
 
 	thisBase_ = this;
@@ -258,73 +220,63 @@ bool TextureManager::Initialize()
 }
 void TextureManager::Clear()
 {
-	{
-		Lock lock(lock_);
-		mapTexture_.clear();
-		mapTextureData_.clear();
-	}
+	Lock lock(lock_);
+	mapTexture_.clear();
+	mapTextureData_.clear();
 }
-void TextureManager::_ReleaseTextureData(std::wstring name)
+void TextureManager::_ReleaseTextureData(const std::wstring& name)
 {
-	{
-		Lock lock(lock_);
-		if (IsDataExists(name)) {
-			mapTextureData_[name]->bLoad_ = true; //読み込み完了扱い
-			mapTextureData_.erase(name);
-			Logger::WriteTop(StringUtility::Format(L"TextureManager：テクスチャを解放しました[%s]", name.c_str()));
-		}
+	Lock lock(lock_);
+	if (IsDataExists(name)) {
+		mapTextureData_[name]->bLoad_ = true; //読み込み完了扱い
+		mapTextureData_.erase(name);
+		Logger::WriteTop(StringUtility::Format(L"TextureManager：テクスチャを解放しました[%s]", name.c_str()));
 	}
 }
 void TextureManager::ReleaseDxResource()
 {
-	std::map<std::wstring, gstd::ref_count_ptr<TextureData>>::iterator itrMap;
-	{
-		Lock lock(GetLock());
-		for (itrMap = mapTextureData_.begin(); itrMap != mapTextureData_.end(); itrMap++) {
-			std::wstring name = itrMap->first;
-			TextureData* data = (itrMap->second).GetPointer();
-			if (data->type_ == TextureData::TYPE_RENDER_TARGET) {
-				if (data->pTexture_ != NULL)
-					data->pTexture_->Release();
-				if (data->lpRenderSurface_ != NULL)
-					data->lpRenderSurface_->Release();
-				if (data->lpRenderZ_ != NULL)
-					data->lpRenderZ_->Release();
-			}
+	Lock lock(GetLock());
+	for (auto& itrMap : mapTextureData_) {
+		std::wstring name = itrMap.first;
+		TextureData* data = (itrMap.second).GetPointer();
+		if (data->type_ == TextureData::TYPE_RENDER_TARGET) {
+			if (data->pTexture_ != nullptr)
+				data->pTexture_->Release();
+			if (data->lpRenderSurface_ != nullptr)
+				data->lpRenderSurface_->Release();
+			if (data->lpRenderZ_ != nullptr)
+				data->lpRenderZ_->Release();
 		}
 	}
 }
 void TextureManager::RestoreDxResource()
 {
 	DirectGraphics* graphics = DirectGraphics::GetBase();
-	std::map<std::wstring, gstd::ref_count_ptr<TextureData>>::iterator itrMap;
-	{
-		Lock lock(GetLock());
-		for (itrMap = mapTextureData_.begin(); itrMap != mapTextureData_.end(); itrMap++) {
-			std::wstring name = itrMap->first;
-			TextureData* data = (itrMap->second).GetPointer();
-			if (data->type_ == TextureData::TYPE_RENDER_TARGET) {
-				int width = data->infoImage_.Width;
-				int height = data->infoImage_.Height;
+	Lock lock(GetLock());
+	for (auto& itrMap : mapTextureData_) {
+		std::wstring name = itrMap.first;
+		TextureData* data = (itrMap.second).GetPointer();
+		if (data->type_ == TextureData::TYPE_RENDER_TARGET) {
+			int width = data->infoImage_.Width;
+			int height = data->infoImage_.Height;
 
-				HRESULT hr;
-				// Zバッファ生成
-				hr = graphics->GetDevice()->CreateDepthStencilSurface(width, height, D3DFMT_D16, D3DMULTISAMPLE_NONE, 0, FALSE, &data->lpRenderZ_, NULL);
-				//テクスチャ作成
-				D3DFORMAT fmt;
-				if (graphics->GetScreenMode() == DirectGraphics::SCREENMODE_FULLSCREEN)
-					fmt = graphics->GetFullScreenPresentParameter().BackBufferFormat;
-				else
-					fmt = graphics->GetWindowPresentParameter().BackBufferFormat;
+			HRESULT hr;
+			// Zバッファ生成
+			hr = graphics->GetDevice()->CreateDepthStencilSurface(width, height, D3DFMT_D16, D3DMULTISAMPLE_NONE, 0, FALSE, &data->lpRenderZ_, nullptr);
+			//テクスチャ作成
+			D3DFORMAT fmt;
+			if (graphics->GetScreenMode() == DirectGraphics::SCREENMODE_FULLSCREEN)
+				fmt = graphics->GetFullScreenPresentParameter().BackBufferFormat;
+			else
+				fmt = graphics->GetWindowPresentParameter().BackBufferFormat;
 
-				hr = graphics->GetDevice()->CreateTexture(width, height, 1, D3DUSAGE_RENDERTARGET, fmt, D3DPOOL_DEFAULT, &data->pTexture_, NULL);
-				data->pTexture_->GetSurfaceLevel(0, &data->lpRenderSurface_);
-			}
+			hr = graphics->GetDevice()->CreateTexture(width, height, 1, D3DUSAGE_RENDERTARGET, fmt, D3DPOOL_DEFAULT, &data->pTexture_, nullptr);
+			data->pTexture_->GetSurfaceLevel(0, &data->lpRenderSurface_);
 		}
 	}
 }
 
-bool TextureManager::_CreateFromFile(std::wstring path)
+bool TextureManager::_CreateFromFile(const std::wstring& path)
 {
 	if (IsDataExists(path)) {
 		return true;
@@ -333,7 +285,7 @@ bool TextureManager::_CreateFromFile(std::wstring path)
 	//まだ作成されていないなら、作成
 	try {
 		ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-		if (reader == NULL)
+		if (reader == nullptr)
 			throw gstd::wexception(L"ファイルが見つかりません");
 		if (!reader->Open())
 			throw gstd::wexception(L"ファイルが開けません");
@@ -384,13 +336,12 @@ bool TextureManager::_CreateFromFile(std::wstring path)
 	}
 	return true;
 }
-bool TextureManager::_CreateRenderTarget(std::wstring name)
+bool TextureManager::_CreateRenderTarget(const std::wstring& name)
 {
 	if (IsDataExists(name)) {
 		return true;
 	}
 
-	bool res = true;
 	try {
 		ref_count_ptr<TextureData> data = new TextureData();
 		DirectGraphics* graphics = DirectGraphics::GetBase();
@@ -438,226 +389,199 @@ bool TextureManager::_CreateRenderTarget(std::wstring name)
 
 	} catch (...) {
 		Logger::WriteTop(StringUtility::Format(L"TextureManager：レンダリングターゲット作成失敗[%s]", name.c_str()));
-		res = false;
+		return false;
 	}
-	return res;
+	return true;
 }
-gstd::ref_count_ptr<Texture> TextureManager::CreateFromFile(std::wstring path)
+gstd::ref_count_ptr<Texture> TextureManager::CreateFromFile(const std::wstring& _Path)
 {
-	path = PathProperty::GetUnique(path);
-	gstd::ref_count_ptr<Texture> res;
-	{
-		Lock lock(lock_);
-		bool bExist = mapTexture_.find(path) != mapTexture_.end();
-		if (bExist) {
-			res = mapTexture_[path];
-		} else {
-			bool bSuccess = _CreateFromFile(path);
-			if (bSuccess) {
-				res = new Texture();
-				res->data_ = mapTextureData_[path];
-			}
-		}
-	}
-	return res;
-}
-
-gstd::ref_count_ptr<Texture> TextureManager::CreateRenderTarget(std::wstring name)
-{
-	gstd::ref_count_ptr<Texture> res;
-	{
-		Lock lock(lock_);
-		bool bExist = mapTexture_.find(name) != mapTexture_.end();
-		if (bExist) {
-			res = mapTexture_[name];
-		} else {
-			bool bSuccess = _CreateRenderTarget(name);
-			if (bSuccess) {
-				res = new Texture();
-				res->data_ = mapTextureData_[name];
-			}
-		}
-	}
-	return res;
-}
-gstd::ref_count_ptr<Texture> TextureManager::CreateFromFileInLoadThread(std::wstring path, bool bLoadImageInfo)
-{
-	path = PathProperty::GetUnique(path);
-	gstd::ref_count_ptr<Texture> res;
-	{
-		Lock lock(lock_);
-		bool bExist = mapTexture_.find(path) != mapTexture_.end();
-
-		if (bExist) {
-			res = mapTexture_[path];
-		} else {
-			bool bLoadTarget = true;
-			res = new Texture();
-			if (!IsDataExists(path)) {
-				ref_count_ptr<TextureData> data(new TextureData());
-				mapTextureData_[path] = data;
-				data->manager_ = this;
-				data->name_ = path;
-				data->bLoad_ = false;
-
-				//画像情報だけ事前に読み込み
-				if (bLoadImageInfo) {
-					try {
-						ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-						if (reader == NULL)
-							throw gstd::wexception(L"ファイルが見つかりません");
-						if (!reader->Open())
-							throw gstd::wexception(L"ファイルが開けません");
-
-						int size = reader->GetFileSize();
-						ByteBuffer buf;
-						buf.SetSize(size);
-						reader->Read(buf.GetPointer(), size);
-
-						D3DXIMAGE_INFO info;
-						HRESULT hr = D3DXGetImageInfoFromFileInMemory(buf.GetPointer(), size, &info);
-						if (FAILED(hr)) {
-							throw gstd::wexception(L"D3DXGetImageInfoFromFileInMemory失敗");
-						}
-
-						data->infoImage_ = info;
-					} catch (gstd::wexception& e) {
-						std::wstring str = StringUtility::Format(L"TextureManager：テクスチャ読み込み失敗[%s]\n\t%s", path.c_str(), e.what());
-						Logger::WriteTop(str);
-						data->bLoad_ = true; //読み込み完了扱い
-						bLoadTarget = false;
-					}
-				}
-			} else
-				bLoadTarget = false;
-
+	std::wstring path = PathProperty::GetUnique(_Path);
+	Lock lock(lock_);
+	auto textureItr = mapTexture_.find(path);
+	if (textureItr != mapTexture_.end()) {
+		return textureItr->second;
+	} else {
+		if (_CreateFromFile(path) == true) {
+			gstd::ref_count_ptr<Texture> res = new Texture();
 			res->data_ = mapTextureData_[path];
-			if (bLoadTarget) {
-				ref_count_ptr<FileManager::LoadObject> source = res;
-				ref_count_ptr<FileManager::LoadThreadEvent> event = new FileManager::LoadThreadEvent(this, path, res);
-				FileManager::GetBase()->AddLoadThreadEvent(event);
+			return res;
+		}
+	}
+	return nullptr;
+}
+
+gstd::ref_count_ptr<Texture> TextureManager::CreateRenderTarget(const std::wstring& name)
+{
+	Lock lock(lock_);
+	auto textureItr = mapTexture_.find(name);
+	if (textureItr != mapTexture_.end()) {
+		return textureItr->second;
+	} else {
+		if (_CreateRenderTarget(name) == true) {
+			gstd::ref_count_ptr<Texture> res = new Texture();
+			res->data_ = mapTextureData_[name];
+			return res;
+		}
+	}
+	return nullptr;
+}
+gstd::ref_count_ptr<Texture> TextureManager::CreateFromFileInLoadThread(const std::wstring& _Path, bool bLoadImageInfo)
+{
+	std::wstring path = PathProperty::GetUnique(_Path);
+	Lock lock(lock_);
+	auto textureItr = mapTexture_.find(path);
+	if (textureItr != mapTexture_.end()) {
+		return textureItr->second;
+	}
+
+	bool bLoadTarget = true;
+	gstd::ref_count_ptr<Texture> res = new Texture();
+	if (!IsDataExists(path)) {
+		ref_count_ptr<TextureData> data(new TextureData());
+		mapTextureData_[path] = data;
+		data->manager_ = this;
+		data->name_ = path;
+		data->bLoad_ = false;
+
+		//画像情報だけ事前に読み込み
+		if (bLoadImageInfo) {
+			try {
+				ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
+				if (reader == nullptr)
+					throw gstd::wexception(L"ファイルが見つかりません");
+				if (!reader->Open())
+					throw gstd::wexception(L"ファイルが開けません");
+
+				int size = reader->GetFileSize();
+				ByteBuffer buf;
+				buf.SetSize(size);
+				reader->Read(buf.GetPointer(), size);
+
+				D3DXIMAGE_INFO info;
+				HRESULT hr = D3DXGetImageInfoFromFileInMemory(buf.GetPointer(), size, &info);
+				if (FAILED(hr)) {
+					throw gstd::wexception(L"D3DXGetImageInfoFromFileInMemory失敗");
+				}
+
+				data->infoImage_ = info;
+			} catch (gstd::wexception& e) {
+				std::wstring str = StringUtility::Format(L"TextureManager：テクスチャ読み込み失敗[%s]\n\t%s", path.c_str(), e.what());
+				Logger::WriteTop(str);
+				data->bLoad_ = true; //読み込み完了扱い
+				bLoadTarget = false;
 			}
 		}
+	} else
+		bLoadTarget = false;
+
+	res->data_ = mapTextureData_[path];
+	if (bLoadTarget) {
+		ref_count_ptr<FileManager::LoadObject> source = res;
+		ref_count_ptr<FileManager::LoadThreadEvent> event = new FileManager::LoadThreadEvent(this, path, res);
+		FileManager::GetBase()->AddLoadThreadEvent(event);
 	}
 	return res;
 }
 void TextureManager::CallFromLoadThread(ref_count_ptr<FileManager::LoadThreadEvent> event)
 {
+	Lock lock(lock_);
+	ref_count_ptr<Texture> texture = ref_count_ptr<Texture>::DownCast(event->GetSource());
+	if (texture == nullptr)
+		return;
+
+	ref_count_ptr<TextureData> data = texture->data_;
+	if (data == nullptr || data->bLoad_)
+		return;
+
+	int countRef = data.GetReferenceCount();
+	//自身とTextureManager内の数だけになったら読み込まない。
+	if (countRef <= 2) {
+		data->bLoad_ = true; //念のため読み込み完了扱い
+		return;
+	}
+
 	std::wstring path = event->GetPath();
-	{
-		Lock lock(lock_);
-		ref_count_ptr<Texture> texture = ref_count_ptr<Texture>::DownCast(event->GetSource());
-		if (texture == NULL)
-			return;
+	try {
+		ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
+		if (reader == nullptr)
+			throw gstd::wexception(L"ファイルが見つかりません");
+		if (!reader->Open())
+			throw gstd::wexception(L"ファイルが開けません");
 
-		ref_count_ptr<TextureData> data = texture->data_;
-		if (data == NULL || data->bLoad_)
-			return;
+		int size = reader->GetFileSize();
+		ByteBuffer buf;
+		buf.SetSize(size);
+		reader->Read(buf.GetPointer(), size);
 
-		int countRef = data.GetReferenceCount();
-		//自身とTextureManager内の数だけになったら読み込まない。
-		if (countRef <= 2) {
-			data->bLoad_ = true; //念のため読み込み完了扱い
-			return;
+		D3DCOLOR colorKey = D3DCOLOR_ARGB(255, 0, 0, 0);
+		if (path.find(L".bmp") == std::wstring::npos) //bmpのみカラーキー適応
+			colorKey = 0;
+
+		D3DFORMAT pixelFormat = D3DFMT_A8R8G8B8;
+
+		HRESULT hr = D3DXCreateTextureFromFileInMemoryEx(DirectGraphics::GetBase()->GetDevice(),
+			buf.GetPointer(), size,
+			D3DX_DEFAULT, D3DX_DEFAULT,
+			0,
+			0,
+			pixelFormat,
+			D3DPOOL_MANAGED,
+			D3DX_FILTER_BOX,
+			D3DX_DEFAULT,
+			colorKey,
+			NULL,
+			NULL,
+			&data->pTexture_);
+		if (FAILED(hr)) {
+			throw gstd::wexception(L"D3DXCreateTextureFromFileInMemoryEx失敗");
 		}
 
-		try {
-			ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-			if (reader == NULL)
-				throw gstd::wexception(L"ファイルが見つかりません");
-			if (!reader->Open())
-				throw gstd::wexception(L"ファイルが開けません");
+		D3DXGetImageInfoFromFileInMemory(buf.GetPointer(), size, &data->infoImage_);
 
-			int size = reader->GetFileSize();
-			ByteBuffer buf;
-			buf.SetSize(size);
-			reader->Read(buf.GetPointer(), size);
-
-			D3DCOLOR colorKey = D3DCOLOR_ARGB(255, 0, 0, 0);
-			if (path.find(L".bmp") == std::wstring::npos) //bmpのみカラーキー適応
-				colorKey = 0;
-
-			D3DFORMAT pixelFormat = D3DFMT_A8R8G8B8;
-
-			HRESULT hr = D3DXCreateTextureFromFileInMemoryEx(DirectGraphics::GetBase()->GetDevice(),
-				buf.GetPointer(), size,
-				D3DX_DEFAULT, D3DX_DEFAULT,
-				0,
-				0,
-				pixelFormat,
-				D3DPOOL_MANAGED,
-				D3DX_FILTER_BOX,
-				D3DX_DEFAULT,
-				colorKey,
-				NULL,
-				NULL,
-				&data->pTexture_);
-			if (FAILED(hr)) {
-				throw gstd::wexception(L"D3DXCreateTextureFromFileInMemoryEx失敗");
-			}
-
-			D3DXGetImageInfoFromFileInMemory(buf.GetPointer(), size, &data->infoImage_);
-
-			Logger::WriteTop(StringUtility::Format(L"TextureManager：テクスチャを読み込みました(LT)[%s]", path.c_str()));
-		} catch (gstd::wexception& e) {
-			std::wstring str = StringUtility::Format(L"TextureManager：テクスチャ読み込み失敗(LT)[%s]\n\t%s", path.c_str(), e.what());
-			Logger::WriteTop(str);
-		}
-		data->bLoad_ = true;
+		Logger::WriteTop(StringUtility::Format(L"TextureManager：テクスチャを読み込みました(LT)[%s]", path.c_str()));
+	} catch (gstd::wexception& e) {
+		std::wstring str = StringUtility::Format(L"TextureManager：テクスチャ読み込み失敗(LT)[%s]\n\t%s", path.c_str(), e.what());
+		Logger::WriteTop(str);
 	}
+	data->bLoad_ = true;
 }
 
-gstd::ref_count_ptr<TextureData> TextureManager::GetTextureData(std::wstring name)
+gstd::ref_count_ptr<TextureData> TextureManager::GetTextureData(const std::wstring& name)
 {
-	gstd::ref_count_ptr<TextureData> res;
-	{
-		Lock lock(lock_);
-		bool bExist = mapTextureData_.find(name) != mapTextureData_.end();
-		if (bExist) {
-			res = mapTextureData_[name];
-		}
+	Lock lock(lock_);
+	auto textureDataItr = mapTextureData_.find(name);
+	if (textureDataItr != mapTextureData_.end()) {
+		return textureDataItr->second;
 	}
-	return res;
+	return nullptr;
 }
 
-gstd::ref_count_ptr<Texture> TextureManager::GetTexture(std::wstring name)
+gstd::ref_count_ptr<Texture> TextureManager::GetTexture(const std::wstring& name)
 {
-	gstd::ref_count_ptr<Texture> res;
-	{
-		Lock lock(lock_);
-		bool bExist = mapTexture_.find(name) != mapTexture_.end();
-		if (bExist) {
-			res = mapTexture_[name];
-		}
+	Lock lock(lock_);
+	auto textureItr = mapTexture_.find(name);
+	if (textureItr != mapTexture_.end()) {
+		return textureItr->second;
 	}
-	return res;
+	return nullptr;
 }
 
-void TextureManager::Add(std::wstring name, gstd::ref_count_ptr<Texture> texture)
+void TextureManager::Add(const std::wstring& name, gstd::ref_count_ptr<Texture> texture)
 {
-	{
-		Lock lock(lock_);
-		bool bExist = mapTexture_.find(name) != mapTexture_.end();
-		if (!bExist) {
-			mapTexture_[name] = texture;
-		}
+	Lock lock(lock_);
+	if (mapTexture_.find(name) == mapTexture_.end()) {
+		mapTexture_[name] = texture;
 	}
 }
-void TextureManager::Release(std::wstring name)
+void TextureManager::Release(const std::wstring& name)
 {
-	{
-		Lock lock(lock_);
-		mapTexture_.erase(name);
-	}
+	Lock lock(lock_);
+	mapTexture_.erase(name);
 }
-bool TextureManager::IsDataExists(std::wstring name)
+bool TextureManager::IsDataExists(const std::wstring& name)
 {
-	bool res = false;
-	{
-		Lock lock(lock_);
-		res = mapTextureData_.find(name) != mapTextureData_.end();
-	}
-	return res;
+	Lock lock(lock_);
+	return mapTextureData_.find(name) != mapTextureData_.end();
 }
 
 /**********************************************************
@@ -706,7 +630,7 @@ void TextureInfoPanel::_Run()
 {
 	while (GetStatus() == RUN) {
 		TextureManager* manager = TextureManager::GetBase();
-		if (manager != NULL)
+		if (manager != nullptr)
 			Update(manager);
 		Sleep(timeUpdateInterval_);
 	}
@@ -716,14 +640,13 @@ void TextureInfoPanel::Update(TextureManager* manager)
 	if (!IsWindowVisible())
 		return;
 	std::set<std::wstring> setKey;
-	std::map<std::wstring, gstd::ref_count_ptr<TextureData>>::iterator itrMap;
 	{
 		Lock lock(manager->GetLock());
 
-		std::map<std::wstring, gstd::ref_count_ptr<TextureData>>& mapData = manager->mapTextureData_;
-		for (itrMap = mapData.begin(); itrMap != mapData.end(); itrMap++) {
-			std::wstring name = itrMap->first;
-			TextureData* data = (itrMap->second).GetPointer();
+		auto& mapData = manager->mapTextureData_;
+		for (auto& itrMap : mapData) {
+			std::wstring name = itrMap.first;
+			TextureData* data = (itrMap.second).GetPointer();
 
 			int address = (int)data;
 			std::wstring key = StringUtility::Format(L"%08x", address);
@@ -733,7 +656,7 @@ void TextureInfoPanel::Update(TextureManager* manager)
 				wndListView_.SetText(index, ROW_ADDRESS, key);
 			}
 
-			int countRef = (itrMap->second).GetReferenceCount();
+			int countRef = (itrMap.second).GetReferenceCount();
 			D3DXIMAGE_INFO* infoImage = &data->infoImage_;
 
 			wndListView_.SetText(index, ROW_NAME, PathProperty::GetFileName(name));
@@ -749,7 +672,7 @@ void TextureInfoPanel::Update(TextureManager* manager)
 	for (int iRow = 0; iRow < wndListView_.GetRowCount();) {
 		std::wstring key = wndListView_.GetText(iRow, ROW_ADDRESS);
 		if (setKey.find(key) != setKey.end())
-			iRow++;
+			++iRow;
 		else
 			wndListView_.DeleteRow(iRow);
 	}

--- a/source/GcLib/directx/Texture.hpp
+++ b/source/GcLib/directx/Texture.hpp
@@ -51,13 +51,13 @@ class Texture : public gstd::FileManager::LoadObject {
 public:
 	Texture();
 	Texture(const Texture* texture);
-	virtual ~Texture();
+	~Texture() override;
 	void Release();
 
 	std::wstring GetName();
-	bool CreateFromFile(std::wstring path);
-	bool CreateRenderTarget(std::wstring name);
-	bool CreateFromFileInLoadThread(std::wstring path, bool bLoadImageInfo = false);
+	bool CreateFromFile(const std::wstring& _Path);
+	bool CreateRenderTarget(const std::wstring& name);
+	bool CreateFromFileInLoadThread(const std::wstring& _Path, bool bLoadImageInfo = false);
 
 	void SetTexture(IDirect3DTexture9* pTexture);
 	IDirect3DTexture9* GetD3DTexture();
@@ -66,7 +66,7 @@ public:
 
 	int GetWidth() const;
 	int GetHeight() const;
-	bool IsLoad() { return data_ != NULL && data_->bLoad_; }
+	bool IsLoad() { return data_ != nullptr && data_->bLoad_; }
 
 protected:
 	gstd::ref_count_ptr<TextureData> data_;
@@ -75,8 +75,8 @@ protected:
 };
 
 /**********************************************************
-	//TextureManager
-	**********************************************************/
+//TextureManager
+**********************************************************/
 class TextureManager : public DirectGraphicsListener, public gstd::FileManager::LoadThreadListener {
 	friend Texture;
 	friend TextureData;
@@ -88,49 +88,49 @@ public:
 
 public:
 	TextureManager();
-	virtual ~TextureManager();
+	~TextureManager() override;
 	static TextureManager* GetBase() { return thisBase_; }
 	virtual bool Initialize();
 	gstd::CriticalSection& GetLock() { return lock_; }
 
 	virtual void Clear();
-	virtual void Add(std::wstring name, gstd::ref_count_ptr<Texture> texture); //テクスチャの参照を保持します
-	virtual void Release(std::wstring name); //保持している参照を解放します
-	virtual bool IsDataExists(std::wstring name);
+	virtual void Add(const std::wstring& name, gstd::ref_count_ptr<Texture> texture); //テクスチャの参照を保持します
+	virtual void Release(const std::wstring& name); //保持している参照を解放します
+	virtual bool IsDataExists(const std::wstring& name);
 
-	virtual void ReleaseDirectGraphics() { ReleaseDxResource(); }
-	virtual void RestoreDirectGraphics() { RestoreDxResource(); }
+	void ReleaseDirectGraphics() override { ReleaseDxResource(); }
+	void RestoreDirectGraphics() override { RestoreDxResource(); }
 	void ReleaseDxResource();
 	void RestoreDxResource();
 
-	gstd::ref_count_ptr<TextureData> GetTextureData(std::wstring name);
-	gstd::ref_count_ptr<Texture> CreateFromFile(std::wstring path); //テクスチャを読み込みます。TextureDataは保持しますが、Textureは保持しません。
-	gstd::ref_count_ptr<Texture> CreateRenderTarget(std::wstring name);
-	gstd::ref_count_ptr<Texture> GetTexture(std::wstring name); //作成済みのテクスチャを取得します
-	gstd::ref_count_ptr<Texture> CreateFromFileInLoadThread(std::wstring path, bool bLoadImageInfo = false);
-	virtual void CallFromLoadThread(gstd::ref_count_ptr<gstd::FileManager::LoadThreadEvent> event);
+	gstd::ref_count_ptr<TextureData> GetTextureData(const std::wstring& name);
+	gstd::ref_count_ptr<Texture> CreateFromFile(const std::wstring& _Path); //テクスチャを読み込みます。TextureDataは保持しますが、Textureは保持しません。
+	gstd::ref_count_ptr<Texture> CreateRenderTarget(const std::wstring& name);
+	gstd::ref_count_ptr<Texture> GetTexture(const std::wstring& name); //作成済みのテクスチャを取得します
+	gstd::ref_count_ptr<Texture> CreateFromFileInLoadThread(const std::wstring& _Path, bool bLoadImageInfo = false);
+	void CallFromLoadThread(gstd::ref_count_ptr<gstd::FileManager::LoadThreadEvent> event) override;
 
 	void SetInfoPanel(gstd::ref_count_ptr<TextureInfoPanel> panel) { panelInfo_ = panel; }
 
 protected:
-	gstd::CriticalSection lock_;
+	mutable gstd::CriticalSection lock_;
 	std::map<std::wstring, gstd::ref_count_ptr<Texture>> mapTexture_;
 	std::map<std::wstring, gstd::ref_count_ptr<TextureData>> mapTextureData_;
 	gstd::ref_count_ptr<TextureInfoPanel> panelInfo_;
 
-	void _ReleaseTextureData(std::wstring name);
-	bool _CreateFromFile(std::wstring path);
-	bool _CreateRenderTarget(std::wstring name);
+	void _ReleaseTextureData(const std::wstring& name);
+	bool _CreateFromFile(const std::wstring& path);
+	bool _CreateRenderTarget(const std::wstring& name);
 };
 
 /**********************************************************
-	//TextureInfoPanel
-	**********************************************************/
+//TextureInfoPanel
+**********************************************************/
 class TextureInfoPanel : public gstd::WindowLogger::Panel, public gstd::Thread {
 public:
 	TextureInfoPanel();
-	~TextureInfoPanel();
-	virtual void LocateParts();
+	~TextureInfoPanel() override;
+	void LocateParts() override;
 	virtual void Update(TextureManager* manager);
 
 protected:
@@ -144,7 +144,7 @@ protected:
 	};
 	int timeUpdateInterval_;
 	gstd::WListView wndListView_;
-	virtual bool _AddedLogger(HWND hTab);
+	bool _AddedLogger(HWND hTab) override;
 	void _Run();
 };
 

--- a/source/GcLib/directx/Texture.hpp
+++ b/source/GcLib/directx/Texture.hpp
@@ -28,8 +28,8 @@ public:
 public:
 	TextureData();
 	virtual ~TextureData();
-	std::wstring GetName() { return name_; }
-	D3DXIMAGE_INFO GetImageInfo() { return infoImage_; }
+	std::wstring GetName() const { return name_; }
+	D3DXIMAGE_INFO GetImageInfo() const { return infoImage_; }
 
 protected:
 	int type_;
@@ -50,7 +50,7 @@ class Texture : public gstd::FileManager::LoadObject {
 
 public:
 	Texture();
-	Texture(Texture* texture);
+	Texture(const Texture* texture);
 	virtual ~Texture();
 	void Release();
 
@@ -64,13 +64,14 @@ public:
 	IDirect3DSurface9* GetD3DSurface();
 	IDirect3DSurface9* GetD3DZBuffer();
 
-	int GetWidth();
-	int GetHeight();
+	int GetWidth() const;
+	int GetHeight() const;
 	bool IsLoad() { return data_ != NULL && data_->bLoad_; }
 
 protected:
 	gstd::ref_count_ptr<TextureData> data_;
 	TextureData* _GetTextureData() { return data_.GetPointer(); }
+	const TextureData* _GetTextureData() const { return data_.GetPointer(); }
 };
 
 /**********************************************************

--- a/source/GcLib/directx/TransitionEffect.cpp
+++ b/source/GcLib/directx/TransitionEffect.cpp
@@ -6,19 +6,15 @@ using namespace directx;
 /**********************************************************
 //TransitionEffect
 **********************************************************/
-TransitionEffect::TransitionEffect()
-{
-}
-TransitionEffect::~TransitionEffect()
-{
-}
+TransitionEffect::TransitionEffect() = default;
+TransitionEffect::~TransitionEffect() = default;
 
 /**********************************************************
 //TransitionEffect_FadeOut
 **********************************************************/
 void TransitionEffect_FadeOut::Work()
 {
-	if (sprite_ == NULL)
+	if (sprite_ == nullptr)
 		return;
 	alpha_ -= diffAlpha_;
 	alpha_ = max(alpha_, 0);
@@ -26,7 +22,7 @@ void TransitionEffect_FadeOut::Work()
 }
 void TransitionEffect_FadeOut::Render()
 {
-	if (sprite_ == NULL)
+	if (sprite_ == nullptr)
 		return;
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	graphics->SetBlendMode(DirectGraphics::MODE_BLEND_ALPHA);
@@ -55,24 +51,20 @@ void TransitionEffect_FadeOut::Initialize(int frame, gstd::ref_count_ptr<Texture
 /**********************************************************
 //TransitionEffectTask
 **********************************************************/
-TransitionEffectTask::TransitionEffectTask()
-{
-}
-TransitionEffectTask::~TransitionEffectTask()
-{
-}
+TransitionEffectTask::TransitionEffectTask() = default;
+TransitionEffectTask::~TransitionEffectTask() = default;
 void TransitionEffectTask::SetTransition(gstd::ref_count_ptr<TransitionEffect> effect)
 {
 	effect_ = effect;
 }
 void TransitionEffectTask::Work()
 {
-	if (effect_ != NULL) {
+	if (effect_ != nullptr) {
 		effect_->Work();
 	}
 }
 void TransitionEffectTask::Render()
 {
-	if (effect_ != NULL)
+	if (effect_ != nullptr)
 		effect_->Render();
 }

--- a/source/GcLib/directx/TransitionEffect.cpp
+++ b/source/GcLib/directx/TransitionEffect.cpp
@@ -34,10 +34,9 @@ void TransitionEffect_FadeOut::Render()
 	graphics->SetZWriteEnalbe(false);
 	sprite_->Render();
 }
-bool TransitionEffect_FadeOut::IsEnd()
+bool TransitionEffect_FadeOut::IsEnd() const
 {
-	bool res = (alpha_ <= 0);
-	return res;
+	return alpha_ <= 0;
 }
 void TransitionEffect_FadeOut::Initialize(int frame, gstd::ref_count_ptr<Texture> texture)
 {

--- a/source/GcLib/directx/TransitionEffect.hpp
+++ b/source/GcLib/directx/TransitionEffect.hpp
@@ -14,19 +14,19 @@ public:
 	virtual ~TransitionEffect();
 	virtual void Work() = 0;
 	virtual void Render() = 0;
-	virtual bool IsEnd() { return true; }
+	virtual bool IsEnd() const { return true; }
 
 protected:
 };
 
 /**********************************************************
-	//TransitionEffect_FadeOut
-	**********************************************************/
+//TransitionEffect_FadeOut
+**********************************************************/
 class TransitionEffect_FadeOut : public TransitionEffect {
 public:
 	virtual void Work();
 	virtual void Render();
-	virtual bool IsEnd();
+	virtual bool IsEnd() const;
 	void Initialize(int frame, gstd::ref_count_ptr<Texture> texture);
 
 protected:

--- a/source/GcLib/directx/TransitionEffect.hpp
+++ b/source/GcLib/directx/TransitionEffect.hpp
@@ -24,9 +24,9 @@ protected:
 **********************************************************/
 class TransitionEffect_FadeOut : public TransitionEffect {
 public:
-	virtual void Work();
-	virtual void Render();
-	virtual bool IsEnd() const;
+	void Work() override;
+	void Render() override;
+	bool IsEnd() const override;
 	void Initialize(int frame, gstd::ref_count_ptr<Texture> texture);
 
 protected:
@@ -42,7 +42,7 @@ class TransitionEffectTask : public gstd::TaskBase {
 
 public:
 	TransitionEffectTask();
-	~TransitionEffectTask();
+	~TransitionEffectTask() override;
 
 	void SetTransition(gstd::ref_count_ptr<TransitionEffect> effect);
 	virtual void Work();

--- a/source/GcLib/gstd/Application.cpp
+++ b/source/GcLib/gstd/Application.cpp
@@ -6,18 +6,18 @@ using namespace gstd;
 /**********************************************************
 //Application
 **********************************************************/
-Application* Application::thisBase_ = NULL;
+Application* Application::thisBase_ = nullptr;
 Application::Application()
 {
 	::InitCommonControls();
 }
 Application::~Application()
 {
-	thisBase_ = NULL;
+	thisBase_ = nullptr;
 }
 bool Application::Initialize()
 {
-	if (thisBase_ != NULL)
+	if (thisBase_ != nullptr)
 		return false;
 	thisBase_ = this;
 	hAppInstance_ = ::GetModuleHandle(NULL);
@@ -27,13 +27,12 @@ bool Application::Initialize()
 }
 bool Application::Run()
 {
-	if (bAppRun_ == false) {
+	if (!bAppRun_) {
 		return false;
 	}
 
 	try {
-		bool res = _Initialize();
-		if (res == false)
+		if (!_Initialize())
 			throw gstd::wexception(L"初期化中に例外が発生しました。");
 	} catch (std::exception& e) {
 		std::wstring log = StringUtility::ConvertMultiToWide(e.what());
@@ -52,20 +51,20 @@ bool Application::Run()
 
 	MSG msg;
 	while (true) {
-		if (bAppRun_ == false)
+		if (!bAppRun_)
 			break;
-		if (::PeekMessage(&msg, 0, 0, 0, PM_NOREMOVE)) {
-			if (!::GetMessage(&msg, NULL, 0, 0))
+		if (::PeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE) != 0) {
+			if (::GetMessage(&msg, NULL, 0, 0) == 0)
 				break;
 			::TranslateMessage(&msg);
 			::DispatchMessage(&msg);
 		} else {
-			if (bAppActive_ == false) {
+			if (!bAppActive_) {
 				Sleep(10);
 				continue;
 			}
 			try {
-				if (_Loop() == false)
+				if (!_Loop())
 					break;
 			} catch (std::exception& e) {
 				std::wstring log = StringUtility::ConvertMultiToWide(e.what());
@@ -89,8 +88,7 @@ bool Application::Run()
 	bAppRun_ = false;
 
 	try {
-		bool res = _Finalize();
-		if (res == false)
+		if (!_Finalize())
 			throw gstd::wexception(L"終了中に例外が発生しました。");
 	} catch (std::exception& e) {
 		std::wstring log = StringUtility::ConvertMultiToWide(e.what());

--- a/source/GcLib/gstd/Application.hpp
+++ b/source/GcLib/gstd/Application.hpp
@@ -16,9 +16,9 @@ public:
 	bool Initialize();
 
 	virtual bool Run();
-	bool IsActive() { return this->bAppActive_; }
+	bool IsActive() const { return this->bAppActive_; }
 	void SetActive(bool b) { this->bAppActive_ = b; }
-	bool IsRun() { return bAppRun_; }
+	bool IsRun() const { return bAppRun_; }
 	void End() { bAppRun_ = false; }
 
 	static HINSTANCE GetApplicationHandle() { return ::GetModuleHandle(NULL); }

--- a/source/GcLib/gstd/File.cpp
+++ b/source/GcLib/gstd/File.cpp
@@ -11,19 +11,19 @@ using namespace gstd;
 **********************************************************/
 ByteBuffer::ByteBuffer()
 {
-	data_ = NULL;
+	data_ = nullptr;
 	Clear();
 }
 ByteBuffer::ByteBuffer(const ByteBuffer& buffer)
 {
-	data_ = NULL;
+	data_ = nullptr;
 	Clear();
 	Copy(buffer);
 }
 ByteBuffer::~ByteBuffer()
 {
 	Clear();
-	if (data_ != NULL)
+	if (data_ != nullptr)
 		delete[] data_;
 }
 int ByteBuffer::_GetReservedSize() const
@@ -40,7 +40,7 @@ void ByteBuffer::_Resize(int size)
 
 	//元のデータをコピー
 	int sizeCopy = min(size, oldSize);
-	if (oldData != NULL) {
+	if (oldData != nullptr) {
 		memcpy(data_, oldData, sizeCopy);
 		//古いデータを削除
 		delete[] oldData;
@@ -50,7 +50,7 @@ void ByteBuffer::_Resize(int size)
 }
 void ByteBuffer::Copy(const ByteBuffer& src)
 {
-	if (data_ != NULL && src.reserve_ != reserve_) {
+	if (data_ != nullptr && src.reserve_ != reserve_) {
 		delete[] data_;
 		data_ = new char[src.reserve_];
 		ZeroMemory(data_, src.reserve_);
@@ -64,7 +64,7 @@ void ByteBuffer::Copy(const ByteBuffer& src)
 }
 void ByteBuffer::Clear()
 {
-	if (data_ != NULL)
+	if (data_ != nullptr)
 		delete[] data_;
 
 	data_ = new char[0];
@@ -137,12 +137,12 @@ int ByteBuffer::Decompress()
 **********************************************************/
 File::File()
 {
-	hFile_ = NULL;
+	hFile_ = nullptr;
 	path_ = L"";
 }
 File::File(const std::wstring& path)
 {
-	hFile_ = NULL;
+	hFile_ = nullptr;
 	path_ = path;
 }
 File::~File()
@@ -151,20 +151,20 @@ File::~File()
 }
 bool File::CreateDirectory()
 {
-	std::wstring dir = PathProperty::GetFileDirectory(path_);
-	if (File::IsExists(dir))
+	std::wstring path = PathProperty::GetFileDirectory(path_);
+	if (File::IsExists(path))
 		return true;
 
-	std::vector<std::wstring> str = StringUtility::Split(dir, L"\\/");
-	std::wstring tPath = L"";
-	for (int iDir = 0; iDir < str.size(); iDir++) {
-		tPath += str[iDir] + L"\\";
+	std::vector<std::wstring> dirs = StringUtility::Split(path, L"\\/");
+	std::wstring tPath;
+	for (const auto& dir : dirs) {
+		tPath += dir + L"\\";
 		WIN32_FIND_DATA fData;
 		HANDLE hFile = ::FindFirstFile(tPath.c_str(), &fData);
 		if (hFile == INVALID_HANDLE_VALUE) {
 			SECURITY_ATTRIBUTES attr;
 			attr.nLength = sizeof(SECURITY_ATTRIBUTES);
-			attr.lpSecurityDescriptor = NULL;
+			attr.lpSecurityDescriptor = nullptr;
 			attr.bInheritHandle = FALSE;
 			::CreateDirectory(tPath.c_str(), &attr);
 		}
@@ -179,22 +179,20 @@ void File::Delete()
 }
 bool File::IsExists()
 {
-	if (hFile_ != NULL)
+	if (hFile_ != nullptr)
 		return true;
 
-	bool res = IsExists(path_);
-	return res;
+	return IsExists(path_);
 }
 bool File::IsExists(const std::wstring& path)
 {
-	bool res = PathFileExists(path.c_str()) == TRUE;
-	return res;
+	return PathFileExists(path.c_str()) == TRUE;
 }
 bool File::IsDirectory()
 {
 	WIN32_FIND_DATA fData;
 	HANDLE hFile = ::FindFirstFile(path_.c_str(), &fData);
-	bool res = hFile != INVALID_HANDLE_VALUE ? true : false;
+	bool res = hFile != INVALID_HANDLE_VALUE;
 	if (res)
 		res = (FILE_ATTRIBUTE_DIRECTORY & fData.dwFileAttributes) > 0;
 
@@ -203,13 +201,12 @@ bool File::IsDirectory()
 }
 int File::GetSize()
 {
-	if (hFile_ != NULL)
-		return ::GetFileSize(hFile_, NULL);
+	if (hFile_ != nullptr)
+		return ::GetFileSize(hFile_, nullptr);
 
-	int res = 0;
 	WIN32_FIND_DATA fData;
 	HANDLE hFile = ::FindFirstFile(path_.c_str(), &fData);
-	res = hFile != INVALID_HANDLE_VALUE ? ::GetFileSize(hFile, NULL) : 0;
+	int res = (hFile != INVALID_HANDLE_VALUE ? ::GetFileSize(hFile, nullptr) : 0);
 	::FindClose(hFile);
 	return res;
 }
@@ -220,49 +217,49 @@ bool File::Open()
 }
 bool File::Open(AccessType typeAccess)
 {
-	if (hFile_ != NULL)
+	if (hFile_ != nullptr)
 		this->Close();
 
 	DWORD access = typeAccess == AccessType::READ ? GENERIC_READ : GENERIC_READ | GENERIC_WRITE;
 	hFile_ = ::CreateFile(path_.c_str(), access,
-		FILE_SHARE_READ, NULL, OPEN_EXISTING,
-		FILE_ATTRIBUTE_NORMAL, NULL);
+		FILE_SHARE_READ, nullptr, OPEN_EXISTING,
+		FILE_ATTRIBUTE_NORMAL, nullptr);
 	if (hFile_ == INVALID_HANDLE_VALUE) {
-		hFile_ = NULL;
+		hFile_ = nullptr;
 		return false;
 	}
 	return true;
 }
 bool File::Create()
 {
-	if (hFile_ != NULL)
+	if (hFile_ != nullptr)
 		this->Close();
 	hFile_ = CreateFile(path_.c_str(), GENERIC_READ | GENERIC_WRITE,
-		FILE_SHARE_READ, NULL, CREATE_ALWAYS,
-		FILE_ATTRIBUTE_NORMAL, NULL);
+		FILE_SHARE_READ, nullptr, CREATE_ALWAYS,
+		FILE_ATTRIBUTE_NORMAL, nullptr);
 	if (hFile_ == INVALID_HANDLE_VALUE) {
-		hFile_ = NULL;
+		hFile_ = nullptr;
 		return false;
 	}
 	return true;
 }
 void File::Close()
 {
-	if (hFile_ != NULL)
+	if (hFile_ != nullptr)
 		CloseHandle(hFile_);
-	hFile_ = NULL;
+	hFile_ = nullptr;
 }
 
 DWORD File::Read(LPVOID buf, DWORD size)
 {
 	DWORD res = 0;
-	::ReadFile(hFile_, buf, size, &res, NULL);
+	::ReadFile(hFile_, buf, size, &res, nullptr);
 	return res;
 }
 DWORD File::Write(const LPVOID buf, DWORD size)
 {
 	DWORD res = 0;
-	::WriteFile(hFile_, buf, size, &res, NULL);
+	::WriteFile(hFile_, buf, size, &res, nullptr);
 	return res;
 }
 bool File::IsEqualsPath(const std::wstring& _Path_first, const std::wstring& _Path_second)
@@ -276,9 +273,8 @@ std::vector<std::wstring> File::GetFilePathList(const std::wstring& dir)
 	std::vector<std::wstring> res;
 
 	WIN32_FIND_DATA data;
-	HANDLE hFind;
 	std::wstring findDir = dir + L"*.*";
-	hFind = FindFirstFile(findDir.c_str(), &data);
+	HANDLE hFind = FindFirstFile(findDir.c_str(), &data);
 	do {
 		std::wstring name = data.cFileName;
 		if ((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
@@ -307,15 +303,16 @@ std::vector<std::wstring> File::GetDirectoryPathList(const std::wstring& dir)
 	std::vector<std::wstring> res;
 
 	WIN32_FIND_DATA data;
-	HANDLE hFind;
 	std::wstring findDir = dir + L"*.*";
-	hFind = FindFirstFile(findDir.c_str(), &data);
+	HANDLE hFind = FindFirstFile(findDir.c_str(), &data);
 	do {
 		std::wstring name = data.cFileName;
-		if ((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) && (name != L".." && name != L".")) {
+		if ((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+			&& (name != L".." && name != L".")) {
 			//ディレクトリ
 			std::wstring tDir = dir + name;
 			tDir += L"\\";
+
 			res.push_back(tDir);
 			continue;
 		}
@@ -340,9 +337,7 @@ ArchiveFileEntry::ArchiveFileEntry()
 	sizeCompressed_ = 0;
 	offset_ = 0;
 }
-ArchiveFileEntry::~ArchiveFileEntry()
-{
-}
+ArchiveFileEntry::~ArchiveFileEntry() = default;
 int ArchiveFileEntry::_GetEntryRecordSize() const
 {
 	int res = 0;
@@ -383,15 +378,10 @@ void ArchiveFileEntry::_ReadEntryRecord(ByteBuffer& buf)
 /**********************************************************
 //FileArchiver
 **********************************************************/
-FileArchiver::FileArchiver()
-{
-}
-FileArchiver::~FileArchiver()
-{
-}
+FileArchiver::FileArchiver() = default;
+FileArchiver::~FileArchiver() = default;
 bool FileArchiver::CreateArchiveFile(const std::wstring& path)
 {
-	bool res = true;
 	File fileArchive(path);
 	if (!fileArchive.Create())
 		throw gstd::wexception(StringUtility::Format(L"ファイル作成失敗[%s]", path.c_str()));
@@ -405,10 +395,7 @@ bool FileArchiver::CreateArchiveFile(const std::wstring& path)
 
 	int posEntryStart = fileArchive.GetFilePointer();
 
-	std::list<ref_count_ptr<ArchiveFileEntry>>::iterator itr;
-	for (itr = listEntry_.begin(); itr != listEntry_.end(); itr++) {
-		ref_count_ptr<ArchiveFileEntry> entry = *itr;
-
+	for (auto& entry : listEntry_) {
 		std::wstring name = entry->GetName();
 		entry->SetName(PathProperty::GetFileName(name));
 
@@ -422,12 +409,11 @@ bool FileArchiver::CreateArchiveFile(const std::wstring& path)
 	}
 	int posEntryEnd = fileArchive.GetFilePointer();
 
-	for (itr = listEntry_.begin(); itr != listEntry_.end(); itr++) {
-		ref_count_ptr<ArchiveFileEntry> entry = *itr;
+	for (auto& entry : listEntry_) {
 		std::wstring path = entry->GetName();
 		File file(path);
 		if (!file.Open())
-			throw gstd::wexception(StringUtility::Format(L"ファイルオープン失敗[%s]", path.c_str()).c_str());
+			throw gstd::wexception(StringUtility::Format(L"ファイルオープン失敗[%s]", path.c_str()));
 
 		entry->_SetDataSize(file.GetSize());
 		entry->_SetOffset(fileArchive.GetFilePointer());
@@ -452,9 +438,7 @@ bool FileArchiver::CreateArchiveFile(const std::wstring& path)
 	fileArchive.Seek(posArchiveEntryHeaderStart);
 	fileArchive.WriteBoolean(false);
 	fileArchive.WriteInteger(0);
-	for (itr = listEntry_.begin(); itr != listEntry_.end(); itr++) {
-		ref_count_ptr<ArchiveFileEntry> entry = *itr;
-
+	for (auto& entry : listEntry_) {
 		std::wstring name = entry->GetName();
 		entry->SetName(PathProperty::GetFileName(name));
 
@@ -490,7 +474,7 @@ bool FileArchiver::CreateArchiveFile(const std::wstring& path)
 		fileArchive.Write(bufGap.GetPointer(), sizeGap);
 	}
 
-	return res;
+	return true;
 }
 
 /**********************************************************
@@ -508,7 +492,7 @@ bool ArchiveFile::Open()
 {
 	if (!file_->Open())
 		return false;
-	if (mapEntry_.size() != 0)
+	if (!mapEntry_.empty())
 		return true;
 
 	bool res = true;
@@ -523,8 +507,8 @@ bool ArchiveFile::Open()
 		bool bCompress = file_->ReadBoolean();
 		int sizeArchiveHeader = file_->ReadInteger();
 
-		ref_count_ptr<Reader> reader = NULL;
-		ByteBuffer* bufIn = new ByteBuffer;
+		ref_count_ptr<Reader> reader = nullptr;
+		auto* bufIn = new ByteBuffer;
 		if (!bCompress)
 			reader = file_;
 		else {
@@ -534,7 +518,7 @@ bool ArchiveFile::Open()
 			reader = bufIn;
 		}
 
-		for (int iEntry = 0; iEntry < countEntry; iEntry++) {
+		for (int iEntry = 0; iEntry < countEntry; ++iEntry) {
 			ref_count_ptr<ArchiveFileEntry> entry = new ArchiveFileEntry();
 			int sizeEntry = reader->ReadInteger();
 			ByteBuffer buf;
@@ -549,7 +533,7 @@ bool ArchiveFile::Open()
 			std::wstring key = entry->GetName();
 			mapEntry_.insert(std::pair<std::wstring, ref_count_ptr<ArchiveFileEntry>>(key, entry));
 		}
-		reader = NULL;
+		reader = nullptr;
 		res = true;
 	} catch (...) {
 		res = false;
@@ -561,12 +545,11 @@ void ArchiveFile::Close()
 {
 	file_->Close();
 }
-std::set<std::wstring> ArchiveFile::GetKeyList()
+std::set<std::wstring> ArchiveFile::GetKeyList() const
 {
 	std::set<std::wstring> res;
-	std::multimap<std::wstring, ref_count_ptr<ArchiveFileEntry>>::iterator itr = mapEntry_.begin();
-	for (; itr != mapEntry_.end(); itr++) {
-		ref_count_ptr<ArchiveFileEntry> entry = itr->second;
+	for (auto& entryItr : mapEntry_) {
+		auto entry = entryItr.second;
 		// std::wstring key = entry->GetDirectory() + entry->GetName();
 		std::wstring key = entry->GetName();
 		res.insert(key);
@@ -579,14 +562,10 @@ std::vector<ref_count_ptr<ArchiveFileEntry>> ArchiveFile::GetEntryList(const std
 	if (!IsExists(name))
 		return res;
 
-	std::pair<std::multimap<std::wstring, ref_count_ptr<ArchiveFileEntry>>::iterator,
-		std::multimap<std::wstring, ref_count_ptr<ArchiveFileEntry>>::iterator>
-		itrPair = mapEntry_.equal_range(name);
-	for (; itrPair.first != itrPair.second; itrPair.first++) {
+	for (auto itrPair = mapEntry_.equal_range(name); itrPair.first != itrPair.second; ++itrPair.first) {
 		ref_count_ptr<ArchiveFileEntry> entry = (itrPair.first)->second;
 		res.push_back(entry);
 	}
-
 	return res;
 }
 bool ArchiveFile::IsExists(const std::wstring& name) const
@@ -642,17 +621,15 @@ ref_count_ptr<ByteBuffer> ArchiveFile::GetBuffer(std::string name)
 /**********************************************************
 //FileManager
 **********************************************************/
-FileManager* FileManager::thisBase_ = NULL;
-FileManager::FileManager()
-{
-}
+FileManager* FileManager::thisBase_ = nullptr;
+FileManager::FileManager() = default;
 FileManager::~FileManager()
 {
 	EndLoadThread();
 }
 bool FileManager::Initialize()
 {
-	if (thisBase_ != NULL)
+	if (thisBase_ != nullptr)
 		return false;
 	thisBase_ = this;
 	threadLoad_ = new LoadThread();
@@ -661,14 +638,12 @@ bool FileManager::Initialize()
 }
 void FileManager::EndLoadThread()
 {
-	{
-		Lock lock(lock_);
-		if (threadLoad_ == NULL)
-			return;
-		threadLoad_->Stop();
-		threadLoad_->Join();
-		threadLoad_ = NULL;
-	}
+	Lock lock(lock_);
+	if (threadLoad_ == nullptr)
+		return;
+	threadLoad_->Stop();
+	threadLoad_->Join();
+	threadLoad_ = nullptr;
 }
 bool FileManager::AddArchiveFile(const std::wstring& path)
 {
@@ -681,25 +656,20 @@ bool FileManager::AddArchiveFile(const std::wstring& path)
 
 	std::set<std::wstring> listKeyIn = file->GetKeyList();
 	std::set<std::wstring> listKeyCurrent;
-	std::map<std::wstring, ref_count_ptr<ArchiveFile>>::iterator itrFile;
-	for (itrFile = mapArchiveFile_.begin(); itrFile != mapArchiveFile_.end(); itrFile++) {
-		ref_count_ptr<ArchiveFile> tFile = itrFile->second;
-		std::set<std::wstring> tList = tFile->GetKeyList();
-		std::set<std::wstring>::iterator itrList = tList.begin();
-		for (; itrList != tList.end(); itrList++) {
-			listKeyCurrent.insert(*itrList);
+	for (auto& tFile : mapArchiveFile_) {
+		std::set<std::wstring> tList = (tFile.second)->GetKeyList();
+		for (const auto& key : tList) {
+			listKeyCurrent.insert(key);
 		}
 	}
 
-	std::set<std::wstring>::iterator itrKey = listKeyIn.begin();
-	for (; itrKey != listKeyIn.end(); itrKey++) {
-		std::wstring key = *itrKey;
+	for (const auto& key : listKeyIn) {
 		if (listKeyCurrent.find(key) == listKeyCurrent.end())
 			continue;
 
 		std::wstring log = StringUtility::Format(L"archive file entry already exists[%s]", key.c_str());
 		Logger::WriteTop(log);
-		throw wexception(log.c_str());
+		throw wexception(log);
 	}
 
 	mapArchiveFile_[path] = file;
@@ -714,28 +684,26 @@ ref_count_ptr<FileReader> FileManager::GetFileReader(const std::wstring& orgPath
 {
 	std::wstring path = PathProperty::GetUnique(orgPath);
 
-	ref_count_ptr<FileReader> res = NULL;
+	ref_count_ptr<FileReader> res = nullptr;
 	ref_count_ptr<File> fileRaw = new File(path);
 	if (fileRaw->IsExists()) {
-		res = new ManagedFileReader(fileRaw, NULL);
+		res = new ManagedFileReader(fileRaw, nullptr);
 	} else {
 		std::vector<ref_count_ptr<ArchiveFileEntry>> listEntry;
 
 		std::map<int, std::wstring> mapArchivePath;
 		std::wstring key = PathProperty::GetFileName(path);
-		std::map<std::wstring, ref_count_ptr<ArchiveFile>>::iterator itr;
-		for (itr = mapArchiveFile_.begin(); itr != mapArchiveFile_.end(); itr++) {
-			std::wstring pathArchive = itr->first;
-			ref_count_ptr<ArchiveFile> fileArchive = itr->second;
+		for (auto& archiveItr : mapArchiveFile_) {
+			std::wstring pathArchive = archiveItr.first;
+			ref_count_ptr<ArchiveFile> fileArchive = archiveItr.second;
 			if (!fileArchive->IsExists(key))
 				continue;
 
 			ref_count_ptr<File> file = new File(pathArchive);
 			std::vector<ref_count_ptr<ArchiveFileEntry>> list = fileArchive->GetEntryList(key);
 			listEntry.insert(listEntry.end(), list.begin(), list.end());
-			for (int iEntry = 0; iEntry < list.size(); iEntry++) {
-				ref_count_ptr<ArchiveFileEntry> entry = list[iEntry];
-				int addr = (int)entry.GetPointer();
+			for (auto& entry : list) {
+				int addr = reinterpret_cast<int>(entry.GetPointer());
 				mapArchivePath[addr] = pathArchive;
 			}
 		}
@@ -751,8 +719,7 @@ ref_count_ptr<FileReader> FileManager::GetFileReader(const std::wstring& orgPath
 			module = PathProperty::GetUnique(module);
 
 			std::wstring target = StringUtility::ReplaceAll(path, module, L"");
-			for (int iEntry = 0; iEntry < listEntry.size(); iEntry++) {
-				ref_count_ptr<ArchiveFileEntry> entry = listEntry[iEntry];
+			for (auto& entry : listEntry) {
 				std::wstring dir = entry->GetDirectory();
 				if (target.find(dir) == std::wstring::npos)
 					continue;
@@ -765,68 +732,60 @@ ref_count_ptr<FileReader> FileManager::GetFileReader(const std::wstring& orgPath
 			}
 		}
 	}
-	if (res != NULL)
+	if (res != nullptr)
 		res->_SetOriginalPath(orgPath);
 	return res;
 }
 
 ref_count_ptr<ByteBuffer> FileManager::_GetByteBuffer(ref_count_ptr<ArchiveFileEntry> entry)
 {
-	ref_count_ptr<ByteBuffer> res = NULL;
 	try {
 		Lock lock(lock_);
 		std::wstring key = entry->GetDirectory() + entry->GetName();
-		if (mapByteBuffer_.find(key) != mapByteBuffer_.end()) {
-			res = mapByteBuffer_[key];
+		auto byteBufferItr = mapByteBuffer_.find(key);
+		if (byteBufferItr != mapByteBuffer_.end()) {
+			return byteBufferItr->second;
 		} else {
-			res = ArchiveFile::CreateEntryBuffer(entry);
-			if (res != NULL)
+			ref_count_ptr<ByteBuffer> res = ArchiveFile::CreateEntryBuffer(entry);
+			if (res != nullptr)
 				mapByteBuffer_[key] = res;
+			return res;
 		}
 	} catch (...) {
+		return nullptr;
 	}
-
-	return res;
 }
 void FileManager::_ReleaseByteBuffer(ref_count_ptr<ArchiveFileEntry> entry)
 {
-	{
-		Lock lock(lock_);
-		std::wstring key = entry->GetDirectory() + entry->GetName();
-		if (mapByteBuffer_.find(key) == mapByteBuffer_.end())
-			return;
-		ref_count_ptr<ByteBuffer> buffer = mapByteBuffer_[key];
-		if (buffer.GetReferenceCount() == 2) {
-			mapByteBuffer_.erase(key);
-		}
+	Lock lock(lock_);
+	std::wstring key = entry->GetDirectory() + entry->GetName();
+	if (mapByteBuffer_.find(key) == mapByteBuffer_.end())
+		return;
+	ref_count_ptr<ByteBuffer> buffer = mapByteBuffer_[key];
+	if (buffer.GetReferenceCount() == 2) {
+		mapByteBuffer_.erase(key);
 	}
 }
 void FileManager::AddLoadThreadEvent(ref_count_ptr<FileManager::LoadThreadEvent> event)
 {
-	{
-		Lock lock(lock_);
-		if (threadLoad_ == NULL)
-			return;
-		threadLoad_->AddEvent(event);
-	}
+	Lock lock(lock_);
+	if (threadLoad_ == nullptr)
+		return;
+	threadLoad_->AddEvent(event);
 }
 void FileManager::AddLoadThreadListener(FileManager::LoadThreadListener* listener)
 {
-	{
-		Lock lock(lock_);
-		if (threadLoad_ == NULL)
-			return;
-		threadLoad_->AddListener(listener);
-	}
+	Lock lock(lock_);
+	if (threadLoad_ == nullptr)
+		return;
+	threadLoad_->AddListener(listener);
 }
 void FileManager::RemoveLoadThreadListener(FileManager::LoadThreadListener* listener)
 {
-	{
-		Lock lock(lock_);
-		if (threadLoad_ == NULL)
-			return;
-		threadLoad_->RemoveListener(listener);
-	}
+	Lock lock(lock_);
+	if (threadLoad_ == nullptr)
+		return;
+	threadLoad_->RemoveListener(listener);
 }
 void FileManager::WaitForThreadLoadComplete()
 {
@@ -836,12 +795,8 @@ void FileManager::WaitForThreadLoadComplete()
 }
 
 //FileManager::LoadThread
-FileManager::LoadThread::LoadThread()
-{
-}
-FileManager::LoadThread::~LoadThread()
-{
-}
+FileManager::LoadThread::LoadThread() = default;
+FileManager::LoadThread::~LoadThread() = default;
 void FileManager::LoadThread::_Run()
 {
 	while (this->GetStatus() == RUN) {
@@ -849,10 +804,10 @@ void FileManager::LoadThread::_Run()
 
 		while (this->GetStatus() == RUN) {
 			// Logger::WriteTop(StringUtility::Format("ロードイベント取り出し開始"));
-			ref_count_ptr<FileManager::LoadThreadEvent> event = NULL;
+			ref_count_ptr<FileManager::LoadThreadEvent> event = nullptr;
 			{
 				Lock lock(lockEvent_);
-				if (listEvent_.size() == 0)
+				if (listEvent_.empty())
 					break;
 				event = listEvent_.front();
 				//listPath_.erase(event->GetPath());
@@ -863,9 +818,7 @@ void FileManager::LoadThread::_Run()
 			// Logger::WriteTop(StringUtility::Format("ロード開始：%s", event->GetPath().c_str()));
 			{
 				Lock lock(lockListener_);
-				std::list<FileManager::LoadThreadListener*>::iterator itr;
-				for (itr = listListener_.begin(); itr != listListener_.end(); itr++) {
-					FileManager::LoadThreadListener* listener = (*itr);
+				for (auto& listener : listListener_) {
 					if (event->GetListener() == listener)
 						listener->CallFromLoadThread(event);
 				}
@@ -885,60 +838,44 @@ void FileManager::LoadThread::Stop()
 	Thread::Stop();
 	signal_.SetSignal();
 }
-bool FileManager::LoadThread::IsThreadLoadComplete()
+bool FileManager::LoadThread::IsThreadLoadComplete() const
 {
-	bool res = false;
-	{
-		Lock lock(lockEvent_);
-		res = listEvent_.size() == 0;
-	}
-	return res;
+	Lock lock(lockEvent_);
+	return listEvent_.empty();
 }
-bool FileManager::LoadThread::IsThreadLoadExists(const std::wstring&)
+bool FileManager::LoadThread::IsThreadLoadExists(const std::wstring& /*unused*/) const
 {
-	bool res = false;
-	{
-		Lock lock(lockEvent_);
-		// res = listPath_.find(path) != listPath_.end();
-	}
-	return res;
+	Lock lock(lockEvent_);
+	// return listPath_.find(path) != listPath_.end();
+	return false;
 }
 void FileManager::LoadThread::AddEvent(ref_count_ptr<FileManager::LoadThreadEvent> event)
 {
-	{
-		Lock lock(lockEvent_);
-		std::wstring path = event->GetPath();
-		if (IsThreadLoadExists(path))
-			return;
-		listEvent_.push_back(event);
-		// listPath_.insert(path);
-		signal_.SetSignal();
-		signal_.SetSignal(false);
-	}
+	Lock lock(lockEvent_);
+	std::wstring path = event->GetPath();
+	if (IsThreadLoadExists(path))
+		return;
+	listEvent_.push_back(event);
+	// listPath_.insert(path);
+	signal_.SetSignal();
+	signal_.SetSignal(false);
 }
-void FileManager::LoadThread::AddListener(FileManager::LoadThreadListener* listener)
+void FileManager::LoadThread::AddListener(FileManager::LoadThreadListener* _Listener)
 {
-	{
-		Lock lock(lockListener_);
-		std::list<FileManager::LoadThreadListener*>::iterator itr;
-		for (itr = listListener_.begin(); itr != listListener_.end(); itr++) {
-			if (*itr == listener)
-				return;
-		}
+	Lock lock(lockListener_);
+	for (const auto& listener : listListener_)
+		if (listener == _Listener)
+			return;
 
-		listListener_.push_back(listener);
-	}
+	listListener_.push_back(_Listener);
 }
 void FileManager::LoadThread::RemoveListener(FileManager::LoadThreadListener* listener)
 {
-	{
-		Lock lock(lockListener_);
-		std::list<FileManager::LoadThreadListener*>::iterator itr;
-		for (itr = listListener_.begin(); itr != listListener_.end(); itr++) {
-			if (*itr != listener)
-				continue;
+	Lock lock(lockListener_);
+	for (auto itr = listListener_.begin(); itr != listListener_.end(); ++itr) {
+		if (*itr == listener) {
 			listListener_.erase(itr);
-			break;
+			return;
 		}
 	}
 }
@@ -952,11 +889,11 @@ ManagedFileReader::ManagedFileReader(ref_count_ptr<File> file, ref_count_ptr<Arc
 	file_ = file;
 	entry_ = entry;
 
-	if (entry_ == NULL) {
+	if (entry_ == nullptr) {
 		type_ = TYPE_NORMAL;
-	} else if (entry_->GetCompressType() == ArchiveFileEntry::CT_NON && entry_ != NULL) {
+	} else if (entry_->GetCompressType() == ArchiveFileEntry::CT_NON) {
 		type_ = TYPE_ARCHIVED;
-	} else if (entry_->GetCompressType() != ArchiveFileEntry::CT_NON && entry_ != NULL) {
+	} else if (entry_->GetCompressType() != ArchiveFileEntry::CT_NON) {
 		type_ = TYPE_ARCHIVED_COMPRESSED;
 	}
 }
@@ -977,16 +914,16 @@ bool ManagedFileReader::Open()
 		}
 	} else if (type_ == TYPE_ARCHIVED_COMPRESSED) {
 		buffer_ = FileManager::GetBase()->_GetByteBuffer(entry_);
-		res = buffer_ != NULL;
+		res = buffer_ != nullptr;
 	}
 	return res;
 }
 void ManagedFileReader::Close()
 {
-	if (file_ != NULL)
+	if (file_ != nullptr)
 		file_->Close();
-	if (buffer_ != NULL) {
-		buffer_ = NULL;
+	if (buffer_ != nullptr) {
+		buffer_ = nullptr;
 		FileManager::GetBase()->_ReleaseByteBuffer(entry_);
 	}
 }
@@ -997,7 +934,7 @@ int ManagedFileReader::GetFileSize()
 		res = file_->GetSize();
 	else if (type_ == TYPE_ARCHIVED)
 		res = entry_->GetDataSize();
-	else if (type_ == TYPE_ARCHIVED_COMPRESSED && buffer_ != NULL)
+	else if (type_ == TYPE_ARCHIVED_COMPRESSED && buffer_ != nullptr)
 		res = buffer_->GetSize();
 	return res;
 }
@@ -1045,7 +982,7 @@ BOOL ManagedFileReader::SetFilePointerEnd()
 		res = file_->Seek(entry_->GetOffset() + entry_->GetDataSize());
 		offset_ = entry_->GetDataSize();
 	} else if (type_ == TYPE_ARCHIVED_COMPRESSED) {
-		if (buffer_ != NULL) {
+		if (buffer_ != nullptr) {
 			offset_ = buffer_->GetSize();
 			res = TRUE;
 		}
@@ -1060,7 +997,7 @@ BOOL ManagedFileReader::Seek(LONG offset)
 	} else if (type_ == TYPE_ARCHIVED) {
 		res = file_->Seek(entry_->GetOffset() + offset);
 	} else if (type_ == TYPE_ARCHIVED_COMPRESSED) {
-		if (buffer_ != NULL) {
+		if (buffer_ != nullptr) {
 			res = TRUE;
 		}
 	}
@@ -1076,7 +1013,7 @@ LONG ManagedFileReader::GetFilePointer()
 	} else if (type_ == TYPE_ARCHIVED) {
 		res = file_->GetFilePointer() - entry_->GetOffset();
 	} else if (type_ == TYPE_ARCHIVED_COMPRESSED) {
-		if (buffer_ != NULL) {
+		if (buffer_ != nullptr) {
 			res = offset_;
 		}
 	}
@@ -1098,9 +1035,8 @@ RecordEntry::RecordEntry()
 {
 	type_ = TYPE_UNKNOWN;
 }
-RecordEntry::~RecordEntry()
-{
-}
+RecordEntry::~RecordEntry() = default;
+
 int RecordEntry::_GetEntryRecordSize() const
 {
 	int res = 0;
@@ -1134,20 +1070,19 @@ void RecordEntry::_ReadEntryRecord(Reader& reader)
 /**********************************************************
 //RecordBuffer
 **********************************************************/
-RecordBuffer::RecordBuffer()
-{
-}
+RecordBuffer::RecordBuffer() = default;
 RecordBuffer::~RecordBuffer()
 {
 	this->Clear();
 }
+
 void RecordBuffer::Clear()
 {
 	mapEntry_.clear();
 }
 ref_count_ptr<RecordEntry> RecordBuffer::GetEntry(const std::string& key)
 {
-	return IsExists(key) ? mapEntry_[key] : NULL;
+	return IsExists(key) ? mapEntry_[key] : nullptr;
 }
 bool RecordBuffer::IsExists(const std::string& key) const
 {
@@ -1156,9 +1091,8 @@ bool RecordBuffer::IsExists(const std::string& key) const
 std::vector<std::string> RecordBuffer::GetKeyList() const
 {
 	std::vector<std::string> res;
-	std::map<std::string, ref_count_ptr<RecordEntry>>::const_iterator itr;
-	for (itr = mapEntry_.begin(); itr != mapEntry_.end(); itr++) {
-		std::string key = itr->first;
+	for (auto& mapItr : mapEntry_) {
+		std::string key = mapItr.first;
 		res.push_back(key);
 	}
 	return res;
@@ -1169,9 +1103,8 @@ void RecordBuffer::Write(Writer& writer)
 	int countEntry = mapEntry_.size();
 	writer.WriteInteger(countEntry);
 
-	std::map<std::string, ref_count_ptr<RecordEntry>>::iterator itr;
-	for (itr = mapEntry_.begin(); itr != mapEntry_.end(); itr++) {
-		ref_count_ptr<RecordEntry> entry = itr->second;
+	for (auto& entryItr : mapEntry_) {
+		ref_count_ptr<RecordEntry> entry = entryItr.second;
 		entry->_WriteEntryRecord(writer);
 	}
 }
@@ -1179,7 +1112,7 @@ void RecordBuffer::Read(Reader& reader)
 {
 	this->Clear();
 	int countEntry = reader.ReadInteger();
-	for (int iEntry = 0; iEntry < countEntry; iEntry++) {
+	for (int iEntry = 0; iEntry < countEntry; ++iEntry) {
 		ref_count_ptr<RecordEntry> entry = new RecordEntry();
 		entry->_ReadEntryRecord(reader);
 
@@ -1344,22 +1277,19 @@ void RecordBuffer::Write(RecordBuffer& record)
 /**********************************************************
 //PropertyFile
 **********************************************************/
-PropertyFile::PropertyFile()
-{
-}
-PropertyFile::~PropertyFile()
-{
-}
-bool PropertyFile::Load(std::wstring path)
+PropertyFile::PropertyFile() = default;
+PropertyFile::~PropertyFile() = default;
+
+bool PropertyFile::Load(const std::wstring& path)
 {
 	mapEntry_.clear();
 
 	std::vector<char> text;
 	FileManager* fileManager = FileManager::GetBase();
-	if (fileManager != NULL) {
+	if (fileManager != nullptr) {
 		ref_count_ptr<FileReader> reader = fileManager->GetFileReader(path);
 
-		if (reader == NULL || !reader->Open()) {
+		if (reader == nullptr || !reader->Open()) {
 			Logger::WriteTop(ErrorUtility::GetFileNotFoundErrorMessage(path));
 			return false;
 		}
@@ -1379,7 +1309,6 @@ bool PropertyFile::Load(std::wstring path)
 		text[size] = '\0';
 	}
 
-	bool res = false;
 	gstd::Scanner scanner(text);
 	try {
 		while (scanner.HasNext()) {
@@ -1419,85 +1348,75 @@ bool PropertyFile::Load(std::wstring path)
 
 			mapEntry_[key] = value;
 		}
-
-		res = true;
 	} catch (gstd::wexception& e) {
 		mapEntry_.clear();
 		Logger::WriteTop(
 			ErrorUtility::GetParseErrorMessage(path, scanner.GetCurrentLine(), e.what()));
-		res = false;
+		return false;
 	}
-	return res;
+	return true;
 }
 bool PropertyFile::HasProperty(const std::wstring& key) const
 {
 	return mapEntry_.find(key) != mapEntry_.end();
 }
-std::wstring PropertyFile::GetString(const std::wstring& key, const std::wstring& def)
+std::wstring PropertyFile::GetString(const std::wstring& key, const std::wstring& def) const
 {
 	if (!HasProperty(key))
 		return def;
-	return mapEntry_[key];
+	return mapEntry_.at(key);
 }
-int PropertyFile::GetInteger(const std::wstring& key, int def)
+int PropertyFile::GetInteger(const std::wstring& key, int def) const
 {
 	if (!HasProperty(key))
 		return def;
-	std::wstring strValue = mapEntry_[key];
+	std::wstring strValue = mapEntry_.at(key);
 	return StringUtility::ToInteger(strValue);
 }
-double PropertyFile::GetReal(const std::wstring& key, double def)
+double PropertyFile::GetReal(const std::wstring& key, double def) const
 {
 	if (!HasProperty(key))
 		return def;
-	std::wstring strValue = mapEntry_[key];
+	std::wstring strValue = mapEntry_.at(key);
 	return StringUtility::ToDouble(strValue);
 }
 
 /**********************************************************
 //Compressor
 **********************************************************/
-Compressor::Compressor()
-{
-}
-Compressor::~Compressor()
-{
-}
+Compressor::Compressor() = default;
+Compressor::~Compressor() = default;
+
 bool Compressor::Compress(ByteBuffer& bufIn, ByteBuffer& bufOut)
 {
 	//TODO 要独自の圧縮を実装
 	//公開ソースでは、受け渡されたデータをそのまま返す
-	bool res = true;
 
 	int inputSize = bufIn.GetSize();
 	bufOut.SetSize(inputSize);
 	memcpy(bufOut.GetPointer(0), bufIn.GetPointer(0), inputSize);
 
-	return res;
+	return true;
 }
 
 /**********************************************************
 //DeCompressor
 **********************************************************/
-DeCompressor::DeCompressor()
-{
-}
-DeCompressor::~DeCompressor()
-{
-}
+DeCompressor::DeCompressor() = default;
+DeCompressor::~DeCompressor() = default;
 
 bool DeCompressor::DeCompress(ByteBuffer& bufIn, ByteBuffer& bufOut)
 {
 	//TODO 要独自の圧縮を実装
 	//公開ソースでは、受け渡されたデータをそのまま返す
 	//why mkm why
-	bool res = true;
+
 	//zlib stuff
 	/*
 	if (!Compressed)
-		return 0;*/
+		return false;*/
 
-	return res;
+	return true;
 }
 
 bool DeCompressor::DeCompressHeader(ByteBuffer& bufIn, ByteBuffer& bufOut)
@@ -1505,11 +1424,11 @@ bool DeCompressor::DeCompressHeader(ByteBuffer& bufIn, ByteBuffer& bufOut)
 	//TODO 要独自の圧縮を実装
 	//公開ソースでは、受け渡されたデータをそのまま返す
 	//why mkm why
-	bool res = true;
+
 	int inputSize = bufIn.GetSize();
 	bufOut.SetSize(inputSize);
 	memcpy(bufOut.GetPointer(0), bufIn.GetPointer(0), inputSize);
-	return res;
+	return true;
 }
 
 /**********************************************************
@@ -1517,16 +1436,13 @@ bool DeCompressor::DeCompressHeader(ByteBuffer& bufIn, ByteBuffer& bufOut)
 **********************************************************/
 const std::string SystemValueManager::RECORD_SYSTEM = "__RECORD_SYSTEM__";
 const std::string SystemValueManager::RECORD_SYSTEM_GLOBAL = "__RECORD_SYSTEM_GLOBAL__";
-SystemValueManager* SystemValueManager::thisBase_ = NULL;
-SystemValueManager::SystemValueManager()
-{
-}
-SystemValueManager::~SystemValueManager()
-{
-}
+SystemValueManager* SystemValueManager::thisBase_ = nullptr;
+SystemValueManager::SystemValueManager() = default;
+SystemValueManager::~SystemValueManager() = default;
+
 bool SystemValueManager::Initialize()
 {
-	if (thisBase_ != NULL)
+	if (thisBase_ != nullptr)
 		return false;
 
 	mapRecord_[RECORD_SYSTEM] = new RecordBuffer();
@@ -1535,11 +1451,11 @@ bool SystemValueManager::Initialize()
 	thisBase_ = this;
 	return true;
 }
-void SystemValueManager::ClearRecordBuffer(std::string key)
+void SystemValueManager::ClearRecordBuffer(const std::string& key)
 {
 	if (!IsExists(key))
 		return;
-	mapRecord_[key]->Clear();
+	mapRecord_.at(key)->Clear();
 }
 bool SystemValueManager::IsExists(const std::string& key) const
 {
@@ -1554,5 +1470,5 @@ bool SystemValueManager::IsExists(const std::string& keyRecord, const std::strin
 }
 gstd::ref_count_ptr<RecordBuffer> SystemValueManager::GetRecordBuffer(const std::string& key)
 {
-	return IsExists(key) ? mapRecord_[key] : NULL;
+	return IsExists(key) ? mapRecord_[key] : nullptr;
 }

--- a/source/GcLib/gstd/File.hpp
+++ b/source/GcLib/gstd/File.hpp
@@ -114,7 +114,7 @@ public:
 	virtual bool IsArchived() { return false; }
 	virtual bool IsCompressed() { return false; }
 
-	std::wstring GetOriginalPath() { return pathOriginal_; }
+	std::wstring GetOriginalPath() const { return pathOriginal_; }
 	std::string ReadAllString()
 	{
 		SetFilePointerBegin();
@@ -123,7 +123,7 @@ public:
 
 protected:
 	std::wstring pathOriginal_;
-	void _SetOriginalPath(std::wstring path) { pathOriginal_ = path; }
+	void _SetOriginalPath(const std::wstring& path) { pathOriginal_ = path; }
 };
 
 /**********************************************************
@@ -132,15 +132,15 @@ protected:
 class ByteBuffer : public Writer, public Reader {
 public:
 	ByteBuffer();
-	ByteBuffer(ByteBuffer& buffer);
+	ByteBuffer(const ByteBuffer& buffer);
 	virtual ~ByteBuffer();
-	void Copy(ByteBuffer& src);
+	void Copy(const ByteBuffer& src);
 	void Clear();
 
 	void Seek(int pos);
 	void SetSize(int size);
-	int GetSize() { return size_; }
-	int GetOffset() { return offset_; }
+	int GetSize() const { return size_; }
+	int GetOffset() const { return offset_; }
 	int Decompress();
 
 	virtual DWORD Write(LPVOID buf, DWORD size);
@@ -154,7 +154,7 @@ protected:
 	int offset_;
 	char* data_;
 
-	int _GetReservedSize();
+	int _GetReservedSize() const;
 	void _Resize(int size);
 };
 
@@ -172,12 +172,12 @@ public:
 
 public:
 	File();
-	File(std::wstring path);
+	File(const std::wstring& path);
 	virtual ~File();
 	bool CreateDirectory();
 	void Delete();
 	bool IsExists();
-	static bool IsExists(std::wstring path);
+	static bool IsExists(const std::wstring& path);
 	bool IsDirectory();
 
 	int GetSize();
@@ -197,9 +197,9 @@ public:
 	BOOL Seek(LONG offset, DWORD seek = FILE_BEGIN) { return (::SetFilePointer(hFile_, offset, NULL, seek) != 0xFFFFFFFF); }
 	LONG GetFilePointer() { return ::SetFilePointer(hFile_, 0, NULL, FILE_CURRENT); }
 
-	static bool IsEqualsPath(std::wstring path1, std::wstring path2);
-	static std::vector<std::wstring> GetFilePathList(std::wstring dir);
-	static std::vector<std::wstring> GetDirectoryPathList(std::wstring dir);
+	static bool IsEqualsPath(const std::wstring& _Path_first, const std::wstring& _Path_second);
+	static std::vector<std::wstring> GetFilePathList(const std::wstring& dir);
+	static std::vector<std::wstring> GetDirectoryPathList(const std::wstring& dir);
 
 protected:
 	HANDLE hFile_;
@@ -226,18 +226,18 @@ public:
 	ArchiveFileEntry();
 	virtual ~ArchiveFileEntry();
 
-	void SetDirectory(std::wstring dir) { dir_ = dir; }
-	std::wstring& GetDirectory() { return dir_; }
-	void SetName(std::wstring name) { name_ = name; }
-	std::wstring& GetName() { return name_; }
+	void SetDirectory(const std::wstring& dir) { dir_ = dir; }
+	std::wstring GetDirectory() const { return dir_; }
+	void SetName(const std::wstring& name) { name_ = name; }
+	std::wstring GetName() const { return name_; }
 	void SetCompressType(CompressType type) { typeCompress_ = type; }
-	CompressType& GetCompressType() { return typeCompress_; }
+	CompressType GetCompressType() const { return typeCompress_; }
 
-	int GetOffset() { return offset_; }
-	int GetDataSize() { return sizeData_; }
-	int GetCompressedDataSize() { return sizeCompressed_; }
+	int GetOffset() const { return offset_; }
+	int GetDataSize() const { return sizeData_; }
+	int GetCompressedDataSize() const { return sizeCompressed_; }
 
-	std::wstring& GetArchivePath() { return pathArchive_; }
+	std::wstring GetArchivePath() const { return pathArchive_; }
 
 private:
 	std::wstring dir_;
@@ -248,14 +248,14 @@ private:
 	int offset_;
 	std::wstring pathArchive_;
 
-	int _GetEntryRecordSize();
+	int _GetEntryRecordSize() const;
 	void _WriteEntryRecord(ByteBuffer& buf);
 	void _ReadEntryRecord(ByteBuffer& buf);
 
 	void _SetOffset(int offset) { offset_ = offset; }
 	void _SetDataSize(int size) { sizeData_ = size; }
 	void _SetCompressedDataSize(int size) { sizeCompressed_ = size; }
-	void _SetArchivePath(std::wstring path) { pathArchive_ = path; }
+	void _SetArchivePath(const std::wstring& path) { pathArchive_ = path; }
 };
 
 /**********************************************************
@@ -267,7 +267,7 @@ public:
 	virtual ~FileArchiver();
 
 	void AddEntry(ref_count_ptr<ArchiveFileEntry> entry) { listEntry_.push_back(entry); }
-	bool CreateArchiveFile(std::wstring path);
+	bool CreateArchiveFile(const std::wstring& path);
 
 private:
 	std::list<ref_count_ptr<ArchiveFileEntry>> listEntry_;
@@ -285,10 +285,10 @@ public:
 
 	std::set<std::wstring> GetKeyList();
 	std::multimap<std::wstring, ref_count_ptr<ArchiveFileEntry>> GetEntryMap() { return mapEntry_; }
-	std::vector<ref_count_ptr<ArchiveFileEntry>> GetEntryList(std::wstring name);
-	bool IsExists(std::wstring name);
+	std::vector<ref_count_ptr<ArchiveFileEntry>> GetEntryList(const std::wstring& name);
+	bool IsExists(const std::wstring& name) const;
 	static ref_count_ptr<ByteBuffer> CreateEntryBuffer(ref_count_ptr<ArchiveFileEntry> entry);
-	//ref_count_ptr<ByteBuffer> GetBuffer(std::string name);
+	// ref_count_ptr<ByteBuffer> GetBuffer(std::string name);
 private:
 	ref_count_ptr<File> file_;
 	std::multimap<std::wstring, ref_count_ptr<ArchiveFileEntry>> mapEntry_;
@@ -312,9 +312,9 @@ public:
 	virtual ~FileManager();
 	virtual bool Initialize();
 	void EndLoadThread();
-	bool AddArchiveFile(std::wstring path);
-	bool RemoveArchiveFile(std::wstring path);
-	ref_count_ptr<FileReader> GetFileReader(std::wstring path);
+	bool AddArchiveFile(const std::wstring& path);
+	bool RemoveArchiveFile(const std::wstring& path);
+	ref_count_ptr<FileReader> GetFileReader(const std::wstring& orgPath);
 
 	void AddLoadThreadEvent(ref_count_ptr<LoadThreadEvent> event);
 	void AddLoadThreadListener(FileManager::LoadThreadListener* listener);
@@ -345,7 +345,7 @@ public:
 	virtual ~LoadThread();
 	virtual void Stop();
 	bool IsThreadLoadComplete();
-	bool IsThreadLoadExists(std::wstring path);
+	bool IsThreadLoadExists(const std::wstring& path);
 	void AddEvent(ref_count_ptr<FileManager::LoadThreadEvent> event);
 	void AddListener(FileManager::LoadThreadListener* listener);
 	void RemoveListener(FileManager::LoadThreadListener* listener);
@@ -384,7 +384,7 @@ public:
 	virtual ~LoadThreadEvent() {}
 
 	FileManager::LoadThreadListener* GetListener() { return listener_; }
-	std::wstring GetPath() { return path_; }
+	std::wstring GetPath() const { return path_; }
 	ref_count_ptr<FileManager::LoadObject> GetSource() { return source_; }
 };
 
@@ -457,9 +457,9 @@ public:
 public:
 	RecordEntry();
 	virtual ~RecordEntry();
-	char GetType() { return type_; }
+	char GetType() const { return type_; }
 
-	void SetKey(std::string key) { key_ = key; }
+	void SetKey(const std::string& key) { key_ = key; }
 	void SetType(char type) { type_ = type; }
 	std::string& GetKey() { return key_; }
 	ByteBuffer& GetBufferRef() { return buffer_; }
@@ -469,7 +469,7 @@ private:
 	std::string key_;
 	ByteBuffer buffer_;
 
-	int _GetEntryRecordSize();
+	int _GetEntryRecordSize() const;
 	void _WriteEntryRecord(Writer& writer);
 	void _ReadEntryRecord(Reader& reader);
 };
@@ -482,34 +482,34 @@ public:
 	RecordBuffer();
 	virtual ~RecordBuffer();
 	void Clear(); //保持データクリア
-	int GetEntryCount() { return mapEntry_.size(); }
-	bool IsExists(std::string key);
-	std::vector<std::string> GetKeyList();
-	ref_count_ptr<RecordEntry> GetEntry(std::string key);
+	int GetEntryCount() const { return mapEntry_.size(); }
+	bool IsExists(const std::string& key) const;
+	std::vector<std::string> GetKeyList() const;
+	ref_count_ptr<RecordEntry> GetEntry(const std::string& key);
 
 	void Write(Writer& writer);
 	void Read(Reader& reader);
-	bool WriteToFile(std::wstring path, std::string header = HEADER_RECORDFILE);
-	bool ReadFromFile(std::wstring path, std::string header = HEADER_RECORDFILE);
+	bool WriteToFile(const std::wstring& path, const std::string& header = HEADER_RECORDFILE);
+	bool ReadFromFile(const std::wstring& path, const std::string& header = HEADER_RECORDFILE);
 
 	//エントリ
-	int GetEntryType(std::string key);
-	int GetEntrySize(std::string key);
+	int GetEntryType(const std::string& key);
+	int GetEntrySize(const std::string& key);
 
 	//エントリ取得(文字列キー)
-	bool GetRecord(std::string key, LPVOID buf, DWORD size);
+	bool GetRecord(const std::string& key, LPVOID buf, DWORD size);
 	template <typename T>
-	bool GetRecord(std::string key, T& data)
+	bool GetRecord(const std::string& key, T& data)
 	{
 		return GetRecord(key, &data, sizeof(T));
 	}
-	bool GetRecordAsBoolean(std::string key);
-	int GetRecordAsInteger(std::string key);
-	float GetRecordAsFloat(std::string key);
-	double GetRecordAsDouble(std::string key);
-	std::string GetRecordAsStringA(std::string key);
-	std::wstring GetRecordAsStringW(std::string key);
-	bool GetRecordAsRecordBuffer(std::string key, RecordBuffer& record);
+	bool GetRecordAsBoolean(const std::string& key);
+	int GetRecordAsInteger(const std::string& key);
+	float GetRecordAsFloat(const std::string& key);
+	double GetRecordAsDouble(const std::string& key);
+	std::string GetRecordAsStringA(const std::string& key);
+	std::wstring GetRecordAsStringW(const std::string& key);
+	bool GetRecordAsRecordBuffer(const std::string& key, RecordBuffer& record);
 
 	//エントリ取得(数値キー)
 	bool GetRecord(int key, LPVOID buf, DWORD size) { return GetRecord(StringUtility::Format("%d", key), buf, size); }
@@ -524,25 +524,25 @@ public:
 	bool GetRecordAsRecordBuffer(int key, RecordBuffer& record) { return GetRecordAsRecordBuffer(StringUtility::Format("%d", key), record); }
 
 	//エントリ設定(文字列キー)
-	void SetRecord(std::string key, LPVOID buf, DWORD size) { SetRecord(RecordEntry::TYPE_UNKNOWN, key, buf, size); }
+	void SetRecord(const std::string& key, LPVOID buf, DWORD size) { SetRecord(RecordEntry::TYPE_UNKNOWN, key, buf, size); }
 	template <typename T>
-	void SetRecord(std::string key, T& data)
+	void SetRecord(const std::string& key, T& data)
 	{
 		SetRecord(RecordEntry::TYPE_UNKNOWN, key, &data, sizeof(T));
 	}
-	void SetRecord(int type, std::string key, LPVOID buf, DWORD size);
+	void SetRecord(int type, const std::string& key, LPVOID buf, DWORD size);
 	template <typename T>
-	void SetRecord(int type, std::string key, T& data)
+	void SetRecord(int type, const std::string& key, T& data)
 	{
 		SetRecord(type, key, &data, sizeof(T));
 	}
-	void SetRecordAsBoolean(std::string key, bool data) { SetRecord(RecordEntry::TYPE_BOOLEAN, key, data); }
-	void SetRecordAsInteger(std::string key, int data) { SetRecord(RecordEntry::TYPE_INTEGER, key, data); }
-	void SetRecordAsFloat(std::string key, float data) { SetRecord(RecordEntry::TYPE_FLOAT, key, data); }
-	void SetRecordAsDouble(std::string key, double data) { SetRecord(RecordEntry::TYPE_DOUBLE, key, data); }
-	void SetRecordAsStringA(std::string key, std::string data) { SetRecord(RecordEntry::TYPE_STRING_A, key, &data[0], data.size()); }
-	void SetRecordAsStringW(std::string key, std::wstring data) { SetRecord(RecordEntry::TYPE_STRING_W, key, &data[0], data.size() * sizeof(wchar_t)); }
-	void SetRecordAsRecordBuffer(std::string key, RecordBuffer& record);
+	void SetRecordAsBoolean(const std::string& key, bool data) { SetRecord(RecordEntry::TYPE_BOOLEAN, key, data); }
+	void SetRecordAsInteger(const std::string& key, int data) { SetRecord(RecordEntry::TYPE_INTEGER, key, data); }
+	void SetRecordAsFloat(const std::string& key, float data) { SetRecord(RecordEntry::TYPE_FLOAT, key, data); }
+	void SetRecordAsDouble(const std::string& key, double data) { SetRecord(RecordEntry::TYPE_DOUBLE, key, data); }
+	void SetRecordAsStringA(const std::string& key, std::string data) { SetRecord(RecordEntry::TYPE_STRING_A, key, &data[0], data.size()); }
+	void SetRecordAsStringW(const std::string& key, std::wstring data) { SetRecord(RecordEntry::TYPE_STRING_W, key, &data[0], data.size() * sizeof(wchar_t)); }
+	void SetRecordAsRecordBuffer(const std::string& key, RecordBuffer& record);
 
 	//エントリ設定(数値キー)
 	void SetRecord(int key, LPVOID buf, DWORD size) { SetRecord(StringUtility::Format("%d", key), buf, size); }
@@ -574,13 +574,13 @@ public:
 
 	bool Load(std::wstring path);
 
-	bool HasProperty(std::wstring key);
-	std::wstring GetString(std::wstring key) { return GetString(key, L""); }
-	std::wstring GetString(std::wstring key, std::wstring def);
-	int GetInteger(std::wstring key) { return GetInteger(key, 0); }
-	int GetInteger(std::wstring key, int def);
-	double GetReal(std::wstring key) { return GetReal(key, 0.0); }
-	double GetReal(std::wstring key, double def);
+	bool HasProperty(const std::wstring& key) const;
+	std::wstring GetString(const std::wstring& key) { return GetString(key, L""); }
+	std::wstring GetString(const std::wstring& key, const std::wstring& def);
+	int GetInteger(const std::wstring& key) { return GetInteger(key, 0); }
+	int GetInteger(const std::wstring& key, int def);
+	double GetReal(const std::wstring& key) { return GetReal(key, 0.0); }
+	double GetReal(const std::wstring& key, double def);
 
 protected:
 	std::map<std::wstring, std::wstring> mapEntry_;
@@ -625,9 +625,9 @@ public:
 	virtual bool Initialize();
 
 	virtual void ClearRecordBuffer(std::string key);
-	bool IsExists(std::string key);
-	bool IsExists(std::string keyRecord, std::string keyValue);
-	gstd::ref_count_ptr<RecordBuffer> GetRecordBuffer(std::string key);
+	bool IsExists(const std::string& key) const;
+	bool IsExists(const std::string& keyRecord, const std::string& keyValue);
+	gstd::ref_count_ptr<RecordBuffer> GetRecordBuffer(const std::string& key);
 
 protected:
 	std::map<std::string, gstd::ref_count_ptr<RecordBuffer>> mapRecord_;

--- a/source/GcLib/gstd/FpsController.cpp
+++ b/source/GcLib/gstd/FpsController.cpp
@@ -142,7 +142,7 @@ void StaticFpsController::Wait()
 	countSkip_ %= (rateSkip + 1);
 	bCriticalFrame_ = false;
 }
-bool StaticFpsController::IsSkip()
+bool StaticFpsController::IsSkip() const
 {
 	int rateSkip = rateSkip_;
 	if (bFastMode_)
@@ -158,16 +158,16 @@ void StaticFpsController::SetSkipRate(int value)
 	rateSkip_ = value;
 	countSkip_ = 0;
 }
-float StaticFpsController::GetCurrentFps()
+float StaticFpsController::GetCurrentFps() const
 {
 	float fps = fpsCurrent_ / (rateSkip_ + 1);
 	return fps;
 }
-float StaticFpsController::GetCurrentWorkFps()
+float StaticFpsController::GetCurrentWorkFps() const
 {
 	return fpsCurrent_;
 }
-float StaticFpsController::GetCurrentRenderFps()
+float StaticFpsController::GetCurrentRenderFps() const
 {
 	float fps = fpsCurrent_ / (rateSkip_ + 1);
 	return fps;
@@ -269,7 +269,7 @@ void AutoSkipFpsController::Wait()
 		timeCurrentFpsUpdate_ = _GetTime();
 	}
 }
-bool AutoSkipFpsController::IsSkip()
+bool AutoSkipFpsController::IsSkip() const
 {
 	return countSkip_ > 0;
 }

--- a/source/GcLib/gstd/FpsController.cpp
+++ b/source/GcLib/gstd/FpsController.cpp
@@ -32,11 +32,6 @@ int FpsController::_GetTime()
 void FpsController::_Sleep(int msec)
 {
 	::Sleep(msec);
-	/*
-	int time = _GetTime();
-	while (abs(_GetTime() - time) < msec)
-		::Sleep(1);
-	*/
 }
 void FpsController::AddFpsControlObject(ref_count_weak_ptr<FpsControlObject> obj)
 {
@@ -44,29 +39,26 @@ void FpsController::AddFpsControlObject(ref_count_weak_ptr<FpsControlObject> obj
 }
 void FpsController::RemoveFpsControlObject(ref_count_weak_ptr<FpsControlObject> obj)
 {
-	std::list<ref_count_weak_ptr<FpsControlObject>>::iterator itr = listFpsControlObject_.begin();
-	;
-	for (; itr != listFpsControlObject_.end(); itr++) {
+	for (auto itr = listFpsControlObject_.begin(); itr != listFpsControlObject_.end(); ++itr) {
 		ref_count_weak_ptr<FpsControlObject> tObj = (*itr);
 		if (obj.GetPointer() == tObj.GetPointer()) {
 			listFpsControlObject_.erase(itr);
-			break;
+			return;
 		}
 	}
 }
 int FpsController::GetControlObjectFps()
 {
 	int res = fps_;
-	std::list<ref_count_weak_ptr<FpsControlObject>>::iterator itr = listFpsControlObject_.begin();
-	;
-	for (; itr != listFpsControlObject_.end();) {
+	for (auto itr = listFpsControlObject_.begin(); itr != listFpsControlObject_.end();) {
 		ref_count_weak_ptr<FpsControlObject> obj = (*itr);
 		if (obj.IsExists()) {
 			int fps = obj->GetFps();
 			res = min(res, fps);
-			itr++;
-		} else
+			++itr;
+		} else {
 			itr = listFpsControlObject_.erase(itr);
+		}
 	}
 	return res;
 }
@@ -83,9 +75,7 @@ StaticFpsController::StaticFpsController()
 	bUseTimer_ = true;
 	timeError_ = 0;
 }
-StaticFpsController::~StaticFpsController()
-{
-}
+StaticFpsController::~StaticFpsController() = default;
 void StaticFpsController::Wait()
 {
 	int time = _GetTime();
@@ -115,17 +105,16 @@ void StaticFpsController::Wait()
 	}
 
 	//1frameにかかった時間を保存
-	double timeCorrect = (double)sleepTime;
+	auto timeCorrect = (double)sleepTime;
 	if (time - timePrevious_ > 0)
 		listFps_.push_back(time - timePrevious_ + ceil(timeCorrect));
 	timePrevious_ = _GetTime();
 
 	if (time - timeCurrentFpsUpdate_ >= 1000) { //一秒ごとに表示フレーム数を更新
-		if (listFps_.size() != 0) {
+		if (!listFps_.empty()) {
 			double tFpsCurrent = 0;
-			std::list<int>::iterator itr;
-			for (itr = listFps_.begin(); itr != listFps_.end(); itr++) {
-				tFpsCurrent += (*itr);
+			for (int fps : listFps_) {
+				tFpsCurrent += fps;
 			}
 			fpsCurrent_ = (double)(1000.0) / ((double)tFpsCurrent / (double)listFps_.size());
 			listFps_.clear();
@@ -134,7 +123,7 @@ void StaticFpsController::Wait()
 
 		timeCurrentFpsUpdate_ = _GetTime();
 	}
-	countSkip_++;
+	++countSkip_;
 
 	int rateSkip = rateSkip_;
 	if (bFastMode_)
@@ -149,9 +138,7 @@ bool StaticFpsController::IsSkip() const
 		rateSkip = FAST_MODE_SKIP_RATE;
 	if (rateSkip == 0 || bCriticalFrame_)
 		return false;
-	if (countSkip_ % (rateSkip + 1) != 0)
-		return true;
-	return false;
+	return countSkip_ % (rateSkip + 1) != 0;
 }
 void StaticFpsController::SetSkipRate(int value)
 {
@@ -160,8 +147,7 @@ void StaticFpsController::SetSkipRate(int value)
 }
 float StaticFpsController::GetCurrentFps() const
 {
-	float fps = fpsCurrent_ / (rateSkip_ + 1);
-	return fps;
+	return fpsCurrent_ / (rateSkip_ + 1);
 }
 float StaticFpsController::GetCurrentWorkFps() const
 {
@@ -169,8 +155,7 @@ float StaticFpsController::GetCurrentWorkFps() const
 }
 float StaticFpsController::GetCurrentRenderFps() const
 {
-	float fps = fpsCurrent_ / (rateSkip_ + 1);
-	return fps;
+	return fpsCurrent_ / (rateSkip_ + 1);
 }
 
 /**********************************************************
@@ -190,9 +175,7 @@ AutoSkipFpsController::AutoSkipFpsController()
 	timeCurrentFpsUpdate_ = 0;
 	timeError_ = 0;
 }
-AutoSkipFpsController::~AutoSkipFpsController()
-{
-}
+AutoSkipFpsController::~AutoSkipFpsController() = default;
 void AutoSkipFpsController::Wait()
 {
 	int time = _GetTime();
@@ -223,12 +206,12 @@ void AutoSkipFpsController::Wait()
 			countSkip_ = countSkipMax_;
 	}
 
-	countSkip_--;
+	--countSkip_;
 	bCriticalFrame_ = false;
 
 	{
 		//1Workにかかった時間を保存
-		double timeCorrect = (double)sleepTime;
+		auto timeCorrect = (double)sleepTime;
 		if (time - timePrevious_ > 0)
 			listFpsWork_.push_back(time - timePrevious_ + ceil(timeCorrect));
 		timePrevious_ = _GetTime();
@@ -244,24 +227,22 @@ void AutoSkipFpsController::Wait()
 
 	timePrevious_ = _GetTime();
 	if (time - timeCurrentFpsUpdate_ >= 1000) { //一秒ごとに表示フレーム数を更新
-		if (listFpsWork_.size() != 0) {
+		if (!listFpsWork_.empty()) {
 			float tFpsCurrent = 0;
-			std::list<int>::iterator itr;
-			for (itr = listFpsWork_.begin(); itr != listFpsWork_.end(); itr++) {
-				tFpsCurrent += (*itr);
+			for (int fps : listFpsWork_) {
+				tFpsCurrent += fps;
 			}
-			fpsCurrentWork_ = (float)(1000.0f) / ((float)tFpsCurrent / (float)listFpsWork_.size());
+			fpsCurrentWork_ = (float)(1000.0F) / ((float)tFpsCurrent / (float)listFpsWork_.size());
 			listFpsWork_.clear();
 		} else
 			fpsCurrentWork_ = 0;
 
-		if (listFpsRender_.size() != 0) {
+		if (!listFpsRender_.empty()) {
 			float tFpsCurrent = 0;
-			std::list<int>::iterator itr;
-			for (itr = listFpsRender_.begin(); itr != listFpsRender_.end(); itr++) {
-				tFpsCurrent += (*itr);
+			for (int fps : listFpsRender_) {
+				tFpsCurrent += fps;
 			}
-			fpsCurrentRender_ = (float)(1000.0f) / ((float)tFpsCurrent / (float)listFpsRender_.size());
+			fpsCurrentRender_ = (float)(1000.0F) / ((float)tFpsCurrent / (float)listFpsRender_.size());
 			listFpsRender_.clear();
 		} else
 			fpsCurrentRender_ = 0;

--- a/source/GcLib/gstd/FpsController.hpp
+++ b/source/GcLib/gstd/FpsController.hpp
@@ -20,16 +20,16 @@ public:
 	FpsController();
 	virtual ~FpsController();
 	virtual void SetFps(int fps) { fps_ = fps; }
-	virtual int GetFps() { return fps_; }
+	virtual int GetFps() const { return fps_; }
 	virtual void SetTimerEnable(bool b) { bUseTimer_ = b; }
 
 	virtual void Wait() = 0;
-	virtual bool IsSkip() { return false; }
+	virtual bool IsSkip() const { return false; }
 	virtual void SetCriticalFrame() { bCriticalFrame_ = true; }
-	virtual float GetCurrentFps() = 0;
-	virtual float GetCurrentWorkFps() { return GetCurrentFps(); }
-	virtual float GetCurrentRenderFps() { return GetCurrentFps(); }
-	bool IsFastMode() { return bFastMode_; }
+	virtual float GetCurrentFps() const = 0;
+	virtual float GetCurrentWorkFps() const { return GetCurrentFps(); }
+	virtual float GetCurrentRenderFps() const { return GetCurrentFps(); }
+	bool IsFastMode() const { return bFastMode_; }
 	void SetFastMode(bool b) { bFastMode_ = b; }
 
 	void AddFpsControlObject(ref_count_weak_ptr<FpsControlObject> obj);
@@ -57,7 +57,7 @@ public:
 	~StaticFpsController();
 
 	virtual void Wait();
-	virtual bool IsSkip();
+	virtual bool IsSkip() const;
 	virtual void SetCriticalFrame()
 	{
 		bCriticalFrame_ = true;
@@ -66,9 +66,9 @@ public:
 	}
 
 	void SetSkipRate(int value);
-	virtual float GetCurrentFps();
-	virtual float GetCurrentWorkFps();
-	virtual float GetCurrentRenderFps();
+	virtual float GetCurrentFps() const;
+	virtual float GetCurrentWorkFps() const;
+	virtual float GetCurrentRenderFps() const;
 
 protected:
 	float fpsCurrent_; //現在のFPS
@@ -94,7 +94,7 @@ public:
 	~AutoSkipFpsController();
 
 	virtual void Wait();
-	virtual bool IsSkip();
+	virtual bool IsSkip() const;
 	virtual void SetCriticalFrame()
 	{
 		bCriticalFrame_ = true;
@@ -102,9 +102,9 @@ public:
 		countSkip_ = 0;
 	}
 
-	virtual float GetCurrentFps() { return GetCurrentWorkFps(); }
-	float GetCurrentWorkFps() { return fpsCurrentWork_; };
-	float GetCurrentRenderFps() { return fpsCurrentRender_; };
+	virtual float GetCurrentFps() const { return GetCurrentWorkFps(); }
+	float GetCurrentWorkFps() const { return fpsCurrentWork_; };
+	float GetCurrentRenderFps() const { return fpsCurrentRender_; };
 
 protected:
 	float fpsCurrentWork_; //実際のfps

--- a/source/GcLib/gstd/FpsController.hpp
+++ b/source/GcLib/gstd/FpsController.hpp
@@ -54,11 +54,11 @@ protected:
 class StaticFpsController : public FpsController {
 public:
 	StaticFpsController();
-	~StaticFpsController();
+	~StaticFpsController() override;
 
-	virtual void Wait();
-	virtual bool IsSkip() const;
-	virtual void SetCriticalFrame()
+	void Wait() override;
+	bool IsSkip() const override;
+	void SetCriticalFrame() override
 	{
 		bCriticalFrame_ = true;
 		timeError_ = 0;
@@ -66,9 +66,9 @@ public:
 	}
 
 	void SetSkipRate(int value);
-	virtual float GetCurrentFps() const;
-	virtual float GetCurrentWorkFps() const;
-	virtual float GetCurrentRenderFps() const;
+	float GetCurrentFps() const override;
+	float GetCurrentWorkFps() const override;
+	float GetCurrentRenderFps() const override;
 
 protected:
 	float fpsCurrent_; //現在のFPS
@@ -91,20 +91,20 @@ private:
 class AutoSkipFpsController : public FpsController {
 public:
 	AutoSkipFpsController();
-	~AutoSkipFpsController();
+	~AutoSkipFpsController() override;
 
-	virtual void Wait();
-	virtual bool IsSkip() const;
-	virtual void SetCriticalFrame()
+	void Wait() override;
+	bool IsSkip() const override;
+	void SetCriticalFrame() override
 	{
 		bCriticalFrame_ = true;
 		timeError_ = 0;
 		countSkip_ = 0;
 	}
 
-	virtual float GetCurrentFps() const { return GetCurrentWorkFps(); }
-	float GetCurrentWorkFps() const { return fpsCurrentWork_; };
-	float GetCurrentRenderFps() const { return fpsCurrentRender_; };
+	float GetCurrentFps() const override { return GetCurrentWorkFps(); }
+	float GetCurrentWorkFps() const override { return fpsCurrentWork_; };
+	float GetCurrentRenderFps() const override { return fpsCurrentRender_; };
 
 protected:
 	float fpsCurrentWork_; //実際のfps
@@ -125,8 +125,8 @@ protected:
 **********************************************************/
 class FpsControlObject {
 public:
-	FpsControlObject() {}
-	virtual ~FpsControlObject() {}
+	FpsControlObject() = default;
+	virtual ~FpsControlObject() = default;
 	virtual int GetFps() = 0;
 };
 

--- a/source/GcLib/gstd/GstdConstant.hpp
+++ b/source/GcLib/gstd/GstdConstant.hpp
@@ -43,13 +43,12 @@
 #endif
 
 //std
-#include <cstdlib>
-#include <cwchar>
-
 #include <algorithm>
+#include <array>
 #include <bitset>
 #include <cmath>
 #include <cstdlib>
+#include <cwchar>
 #include <exception>
 #include <list>
 #include <map>

--- a/source/GcLib/gstd/GstdUtility.cpp
+++ b/source/GcLib/gstd/GstdUtility.cpp
@@ -48,7 +48,7 @@ int Encoding::GetBomSize(const void* data, int dataSize)
 
 //================================================================
 //StringUtility
-std::string StringUtility::ConvertWideToMulti(std::wstring const& wstr, int codeMulti)
+std::string StringUtility::ConvertWideToMulti(const std::wstring& wstr, int codeMulti)
 {
 	if (wstr == L"")
 		return "";
@@ -70,7 +70,7 @@ std::string StringUtility::ConvertWideToMulti(std::wstring const& wstr, int code
 	return str;
 }
 
-std::wstring StringUtility::ConvertMultiToWide(std::string const& str, int codeMulti)
+std::wstring StringUtility::ConvertMultiToWide(const std::string& str, int codeMulti)
 {
 	if (str == "")
 		return L"";
@@ -91,33 +91,32 @@ std::wstring StringUtility::ConvertMultiToWide(std::string const& str, int codeM
 	return wstr;
 }
 
-std::string StringUtility::ConvertUtf8ToMulti(std::vector<char>& text)
+std::string StringUtility::ConvertUtf8ToMulti(const std::vector<char>& text)
 {
 	std::wstring wstr = ConvertUtf8ToWide(text); //UTF16に変換
 	std::string strShiftJIS = ConvertWideToMulti(wstr); //ShiftJISに変換
 
 	return strShiftJIS;
 }
-std::wstring StringUtility::ConvertUtf8ToWide(std::vector<char>& text)
+std::wstring StringUtility::ConvertUtf8ToWide(const std::vector<char>& text)
 {
 	int posText = 0;
-	if ((unsigned char)&text[0] == 0xef && (unsigned char)&text[1] == 0xbb && (unsigned char)&text[2] == 0xbf) {
+	if ((const unsigned char)&text[0] == 0xef && (const unsigned char)&text[1] == 0xbb && (const unsigned char)&text[2] == 0xbf) {
 		posText += 3;
 	}
 
-	std::string str = &text[posText];
-	std::wstring wstr = ConvertMultiToWide(str, CP_UTF8); //UTF16に変換
+	std::wstring wstr = ConvertMultiToWide(&text[posText], CP_UTF8); //UTF16に変換
 	return wstr;
 }
 
 //----------------------------------------------------------------
-std::vector<std::string> StringUtility::Split(std::string str, std::string delim)
+std::vector<std::string> StringUtility::Split(const std::string& str, const std::string& delim)
 {
 	std::vector<std::string> res;
 	Split(str, delim, res);
 	return res;
 }
-void StringUtility::Split(std::string str, std::string delim, std::vector<std::string>& res)
+void StringUtility::Split(const std::string& str, const std::string& delim, std::vector<std::string>& res)
 {
 	//wcstok
 	std::wstring wstr = StringUtility::ConvertMultiToWide(str);
@@ -152,7 +151,7 @@ void StringUtility::Split(std::string str, std::string delim, std::vector<std::s
 	*/
 }
 
-std::string StringUtility::Format(char* str, ...)
+std::string StringUtility::Format(const char* str, ...)
 {
 	std::string res;
 	char buf[256];
@@ -177,11 +176,11 @@ std::string StringUtility::Format(char* str, ...)
 	return res;
 }
 
-int StringUtility::CountCharacter(std::string& str, char c)
+int StringUtility::CountCharacter(const std::string& str, char c)
 {
 	int count = 0;
-	char* pbuf = &str[0];
-	char* ebuf = &str[str.size() - 1];
+	const char* pbuf = &str[0];
+	const char* ebuf = &str[str.size() - 1];
 	while (pbuf <= ebuf) {
 		if (*pbuf == c)
 			count++;
@@ -193,7 +192,7 @@ int StringUtility::CountCharacter(std::string& str, char c)
 	}
 	return count;
 }
-int StringUtility::CountCharacter(std::vector<char>& str, char c)
+int StringUtility::CountCharacter(const std::vector<char>& str, char c)
 {
 	if (str.size() == 0)
 		return 0;
@@ -203,8 +202,8 @@ int StringUtility::CountCharacter(std::vector<char>& str, char c)
 		encoding = Encoding::UTF16LE;
 
 	int count = 0;
-	char* pbuf = &str[0];
-	char* ebuf = &str[str.size() - 1];
+	const char* pbuf = &str[0];
+	const char* ebuf = &str[str.size() - 1];
 	while (pbuf <= ebuf) {
 		if (encoding == Encoding::UTF16LE) {
 			wchar_t ch = (wchar_t&)*pbuf;
@@ -222,20 +221,19 @@ int StringUtility::CountCharacter(std::vector<char>& str, char c)
 	}
 	return count;
 }
-int StringUtility::ToInteger(std::string const& s)
+int StringUtility::ToInteger(const std::string& s)
 {
 	return atoi(s.c_str());
 }
-double StringUtility::ToDouble(std::string const& s)
+double StringUtility::ToDouble(const std::string& s)
 {
 	return atof(s.c_str());
 }
-std::string StringUtility::Replace(std::string& source, std::string pattern, std::string placement)
+std::string StringUtility::Replace(const std::string& source, const std::string pattern, const std::string placement)
 {
-	std::string res = ReplaceAll(source, pattern, placement, 1);
-	return res;
+	return ReplaceAll(source, pattern, placement, 1);
 }
-std::string StringUtility::ReplaceAll(std::string& source, std::string pattern, std::string placement, int replaceCount, int start, int end)
+std::string StringUtility::ReplaceAll(const std::string& source, const std::string pattern, const std::string placement, int replaceCount, int start, int end)
 {
 	bool bDBCSLeadByteCheck = (pattern.size() == 1);
 	std::string result;
@@ -272,7 +270,7 @@ std::string StringUtility::ReplaceAll(std::string& source, std::string pattern, 
 	result.append(source, pos_before, source.size() - pos_before);
 	return result;
 }
-std::string StringUtility::Slice(std::string const& s, int length)
+std::string StringUtility::Slice(const std::string& s, int length)
 {
 	length = min(s.size() - 1, length);
 	return s.substr(0, length);
@@ -326,7 +324,7 @@ void StringUtility::Split(std::wstring str, std::wstring delim, std::vector<std:
 		res.push_back(s);
 	}
 }
-std::wstring StringUtility::Format(wchar_t* str, ...)
+std::wstring StringUtility::Format(const wchar_t* str, ...)
 {
 	std::wstring res;
 	wchar_t buf[256];
@@ -350,7 +348,7 @@ std::wstring StringUtility::Format(wchar_t* str, ...)
 	va_end(vl);
 	return res;
 }
-std::wstring StringUtility::FormatToWide(char* str, ...)
+std::wstring StringUtility::FormatToWide(const char* str, ...)
 {
 	std::string res;
 	char buf[256];
@@ -377,33 +375,32 @@ std::wstring StringUtility::FormatToWide(char* str, ...)
 	return wres;
 }
 
-int StringUtility::CountCharacter(std::wstring& str, wchar_t c)
+int StringUtility::CountCharacter(const std::wstring& str, wchar_t c)
 {
 	int count = 0;
-	wchar_t* pbuf = &str[0];
-	wchar_t* ebuf = &str[str.size() - 1];
+	const wchar_t* pbuf = &str[0];
+	const wchar_t* ebuf = &str[str.size() - 1];
 	while (pbuf <= ebuf) {
 		if (*pbuf == c)
 			count++;
 	}
 	return count;
 }
-int StringUtility::ToInteger(std::wstring const& s)
+int StringUtility::ToInteger(const std::wstring& s)
 {
 	return _wtoi(s.c_str());
 }
-double StringUtility::ToDouble(std::wstring const& s)
+double StringUtility::ToDouble(const std::wstring& s)
 {
 	wchar_t* stopscan;
 	return wcstod(s.c_str(), &stopscan);
 	// return _wtof(s.c_str());
 }
-std::wstring StringUtility::Replace(std::wstring& source, std::wstring pattern, std::wstring placement)
+std::wstring StringUtility::Replace(const std::wstring& source, const std::wstring pattern, const std::wstring placement)
 {
-	std::wstring res = ReplaceAll(source, pattern, placement, 1);
-	return res;
+	return ReplaceAll(source, pattern, placement, 1);
 }
-std::wstring StringUtility::ReplaceAll(std::wstring& source, std::wstring pattern, std::wstring placement, int replaceCount, int start, int end)
+std::wstring StringUtility::ReplaceAll(const std::wstring& source, const std::wstring pattern, const std::wstring placement, int replaceCount, int start, int end)
 {
 	std::wstring result;
 	if (end == 0)
@@ -426,7 +423,7 @@ std::wstring StringUtility::ReplaceAll(std::wstring& source, std::wstring patter
 	result.append(source, pos_before, source.size() - pos_before);
 	return result;
 }
-std::wstring StringUtility::Slice(std::wstring const& s, int length)
+std::wstring StringUtility::Slice(const std::wstring& s, int length)
 {
 	length = min(s.size() - 1, length);
 	return s.substr(0, length);
@@ -458,7 +455,7 @@ std::wstring StringUtility::Trim(const std::wstring& str)
 	}
 	return res;
 }
-int StringUtility::CountAsciiSizeCharacter(std::wstring& str)
+int StringUtility::CountAsciiSizeCharacter(const std::wstring& str)
 {
 	if (str.size() == 0)
 		return 0;
@@ -480,10 +477,9 @@ int StringUtility::CountAsciiSizeCharacter(std::wstring& str)
 	delete[] listType;
 	return res;
 }
-int StringUtility::GetByteSize(std::wstring& str)
+int StringUtility::GetByteSize(const std::wstring& str)
 {
-	int res = str.size() * sizeof(wchar_t);
-	return res;
+	return str.size() * sizeof(wchar_t);
 }
 
 //================================================================
@@ -519,17 +515,17 @@ std::wstring ErrorUtility::GetErrorMessage(int type)
 		res = L"invalid index";
 	return res;
 }
-std::wstring ErrorUtility::GetFileNotFoundErrorMessage(std::wstring path)
+std::wstring ErrorUtility::GetFileNotFoundErrorMessage(const std::wstring& path)
 {
 	std::wstring res = GetErrorMessage(ERROR_FILE_NOTFOUND);
 	res += StringUtility::Format(L" path[%s]", path.c_str());
 	return res;
 }
-std::wstring ErrorUtility::GetParseErrorMessage(int line, std::wstring what)
+std::wstring ErrorUtility::GetParseErrorMessage(int line, const std::wstring& what)
 {
 	return GetParseErrorMessage(L"", line, what);
 }
-std::wstring ErrorUtility::GetParseErrorMessage(std::wstring path, int line, std::wstring what)
+std::wstring ErrorUtility::GetParseErrorMessage(const std::wstring& path, int line, const std::wstring& what)
 {
 	std::wstring res = GetErrorMessage(ERROR_PARSE);
 	res += StringUtility::Format(L" path[%s] line[%d] msg[%s]", path.c_str(), line, what.c_str());
@@ -566,7 +562,7 @@ void ByteOrder::Reverse(LPVOID buf, DWORD size)
 
 //================================================================
 //Scanner
-Scanner::Scanner(char* str, int size)
+Scanner::Scanner(const char* str, int size)
 {
 	std::vector<char> buf;
 	buf.resize(size);
@@ -574,14 +570,14 @@ Scanner::Scanner(char* str, int size)
 	buf.push_back('\0');
 	this->Scanner::Scanner(buf);
 }
-Scanner::Scanner(std::string str)
+Scanner::Scanner(const std::string& str)
 {
 	std::vector<char> buf;
 	buf.resize(str.size() + 1);
 	memcpy(&buf[0], str.c_str(), str.size() + 1);
 	this->Scanner::Scanner(buf);
 }
-Scanner::Scanner(std::wstring wstr)
+Scanner::Scanner(const std::wstring& wstr)
 {
 	std::vector<char> buf;
 	int textSize = wstr.size() * sizeof(wchar_t);
@@ -590,7 +586,7 @@ Scanner::Scanner(std::wstring wstr)
 	memcpy(&buf[2], wstr.c_str(), textSize + 2);
 	this->Scanner::Scanner(buf);
 }
-Scanner::Scanner(std::vector<char>& buf)
+Scanner::Scanner(const std::vector<char>& buf)
 {
 	bPermitSignNumber_ = true;
 	buffer_ = buf;
@@ -613,7 +609,7 @@ Scanner::Scanner(std::vector<char>& buf)
 Scanner::~Scanner()
 {
 }
-wchar_t Scanner::_CurrentChar()
+wchar_t Scanner::_CurrentChar() const
 {
 	wchar_t res = L'\0';
 	if (typeEncoding_ == Encoding::UTF16LE) {
@@ -709,7 +705,7 @@ void Scanner::_SkipSpace()
 		ch = _NextChar();
 	}
 }
-void Scanner::_RaiseError(std::wstring str)
+void Scanner::_RaiseError(const std::wstring& str) const
 {
 	throw gstd::wexception(str);
 }
@@ -937,36 +933,32 @@ Token& Scanner::Next()
 
 	return token_;
 }
-bool Scanner::HasNext()
+bool Scanner::HasNext() const
 {
-	// bool res = true;
-	// res &= pointer_ < buffer_.size();
-	// res &= _CurrentChar() != L'\0';
-	// res &= token_.GetType() != Token::TK_EOF;
 	return pointer_ < buffer_.size() && _CurrentChar() != L'\0' && token_.GetType() != Token::TK_EOF;
 }
-void Scanner::CheckType(Token& tok, Token::Type type)
+void Scanner::CheckType(const Token& tok, Token::Type type) const
 {
 	if (tok.type_ != type) {
 		std::wstring str = StringUtility::Format(L"CheckType error[%s]:", tok.element_.c_str());
 		_RaiseError(str);
 	}
 }
-void Scanner::CheckIdentifer(Token& tok, std::wstring id)
+void Scanner::CheckIdentifer(const Token& tok, const std::wstring& id) const
 {
 	if (tok.type_ != Token::TK_ID || tok.GetIdentifier() != id) {
 		std::wstring str = StringUtility::Format(L"CheckID error[%s]:", tok.element_.c_str());
 		_RaiseError(str);
 	}
 }
-int Scanner::GetCurrentLine()
+int Scanner::GetCurrentLine() const
 {
 	if (buffer_.size() == 0)
 		return 0;
 
 	int line = 1;
-	char* pbuf = &buffer_[0];
-	char* ebuf = &buffer_[pointer_];
+	const char* pbuf = &buffer_[0];
+	const char* ebuf = &buffer_[pointer_];
 	while (true) {
 		if (typeEncoding_ == Encoding::UTF16LE) {
 			if (pbuf + 1 >= ebuf)
@@ -989,7 +981,7 @@ int Scanner::GetCurrentLine()
 	}
 	return line;
 }
-int Scanner::GetCurrentPointer()
+int Scanner::GetCurrentPointer() const
 {
 	return pointer_;
 }
@@ -1001,22 +993,22 @@ void Scanner::SetPointerBegin()
 {
 	pointer_ = textStartPointer_;
 }
-std::wstring Scanner::GetString(int start, int end)
+std::wstring Scanner::GetString(int start, int end) const
 {
 	std::wstring res;
 	if (typeEncoding_ == Encoding::UTF16LE) {
-		wchar_t* pPosStart = (wchar_t*)&buffer_[start];
-		wchar_t* pPosEnd = (wchar_t*)&buffer_[end];
+		auto pPosStart = (const wchar_t*)&buffer_[start];
+		auto pPosEnd = (const wchar_t*)&buffer_[end];
 		res = std::wstring(pPosStart, pPosEnd);
 	} else {
-		char* pPosStart = &buffer_[start];
-		char* pPosEnd = &buffer_[end];
+		const char* pPosStart = &buffer_[start];
+		const char* pPosEnd = &buffer_[end];
 		std::string str = std::string(pPosStart, pPosEnd);
 		res = StringUtility::ConvertMultiToWide(str);
 	}
 	return res;
 }
-bool Scanner::CompareMemory(int start, int end, const char* data)
+bool Scanner::CompareMemory(int start, int end, const char* data) const
 {
 	if (end >= buffer_.size())
 		return false;
@@ -1027,62 +1019,54 @@ bool Scanner::CompareMemory(int start, int end, const char* data)
 }
 
 //Token
-std::wstring& Token::GetIdentifier()
+std::wstring Token::GetIdentifier() const
 {
 	if (type_ != TK_ID) {
 		throw gstd::wexception(L"Token::GetIdentifier:データのタイプが違います");
 	}
 	return element_;
 }
-std::wstring Token::GetString()
+std::wstring Token::GetString() const
 {
 	if (type_ != TK_STRING) {
 		throw gstd::wexception(L"Token::GetString:データのタイプが違います");
 	}
 	return element_.substr(1, element_.size() - 2);
 }
-int Token::GetInteger()
+int Token::GetInteger() const
 {
 	if (type_ != TK_INT) {
 		throw gstd::wexception(L"Token::GetInterger:データのタイプが違います");
 	}
 	return StringUtility::ToInteger(element_);
 }
-double Token::GetReal()
+double Token::GetReal() const
 {
 	if (type_ != TK_REAL && type_ != TK_INT) {
 		throw gstd::wexception(L"Token::GetReal:データのタイプが違います");
 	}
 	return StringUtility::ToDouble(element_);
 }
-bool Token::GetBoolean()
+bool Token::GetBoolean() const
 {
-	bool res = false;
 	if (type_ == TK_REAL && type_ == TK_INT) {
-		res = GetReal() == 1;
+		return GetReal() == 1;
 	} else {
-		res = element_ == L"true";
+		return element_ == L"true";
 	}
-	return res;
 }
 
-std::string Token::GetElementA()
+std::string Token::GetElementA() const
 {
-	std::wstring wstr = GetElement();
-	std::string res = StringUtility::ConvertWideToMulti(wstr);
-	return res;
+	return StringUtility::ConvertWideToMulti(GetElement());
 }
-std::string Token::GetStringA()
+std::string Token::GetStringA() const
 {
-	std::wstring wstr = GetString();
-	std::string res = StringUtility::ConvertWideToMulti(wstr);
-	return res;
+	return StringUtility::ConvertWideToMulti(GetString());
 }
-std::string Token::GetIdentifierA()
+std::string Token::GetIdentifierA() const
 {
-	std::wstring wstr = GetIdentifier();
-	std::string res = StringUtility::ConvertWideToMulti(wstr);
-	return res;
+	return StringUtility::ConvertWideToMulti(GetIdentifier());
 }
 
 //================================================================
@@ -1090,14 +1074,14 @@ std::string Token::GetIdentifierA()
 TextParser::TextParser()
 {
 }
-TextParser::TextParser(std::string source)
+TextParser::TextParser(const std::string& source)
 {
 	SetSource(source);
 }
 TextParser::~TextParser()
 {
 }
-void TextParser::_RaiseError(std::wstring message)
+void TextParser::_RaiseError(const std::wstring& message)
 {
 	throw gstd::wexception(message);
 }
@@ -1280,7 +1264,7 @@ TextParser::Result TextParser::_ParseIdentifer(int pos)
 	return res;
 }
 
-void TextParser::SetSource(std::string source)
+void TextParser::SetSource(const std::string& source)
 {
 	std::vector<char> buf;
 	buf.resize(source.size() + 1);

--- a/source/GcLib/gstd/GstdUtility.cpp
+++ b/source/GcLib/gstd/GstdUtility.cpp
@@ -50,12 +50,12 @@ int Encoding::GetBomSize(const void* data, int dataSize)
 //StringUtility
 std::string StringUtility::ConvertWideToMulti(const std::wstring& wstr, int codeMulti)
 {
-	if (wstr == L"")
+	if (wstr.empty())
 		return "";
 
 	//マルチバイト変換後のサイズを調べます
 	//WideCharToMultiByteの第6引数に0を渡すと変換後のサイズが返ります
-	int sizeMulti = ::WideCharToMultiByte(codeMulti, 0, wstr.c_str(), -1, NULL, 0, NULL, NULL);
+	int sizeMulti = ::WideCharToMultiByte(codeMulti, 0, wstr.c_str(), -1, nullptr, 0, nullptr, nullptr);
 	if (sizeMulti == 0)
 		return ""; //失敗(とりあえず空文字とします)
 
@@ -66,18 +66,18 @@ std::string StringUtility::ConvertWideToMulti(const std::wstring& wstr, int code
 	std::string str;
 	str.resize(sizeMulti);
 	::WideCharToMultiByte(codeMulti, 0, wstr.c_str(), -1, &str[0],
-		sizeMulti, NULL, NULL);
+		sizeMulti, nullptr, nullptr);
 	return str;
 }
 
 std::wstring StringUtility::ConvertMultiToWide(const std::string& str, int codeMulti)
 {
-	if (str == "")
+	if (str.empty())
 		return L"";
 
 	//UNICODE変換後のサイズを調べます
 	//MultiByteToWideCharの第6引数に0を渡すと変換後のサイズが返ります
-	int sizeWide = ::MultiByteToWideChar(codeMulti, 0, str.c_str(), -1, NULL, 0);
+	int sizeWide = ::MultiByteToWideChar(codeMulti, 0, str.c_str(), -1, nullptr, 0);
 	if (sizeWide == 0)
 		return L""; //失敗(とりあえず空文字とします)
 
@@ -120,14 +120,14 @@ void StringUtility::Split(const std::string& str, const std::string& delim, std:
 {
 	//wcstok
 	std::wstring wstr = StringUtility::ConvertMultiToWide(str);
-	wchar_t* wsource = new wchar_t[wstr.size() + sizeof(wchar_t)];
+	auto* wsource = new wchar_t[wstr.size() + sizeof(wchar_t)];
 	memcpy(wsource, wstr.c_str(), wstr.size() * sizeof(wchar_t));
 	wsource[wstr.size()] = 0;
 	std::wstring wdelim = StringUtility::ConvertMultiToWide(delim);
 
-	wchar_t* pStr = NULL;
+	wchar_t* pStr = nullptr;
 	wchar_t* cDelim = const_cast<wchar_t*>(wdelim.c_str());
-	while ((pStr = wcstok(pStr == NULL ? wsource : NULL, cDelim)) != NULL) {
+	while ((pStr = wcstok(pStr == nullptr ? wsource : nullptr, cDelim)) != nullptr) {
 		//切り出した文字列を追加
 		std::string s = StringUtility::ConvertWideToMulti(std::wstring(pStr));
 		s = s.substr(0, s.size() - 1); //最後の\0を削除
@@ -194,7 +194,7 @@ int StringUtility::CountCharacter(const std::string& str, char c)
 }
 int StringUtility::CountCharacter(const std::vector<char>& str, char c)
 {
-	if (str.size() == 0)
+	if (str.empty())
 		return 0;
 
 	int encoding = Encoding::SHIFT_JIS;
@@ -208,15 +208,15 @@ int StringUtility::CountCharacter(const std::vector<char>& str, char c)
 		if (encoding == Encoding::UTF16LE) {
 			wchar_t ch = (wchar_t&)*pbuf;
 			if (ch == (wchar_t)c)
-				count++;
+				++count;
 			pbuf += 2;
 		} else {
 			if (*pbuf == c)
-				count++;
+				++count;
 			if (IsDBCSLeadByteEx(Encoding::CP_SHIFT_JIS, *pbuf))
 				pbuf += 2;
 			else
-				pbuf++;
+				++pbuf;
 		}
 	}
 	return count;
@@ -248,11 +248,10 @@ std::string StringUtility::ReplaceAll(const std::string& source, const std::stri
 		if (pos > 0) {
 			char ch = source[pos - 1];
 			if (bDBCSLeadByteCheck && IsDBCSLeadByteEx(Encoding::CP_SHIFT_JIS, ch)) {
-				pos++;
+				++pos;
 				if (pos >= end)
 					break;
-				else
-					continue;
+				continue;
 			}
 			if (pos >= end)
 				break;
@@ -263,7 +262,7 @@ std::string StringUtility::ReplaceAll(const std::string& source, const std::stri
 		pos += len;
 		pos_before = pos;
 
-		count++;
+		++count;
 		if (count >= replaceCount)
 			break;
 	}
@@ -277,22 +276,22 @@ std::string StringUtility::Slice(const std::string& s, int length)
 }
 std::string StringUtility::Trim(const std::string& str)
 {
-	if (str.size() == 0)
+	if (str.empty())
 		return str;
 
 	std::wstring wstr = StringUtility::ConvertMultiToWide(str);
 	int left = 0;
-	for (; left < wstr.size(); left++) {
+	for (; left < wstr.size(); ++left) {
 		wchar_t wch = wstr[left];
 		if (wch != 0x20 && wch != 0x09)
 			break;
 	}
 
 	int right = wstr.size() - 1;
-	for (; right >= 0; right--) {
+	for (; right >= 0; --right) {
 		wchar_t wch = wstr[right];
 		if (wch != 0x20 && wch != 0x09 && wch != 0x0 && wch != '\r' && wch != '\n') {
-			right++;
+			++right;
 			break;
 		}
 	}
@@ -315,9 +314,9 @@ std::vector<std::wstring> StringUtility::Split(std::wstring str, std::wstring de
 void StringUtility::Split(std::wstring str, std::wstring delim, std::vector<std::wstring>& res)
 {
 	wchar_t* wsource = (wchar_t*)str.c_str();
-	wchar_t* pStr = NULL;
+	wchar_t* pStr = nullptr;
 	wchar_t* cDelim = const_cast<wchar_t*>(delim.c_str());
-	while ((pStr = wcstok(pStr == NULL ? wsource : NULL, cDelim)) != NULL) {
+	while ((pStr = wcstok(pStr == nullptr ? wsource : nullptr, cDelim)) != nullptr) {
 		//切り出した文字列を追加
 		std::wstring s = std::wstring(pStr);
 		// s = s.substr(0, s.size() - 1);//最後の\0を削除
@@ -382,7 +381,7 @@ int StringUtility::CountCharacter(const std::wstring& str, wchar_t c)
 	const wchar_t* ebuf = &str[str.size() - 1];
 	while (pbuf <= ebuf) {
 		if (*pbuf == c)
-			count++;
+			++count;
 	}
 	return count;
 }
@@ -416,7 +415,7 @@ std::wstring StringUtility::ReplaceAll(const std::wstring& source, const std::ws
 		pos += len;
 		pos_before = pos;
 
-		count++;
+		++count;
 		if (count >= replaceCount)
 			break;
 	}
@@ -430,7 +429,7 @@ std::wstring StringUtility::Slice(const std::wstring& s, int length)
 }
 std::wstring StringUtility::Trim(const std::wstring& str)
 {
-	if (str.size() == 0)
+	if (str.empty())
 		return str;
 
 	int left = 0;
@@ -441,10 +440,10 @@ std::wstring StringUtility::Trim(const std::wstring& str)
 	}
 
 	int right = str.size() - 1;
-	for (; right >= 0; right--) {
+	for (; right >= 0; --right) {
 		wchar_t wch = str[right];
 		if (wch != 0x20 && wch != 0x09 && wch != 0x0 && wch != '\r' && wch != '\n') {
-			right++;
+			++right;
 			break;
 		}
 	}
@@ -457,7 +456,7 @@ std::wstring StringUtility::Trim(const std::wstring& str)
 }
 int StringUtility::CountAsciiSizeCharacter(const std::wstring& str)
 {
-	if (str.size() == 0)
+	if (str.empty())
 		return 0;
 
 	int wcount = str.size();
@@ -468,7 +467,7 @@ int StringUtility::CountAsciiSizeCharacter(const std::wstring& str)
 	for (int iType = 0; iType < wcount; iType++) {
 		WORD type = listType[iType];
 		if ((type & C3_HALFWIDTH) == C3_HALFWIDTH) {
-			res++;
+			++res;
 		} else {
 			res += 2;
 		}
@@ -488,12 +487,12 @@ std::wstring ErrorUtility::GetLastErrorMessage(DWORD error)
 {
 	LPVOID lpMsgBuf;
 	::FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-		NULL,
+		nullptr,
 		error,
 		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), // 既定の言語
 		(LPTSTR)&lpMsgBuf,
 		0,
-		NULL);
+		nullptr);
 	std::wstring res = (wchar_t*)lpMsgBuf;
 	::LocalFree(lpMsgBuf);
 	return res;
@@ -547,16 +546,11 @@ void Math::InitializeFPU()
 //ByteOrder
 void ByteOrder::Reverse(LPVOID buf, DWORD size)
 {
-	unsigned char* pStart = (unsigned char*)buf;
+	auto* pStart = (unsigned char*)buf;
 	unsigned char* pEnd = (unsigned char*)buf + size - 1;
 
-	for (; pStart < pEnd;) {
-		unsigned char temp = *pStart;
-		*pStart = *pEnd;
-		*pEnd = temp;
-
-		pStart++;
-		pEnd--;
+	for (; pStart < pEnd; ++pStart, --pEnd) {
+		std::swap(*pStart, *pEnd);
 	}
 }
 
@@ -606,9 +600,7 @@ Scanner::Scanner(const std::vector<char>& buf)
 
 	SetPointerBegin();
 }
-Scanner::~Scanner()
-{
-}
+Scanner::~Scanner() = default;
 wchar_t Scanner::_CurrentChar() const
 {
 	wchar_t res = L'\0';
@@ -617,8 +609,7 @@ wchar_t Scanner::_CurrentChar() const
 			res = (wchar_t&)buffer_[pointer_];
 	} else {
 		if (pointer_ < buffer_.size()) {
-			char ch = buffer_[pointer_];
-			res = ch;
+			res = buffer_[pointer_];
 		}
 	}
 	return res;
@@ -626,7 +617,7 @@ wchar_t Scanner::_CurrentChar() const
 
 wchar_t Scanner::_NextChar()
 {
-	if (HasNext() == false) {
+	if (!HasNext()) {
 		Logger::WriteTop(L"終端異常発生->");
 
 		int size = buffer_.size() - textStartPointer_;
@@ -635,13 +626,11 @@ wchar_t Scanner::_NextChar()
 		Logger::WriteTop(target);
 
 		int index = 1;
-		std::list<Token>::iterator itr;
-		for (itr = listDebugToken_.begin(); itr != listDebugToken_.end(); itr++) {
-			Token token = *itr;
+		for (const auto& token : listDebugToken_) {
 			std::wstring log = StringUtility::Format(L"  %2d token -> type=%2d, element=%s, start=%d, end=%d",
 				index, token.GetType(), token.GetElement().c_str(), token.GetStartPointer(), token.GetEndPointer());
 			Logger::WriteTop(log);
-			index++;
+			++index;
 		}
 
 		_RaiseError(L"_NextChar:すでに文字列終端です");
@@ -654,12 +643,10 @@ wchar_t Scanner::_NextChar()
 			while (IsDBCSLeadByteEx(Encoding::CP_SHIFT_JIS, buffer_[pointer_]))
 				pointer_ += 2;
 		} else {
-			pointer_++;
+			++pointer_;
 		}
 	}
-
-	wchar_t res = _CurrentChar();
-	return res;
+	return _CurrentChar();
 }
 void Scanner::_SkipComment()
 {
@@ -699,9 +686,7 @@ void Scanner::_SkipComment()
 void Scanner::_SkipSpace()
 {
 	wchar_t ch = _CurrentChar();
-	while (true) {
-		if (ch != L' ' && ch != L'\t')
-			break;
+	while (ch == L' ' || ch == L'\t') {
 		ch = _NextChar();
 	}
 }
@@ -901,13 +886,13 @@ Token& Scanner::Next()
 	if (type == Token::TK_STRING) {
 		std::wstring wstr;
 		if (typeEncoding_ == Encoding::UTF16LE) {
-			wchar_t* pPosStart = (wchar_t*)&buffer_[posStart];
-			wchar_t* pPosEnd = (wchar_t*)&buffer_[pointer_];
+			const wchar_t* pPosStart = (wchar_t*)&buffer_[posStart];
+			const wchar_t* pPosEnd = (wchar_t*)&buffer_[pointer_];
 			wstr = std::wstring(pPosStart, pPosEnd);
 			wstr = StringUtility::ReplaceAll(wstr, L"\\\"", L"\"");
 		} else {
-			char* pPosStart = &buffer_[posStart];
-			char* pPosEnd = &buffer_[pointer_];
+			const char* pPosStart = &buffer_[posStart];
+			const char* pPosEnd = &buffer_[pointer_];
 			std::string str = std::string(pPosStart, pPosEnd);
 			str = StringUtility::ReplaceAll(str, "\\\"", "\"");
 			wstr = StringUtility::ConvertMultiToWide(str);
@@ -917,12 +902,12 @@ Token& Scanner::Next()
 	} else {
 		std::wstring wstr;
 		if (typeEncoding_ == Encoding::UTF16LE) {
-			wchar_t* pPosStart = (wchar_t*)&buffer_[posStart];
-			wchar_t* pPosEnd = (wchar_t*)&buffer_[pointer_];
+			const wchar_t* pPosStart = (wchar_t*)&buffer_[posStart];
+			const wchar_t* pPosEnd = (wchar_t*)&buffer_[pointer_];
 			wstr = std::wstring(pPosStart, pPosEnd);
 		} else {
-			char* pPosStart = &buffer_[posStart];
-			char* pPosEnd = &buffer_[pointer_];
+			const char* pPosStart = &buffer_[posStart];
+			const char* pPosEnd = &buffer_[pointer_];
 			std::string str = std::string(pPosStart, pPosEnd);
 			wstr = StringUtility::ConvertMultiToWide(str);
 		}
@@ -935,7 +920,9 @@ Token& Scanner::Next()
 }
 bool Scanner::HasNext() const
 {
-	return pointer_ < buffer_.size() && _CurrentChar() != L'\0' && token_.GetType() != Token::TK_EOF;
+	return pointer_ < buffer_.size()
+		&& _CurrentChar() != L'\0'
+		&& token_.GetType() != Token::TK_EOF;
 }
 void Scanner::CheckType(const Token& tok, Token::Type type) const
 {
@@ -953,7 +940,7 @@ void Scanner::CheckIdentifer(const Token& tok, const std::wstring& id) const
 }
 int Scanner::GetCurrentLine() const
 {
-	if (buffer_.size() == 0)
+	if (buffer_.empty())
 		return 0;
 
 	int line = 1;
@@ -965,17 +952,17 @@ int Scanner::GetCurrentLine() const
 				break;
 			wchar_t wch = (wchar_t&)*pbuf;
 			if (wch == L'\n')
-				line++;
+				++line;
 			pbuf += 2;
 		} else {
 			if (pbuf >= ebuf)
 				break;
-			if (IsDBCSLeadByteEx(Encoding::CP_SHIFT_JIS, *pbuf)) {
+			if (IsDBCSLeadByteEx(Encoding::CP_SHIFT_JIS, *pbuf) != 0) {
 				pbuf += 2;
 			} else {
 				if (*pbuf == '\n')
-					line++;
-				pbuf++;
+					++line;
+				++pbuf;
 			}
 		}
 	}
@@ -997,8 +984,8 @@ std::wstring Scanner::GetString(int start, int end) const
 {
 	std::wstring res;
 	if (typeEncoding_ == Encoding::UTF16LE) {
-		auto pPosStart = (const wchar_t*)&buffer_[start];
-		auto pPosEnd = (const wchar_t*)&buffer_[end];
+		const wchar_t* pPosStart = (const wchar_t*)&buffer_[start];
+		const wchar_t* pPosEnd = (const wchar_t*)&buffer_[end];
 		res = std::wstring(pPosStart, pPosEnd);
 	} else {
 		const char* pPosStart = &buffer_[start];
@@ -1014,8 +1001,7 @@ bool Scanner::CompareMemory(int start, int end, const char* data) const
 		return false;
 
 	int bufSize = end - start;
-	bool res = memcmp(&buffer_[start], data, bufSize) == 0;
-	return res;
+	return (memcmp(&buffer_[start], data, bufSize) == 0);
 }
 
 //Token
@@ -1071,16 +1057,13 @@ std::string Token::GetIdentifierA() const
 
 //================================================================
 //TextParser
-TextParser::TextParser()
-{
-}
+TextParser::TextParser() = default;
 TextParser::TextParser(const std::string& source)
 {
 	SetSource(source);
 }
-TextParser::~TextParser()
-{
-}
+TextParser::~TextParser() = default;
+
 void TextParser::_RaiseError(const std::wstring& message)
 {
 	throw gstd::wexception(message);
@@ -1274,7 +1257,7 @@ void TextParser::SetSource(const std::string& source)
 }
 TextParser::Result TextParser::GetResult()
 {
-	if (scan_ == NULL)
+	if (scan_ == nullptr)
 		_RaiseError(L"テキストが設定されていません");
 	scan_->SetPointerBegin();
 	Result res = _ParseComparison(scan_->GetCurrentPointer());
@@ -1284,7 +1267,7 @@ TextParser::Result TextParser::GetResult()
 }
 double TextParser::GetReal()
 {
-	if (scan_ == NULL)
+	if (scan_ == nullptr)
 		_RaiseError(L"テキストが設定されていません");
 	scan_->SetPointerBegin();
 	Result res = _ParseSum(scan_->GetCurrentPointer());
@@ -1302,7 +1285,7 @@ const wchar_t* Font::MINCHOH = L"MS Mincho";
 
 Font::Font()
 {
-	hFont_ = NULL;
+	hFont_ = nullptr;
 }
 Font::~Font()
 {
@@ -1310,9 +1293,9 @@ Font::~Font()
 }
 void Font::Clear()
 {
-	if (hFont_ != NULL) {
+	if (hFont_ != nullptr) {
 		::DeleteObject(hFont_);
-		hFont_ = NULL;
+		hFont_ = nullptr;
 		ZeroMemory(&info_, sizeof(LOGFONT));
 	}
 }
@@ -1321,14 +1304,14 @@ void Font::CreateFont(const wchar_t* type, int size, bool bBold, bool bItalic, b
 	LOGFONT fontInfo;
 
 	lstrcpy(fontInfo.lfFaceName, type);
-	fontInfo.lfWeight = (bBold == false) * FW_NORMAL + (bBold == TRUE) * FW_BOLD;
+	fontInfo.lfWeight = bBold ? FW_BOLD : FW_NORMAL;
 	fontInfo.lfEscapement = 0;
 	fontInfo.lfWidth = 0;
 	fontInfo.lfHeight = size;
-	fontInfo.lfItalic = bItalic;
-	fontInfo.lfUnderline = bLine;
+	fontInfo.lfItalic = static_cast<BYTE>(bItalic);
+	fontInfo.lfUnderline = static_cast<BYTE>(bLine);
 	fontInfo.lfCharSet = ANSI_CHARSET;
-	for (int i = 0; i < (int)wcslen(type); i++) {
+	for (int i = 0; i < (int)wcslen(type); ++i) {
 		if (!(IsCharAlphaNumeric(type[i]) || type[i] == L' ' || type[i] == L'-')) {
 			fontInfo.lfCharSet = SHIFTJIS_CHARSET;
 			break;
@@ -1339,7 +1322,7 @@ void Font::CreateFont(const wchar_t* type, int size, bool bBold, bool bItalic, b
 }
 void Font::CreateFontIndirect(LOGFONT& fontInfo)
 {
-	if (hFont_ != NULL)
+	if (hFont_ != nullptr)
 		this->Clear();
 	hFont_ = ::CreateFontIndirect(&fontInfo);
 	info_ = fontInfo;

--- a/source/GcLib/gstd/GstdUtility.hpp
+++ b/source/GcLib/gstd/GstdUtility.hpp
@@ -11,9 +11,9 @@ namespace gstd {
 class wexception {
 public:
 	wexception() {}
-	wexception(std::wstring msg) { message_ = msg; }
-	std::wstring GetMessage() { return message_; }
-	const wchar_t* what() { return message_.c_str(); }
+	wexception(const std::wstring& msg) { message_ = msg; }
+	std::wstring GetMessage() const { return message_; }
+	const wchar_t* what() const { return message_.c_str(); }
 
 protected:
 	std::wstring message_;
@@ -61,41 +61,41 @@ public:
 //StringUtility
 class StringUtility {
 public:
-	static std::string ConvertWideToMulti(std::wstring const& wstr, int codeMulti = 932);
-	static std::wstring ConvertMultiToWide(std::string const& str, int codeMulti = 932);
-	static std::string ConvertUtf8ToMulti(std::vector<char>& text);
-	static std::wstring ConvertUtf8ToWide(std::vector<char>& text);
+	static std::string ConvertWideToMulti(const std::wstring& wstr, int codeMulti = 932);
+	static std::wstring ConvertMultiToWide(const std::string& str, int codeMulti = 932);
+	static std::string ConvertUtf8ToMulti(const std::vector<char>& text);
+	static std::wstring ConvertUtf8ToWide(const std::vector<char>& text);
 
 	//----------------------------------------------------------------
-	static std::vector<std::string> Split(std::string str, std::string delim);
-	static void Split(std::string str, std::string delim, std::vector<std::string>& res);
-	static std::string Format(char* str, ...);
+	static std::vector<std::string> Split(const std::string& str, const std::string& delim);
+	static void Split(const std::string& str, const std::string& delim, std::vector<std::string>& res);
+	static std::string Format(const char* str, ...);
 
-	static int CountCharacter(std::string& str, char c);
-	static int CountCharacter(std::vector<char>& str, char c);
-	static int ToInteger(std::string const& s);
-	static double ToDouble(std::string const& s);
-	static std::string Replace(std::string& source, std::string pattern, std::string placement);
-	static std::string ReplaceAll(std::string& source, std::string pattern, std::string placement, int replaceCount = INT_MAX, int start = 0, int end = 0);
-	static std::string Slice(std::string const& s, int length);
+	static int CountCharacter(const std::string& str, char c);
+	static int CountCharacter(const std::vector<char>& str, char c);
+	static int ToInteger(const std::string& s);
+	static double ToDouble(const std::string& s);
+	static std::string Replace(const std::string& source, const std::string pattern, const std::string placement);
+	static std::string ReplaceAll(const std::string& source, const std::string pattern, const std::string placement, int replaceCount = INT_MAX, int start = 0, int end = 0);
+	static std::string Slice(const std::string& s, int length);
 	static std::string Trim(const std::string& str);
 
 	//----------------------------------------------------------------
 	//std::wstring.sizeは文字数を返す。バイト数ではない。
 	static std::vector<std::wstring> Split(std::wstring str, std::wstring delim);
 	static void Split(std::wstring str, std::wstring delim, std::vector<std::wstring>& res);
-	static std::wstring Format(wchar_t* str, ...);
-	static std::wstring FormatToWide(char* str, ...);
+	static std::wstring Format(const wchar_t* str, ...);
+	static std::wstring FormatToWide(const char* str, ...);
 
-	static int CountCharacter(std::wstring& str, wchar_t c);
-	static int ToInteger(std::wstring const& s);
-	static double ToDouble(std::wstring const& s);
-	static std::wstring Replace(std::wstring& source, std::wstring pattern, std::wstring placement);
-	static std::wstring ReplaceAll(std::wstring& source, std::wstring pattern, std::wstring placement, int replaceCount = INT_MAX, int start = 0, int end = 0);
-	static std::wstring Slice(std::wstring const& s, int length);
+	static int CountCharacter(const std::wstring& str, wchar_t c);
+	static int ToInteger(const std::wstring& s);
+	static double ToDouble(const std::wstring& s);
+	static std::wstring Replace(const std::wstring& source, const std::wstring pattern, const std::wstring placement);
+	static std::wstring ReplaceAll(const std::wstring& source, const std::wstring pattern, const std::wstring placement, int replaceCount = INT_MAX, int start = 0, int end = 0);
+	static std::wstring Slice(const std::wstring& s, int length);
 	static std::wstring Trim(const std::wstring& str);
-	static int CountAsciiSizeCharacter(std::wstring& str);
-	static int GetByteSize(std::wstring& str);
+	static int CountAsciiSizeCharacter(const std::wstring& str);
+	static int GetByteSize(const std::wstring& str);
 };
 
 //================================================================
@@ -113,9 +113,9 @@ public:
 	static std::wstring GetLastErrorMessage(DWORD error);
 	static std::wstring GetLastErrorMessage();
 	static std::wstring GetErrorMessage(int type);
-	static std::wstring GetFileNotFoundErrorMessage(std::wstring path);
-	static std::wstring GetParseErrorMessage(int line, std::wstring what);
-	static std::wstring GetParseErrorMessage(std::wstring path, int line, std::wstring what);
+	static std::wstring GetFileNotFoundErrorMessage(const std::wstring& path);
+	static std::wstring GetParseErrorMessage(int line, const std::wstring& what);
+	static std::wstring GetParseErrorMessage(const std::wstring& path, int line, const std::wstring& what);
 };
 
 //================================================================
@@ -123,8 +123,8 @@ public:
 const double PAI = 3.14159265358979323846;
 class Math {
 public:
-	inline static double DegreeToRadian(double angle) { return angle * PAI / 180; }
-	inline static double RadianToDegree(double angle) { return angle * 180 / PAI; }
+	static double DegreeToRadian(double angle) { return angle * PAI / 180; }
+	static double RadianToDegree(double angle) { return angle * 180 / PAI; }
 
 	static void InitializeFPU();
 
@@ -145,46 +145,10 @@ public:
 };
 
 //================================================================
-//Sort
-class SortUtility {
-public:
-	template <class BidirectionalIterator, class Predicate>
-	static void CombSort(BidirectionalIterator first,
-		BidirectionalIterator last,
-		Predicate pr)
-	{
-		int gap = static_cast<int>(std::distance(first, last));
-		if (gap < 1)
-			return;
-
-		BidirectionalIterator first2 = last;
-		bool swapped = false;
-		do {
-			int newgap = (gap * 10 + 3) / 13;
-			if (newgap < 1)
-				newgap = 1;
-			if (newgap == 9 || newgap == 10)
-				newgap = 11;
-			std::advance(first2, newgap - gap);
-			gap = newgap;
-			swapped = false;
-			for (BidirectionalIterator target1 = first, target2 = first2;
-				 target2 != last;
-				 ++target1, ++target2) {
-				if (pr(*target2, *target1)) {
-					std::iter_swap(target1, target2);
-					swapped = true;
-				}
-			}
-		} while ((gap > 1) || swapped);
-	}
-};
-
-//================================================================
 //PathProperty
 class PathProperty {
 public:
-	static std::wstring GetFileDirectory(std::wstring path)
+	static std::wstring GetFileDirectory(const std::wstring& path)
 	{
 		wchar_t pDrive[_MAX_PATH];
 		wchar_t pDir[_MAX_PATH];
@@ -192,7 +156,7 @@ public:
 		return std::wstring(pDrive) + std::wstring(pDir);
 	}
 
-	static std::wstring GetDirectoryName(std::wstring path)
+	static std::wstring GetDirectoryName(const std::wstring& path)
 	{
 		//ディレクトリ名を返す
 		std::wstring dir = GetFileDirectory(path);
@@ -201,7 +165,7 @@ public:
 		return strs[strs.size() - 1];
 	}
 
-	static std::wstring GetFileName(std::wstring path)
+	static std::wstring GetFileName(const std::wstring& path)
 	{
 		wchar_t pFileName[_MAX_PATH];
 		wchar_t pExt[_MAX_PATH];
@@ -209,21 +173,21 @@ public:
 		return std::wstring(pFileName) + std::wstring(pExt);
 	}
 
-	static std::wstring GetDriveName(std::wstring path)
+	static std::wstring GetDriveName(const std::wstring& path)
 	{
 		wchar_t pDrive[_MAX_PATH];
 		_wsplitpath(path.c_str(), pDrive, NULL, NULL, NULL);
 		return std::wstring(pDrive);
 	}
 
-	static std::wstring GetFileNameWithoutExtension(std::wstring path)
+	static std::wstring GetFileNameWithoutExtension(const std::wstring& path)
 	{
 		wchar_t pFileName[_MAX_PATH];
 		_wsplitpath(path.c_str(), NULL, NULL, pFileName, NULL);
 		return std::wstring(pFileName);
 	}
 
-	static std::wstring GetFileExtension(std::wstring path)
+	static std::wstring GetFileExtension(const std::wstring& path)
 	{
 		wchar_t pExt[_MAX_PATH];
 		_wsplitpath(path.c_str(), NULL, NULL, NULL, pExt);
@@ -245,7 +209,7 @@ public:
 		GetModuleFileName(NULL, modulePath, sizeof(modulePath) - 1); //実行ファイルパス取得
 		return GetFileDirectory(std::wstring(modulePath));
 	}
-	static std::wstring GetDirectoryWithoutModuleDirectory(std::wstring path)
+	static std::wstring GetDirectoryWithoutModuleDirectory(const std::wstring& path)
 	{	//パスから実行ファイルディレクトリを除いたディレクトリを返す
 		std::wstring res = GetFileDirectory(path);
 		std::wstring dirModule = GetModuleDirectory();
@@ -254,20 +218,19 @@ public:
 		}
 		return res;
 	}
-	static std::wstring GetPathWithoutModuleDirectory(std::wstring path)
+	static std::wstring GetPathWithoutModuleDirectory(const std::wstring& path)
 	{	//パスから実行ファイルディレクトリを取り除く
 		std::wstring dirModule = GetModuleDirectory();
 		dirModule = ReplaceYenToSlash(dirModule);
-		path = Canonicalize(path);
-		path = ReplaceYenToSlash(path);
+		std::wstring res = Canonicalize(path);
+		res = ReplaceYenToSlash(res);
 
-		std::wstring res = path;
 		if (res.find(dirModule) != std::wstring::npos) {
 			res = res.substr(dirModule.size());
 		}
 		return res;
 	}
-	static std::wstring GetRelativeDirectory(std::wstring from, std::wstring to)
+	static std::wstring GetRelativeDirectory(const std::wstring& from, const std::wstring& to)
 	{
 		wchar_t path[_MAX_PATH];
 		BOOL b = PathRelativePathTo(path, from.c_str(), FILE_ATTRIBUTE_DIRECTORY, to.c_str(), FILE_ATTRIBUTE_DIRECTORY);
@@ -278,19 +241,19 @@ public:
 		}
 		return res;
 	}
-	static std::wstring ReplaceYenToSlash(std::wstring path)
+	static std::wstring ReplaceYenToSlash(const std::wstring& path)
 	{
 		std::wstring res = StringUtility::ReplaceAll(path, L"\\", L"/");
 		return res;
 	}
-	static std::wstring Canonicalize(std::wstring srcPath)
+	static std::wstring Canonicalize(const std::wstring& srcPath)
 	{
 		wchar_t destPath[_MAX_PATH];
 		PathCanonicalize(destPath, srcPath.c_str());
 		std::wstring res(destPath);
 		return res;
 	}
-	static std::wstring GetUnique(std::wstring srcPath)
+	static std::wstring GetUnique(const std::wstring& srcPath)
 	{
 		std::wstring res = StringUtility::ReplaceAll(srcPath, L"/", L"\\");
 		res = Canonicalize(res);
@@ -304,7 +267,7 @@ public:
 class BitAccess {
 public:
 	template <typename T>
-	static bool GetBit(T value, int bit)
+	static bool GetBit(const T& value, int bit)
 	{
 		T mask = (T)1 << bit;
 		return (value & mask) != 0;
@@ -319,7 +282,7 @@ public:
 		return value;
 	}
 	template <typename T>
-	static unsigned char GetByte(T value, int bit)
+	static unsigned char GetByte(const T& value, int bit)
 	{
 		return (unsigned char)(value >> bit);
 	}
@@ -448,7 +411,7 @@ public:
 		posStart_ = 0;
 		posEnd_ = 0;
 	}
-	Token(Type type, std::wstring& element, int start, int end)
+	Token(Type type, const std::wstring& element, int start, int end)
 	{
 		type_ = type;
 		element_ = element;
@@ -457,21 +420,22 @@ public:
 	}
 	virtual ~Token(){};
 
-	Type GetType() { return type_; }
-	std::wstring& GetElement() { return element_; }
-	std::string GetElementA();
+	Type GetType() const { return type_; }
+	std::wstring GetElement() const { return element_; }
+	std::string GetElementA() const;
 
-	int GetStartPointer() { return posStart_; }
-	int GetEndPointer() { return posEnd_; }
+	std::wstring GetString() const;
+	std::string GetStringA() const;
 
-	int GetInteger();
-	double GetReal();
-	bool GetBoolean();
-	std::wstring GetString();
-	std::wstring& GetIdentifier();
+	std::wstring GetIdentifier() const;
+	std::string GetIdentifierA() const;
 
-	std::string GetStringA();
-	std::string GetIdentifierA();
+	int GetStartPointer() const { return posStart_; }
+	int GetEndPointer() const { return posEnd_; }
+
+	int GetInteger() const;
+	double GetReal() const;
+	bool GetBoolean() const;
 
 protected:
 	Type type_;
@@ -487,28 +451,28 @@ public:
 	};
 
 public:
-	Scanner(char* str, int size);
-	Scanner(std::string str);
-	Scanner(std::wstring wstr);
-	Scanner(std::vector<char>& buf);
+	Scanner(const char* str, int size);
+	Scanner(const std::string& str);
+	Scanner(const std::wstring& wstr);
+	Scanner(const std::vector<char>& buf);
 	virtual ~Scanner();
 
 	void SetPermitSignNumber(bool bEnable) { bPermitSignNumber_ = bEnable; }
-	int GetEncoding() { return typeEncoding_; }
+	int GetEncoding() const { return typeEncoding_; }
 
 	Token& GetToken(); //現在のトークンを取得
 	Token& Next();
-	bool HasNext();
-	void CheckType(Token& tok, Token::Type type);
-	void CheckIdentifer(Token& tok, std::wstring id);
-	int GetCurrentLine();
+	bool HasNext() const;
+	void CheckType(const Token& tok, Token::Type type) const;
+	void CheckIdentifer(const Token& tok, const std::wstring& id) const;
+	int GetCurrentLine() const;
 
-	int GetCurrentPointer();
+	int GetCurrentPointer() const;
 	void SetCurrentPointer(int pos);
 	void SetPointerBegin();
-	std::wstring GetString(int start, int end);
+	std::wstring GetString(int start, int end) const;
 
-	bool CompareMemory(int start, int end, const char* data);
+	bool CompareMemory(int start, int end, const char* data) const;
 
 protected:
 	int typeEncoding_;
@@ -519,12 +483,12 @@ protected:
 	bool bPermitSignNumber_;
 	std::list<Token> listDebugToken_;
 
-	wchar_t _CurrentChar();
+	wchar_t _CurrentChar() const;
 	wchar_t _NextChar(); //ポインタを進めて次の文字を調べる
 
 	virtual void _SkipComment(); //コメントをとばす
 	virtual void _SkipSpace(); //空白をとばす
-	virtual void _RaiseError(std::wstring str); //例外を投げます
+	virtual void _RaiseError(const std::wstring& str) const; //例外を投げます
 };
 
 //================================================================
@@ -551,8 +515,8 @@ public:
 
 	public:
 		virtual ~Result(){};
-		int GetType() { return type_; }
-		double GetReal()
+		int GetType() const { return type_; }
+		double GetReal() const
 		{
 			double res = valueReal_;
 			if (IsBoolean())
@@ -566,7 +530,7 @@ public:
 			type_ = TYPE_REAL;
 			valueReal_ = value;
 		}
-		bool GetBoolean()
+		bool GetBoolean() const
 		{
 			bool res = valueBoolean_;
 			if (IsReal())
@@ -580,7 +544,7 @@ public:
 			type_ = TYPE_BOOLEAN;
 			valueBoolean_ = value;
 		}
-		std::wstring GetString()
+		std::wstring GetString() const
 		{
 			std::wstring res = valueString_;
 			if (IsReal())
@@ -589,29 +553,29 @@ public:
 				res = (valueBoolean_ ? L"true" : L"false");
 			return res;
 		}
-		void SetString(std::wstring value)
+		void SetString(const std::wstring& value)
 		{
 			type_ = TYPE_STRING;
 			valueString_ = value;
 		}
-		bool IsReal() { return type_ == TYPE_REAL; }
-		bool IsBoolean() { return type_ == TYPE_BOOLEAN; }
-		bool IsString() { return type_ == TYPE_STRING; }
+		bool IsReal() const { return type_ == TYPE_REAL; }
+		bool IsBoolean() const { return type_ == TYPE_BOOLEAN; }
+		bool IsString() const { return type_ == TYPE_STRING; }
 	};
 
 public:
 	TextParser();
-	TextParser(std::string source);
+	TextParser(const std::string& source);
 	virtual ~TextParser();
 
-	void SetSource(std::string source);
+	void SetSource(const std::string& source);
 	Result GetResult();
 	double GetReal();
 
 protected:
 	gstd::ref_count_ptr<Scanner> scan_;
 
-	void _RaiseError(std::wstring message);
+	void _RaiseError(const std::wstring& message);
 	Result _ParseComparison(int pos);
 	Result _ParseSum(int pos);
 	Result _ParseProduct(int pos);
@@ -629,7 +593,7 @@ public:
 	void CreateFontIndirect(LOGFONT& fontInfo);
 	void Clear();
 	HFONT GetHandle() { return hFont_; }
-	LOGFONT GetInfo() { return info_; }
+	LOGFONT GetInfo() const { return info_; }
 
 public:
 	const static wchar_t* GOTHIC;
@@ -660,7 +624,7 @@ public:
 		return res;
 	}
 
-	int GetUsedPoolObjectCount()
+	int GetUsedPoolObjectCount() const
 	{
 		int res = 0;
 		for (int i = 0; i < listUsedPool_.size(); i++) {
@@ -669,7 +633,7 @@ public:
 		return res;
 	}
 
-	int GetCachePoolObjectCount()
+	int GetCachePoolObjectCount() const
 	{
 		int res = 0;
 		for (int i = 0; i < listCachePool_.size(); i++) {

--- a/source/GcLib/gstd/GstdUtility.hpp
+++ b/source/GcLib/gstd/GstdUtility.hpp
@@ -10,7 +10,7 @@ namespace gstd {
 //wexception
 class wexception {
 public:
-	wexception() {}
+	wexception() = default;
 	wexception(const std::wstring& msg) { message_ = msg; }
 	std::wstring GetMessage() const { return message_; }
 	const wchar_t* what() const { return message_.c_str(); }
@@ -75,8 +75,8 @@ public:
 	static int CountCharacter(const std::vector<char>& str, char c);
 	static int ToInteger(const std::string& s);
 	static double ToDouble(const std::string& s);
-	static std::string Replace(const std::string& source, const std::string pattern, const std::string placement);
-	static std::string ReplaceAll(const std::string& source, const std::string pattern, const std::string placement, int replaceCount = INT_MAX, int start = 0, int end = 0);
+	static std::string Replace(const std::string& source, std::string pattern, std::string placement);
+	static std::string ReplaceAll(const std::string& source, std::string pattern, std::string placement, int replaceCount = INT_MAX, int start = 0, int end = 0);
 	static std::string Slice(const std::string& s, int length);
 	static std::string Trim(const std::string& str);
 
@@ -90,8 +90,8 @@ public:
 	static int CountCharacter(const std::wstring& str, wchar_t c);
 	static int ToInteger(const std::wstring& s);
 	static double ToDouble(const std::wstring& s);
-	static std::wstring Replace(const std::wstring& source, const std::wstring pattern, const std::wstring placement);
-	static std::wstring ReplaceAll(const std::wstring& source, const std::wstring pattern, const std::wstring placement, int replaceCount = INT_MAX, int start = 0, int end = 0);
+	static std::wstring Replace(const std::wstring& source, std::wstring pattern, std::wstring placement);
+	static std::wstring ReplaceAll(const std::wstring& source, std::wstring pattern, std::wstring placement, int replaceCount = INT_MAX, int start = 0, int end = 0);
 	static std::wstring Slice(const std::wstring& s, int length);
 	static std::wstring Trim(const std::wstring& str);
 	static int CountAsciiSizeCharacter(const std::wstring& str);
@@ -152,7 +152,7 @@ public:
 	{
 		wchar_t pDrive[_MAX_PATH];
 		wchar_t pDir[_MAX_PATH];
-		_wsplitpath(path.c_str(), pDrive, pDir, NULL, NULL);
+		_wsplitpath(path.c_str(), pDrive, pDir, nullptr, nullptr);
 		return std::wstring(pDrive) + std::wstring(pDir);
 	}
 
@@ -169,28 +169,28 @@ public:
 	{
 		wchar_t pFileName[_MAX_PATH];
 		wchar_t pExt[_MAX_PATH];
-		_wsplitpath(path.c_str(), NULL, NULL, pFileName, pExt);
+		_wsplitpath(path.c_str(), nullptr, nullptr, pFileName, pExt);
 		return std::wstring(pFileName) + std::wstring(pExt);
 	}
 
 	static std::wstring GetDriveName(const std::wstring& path)
 	{
 		wchar_t pDrive[_MAX_PATH];
-		_wsplitpath(path.c_str(), pDrive, NULL, NULL, NULL);
+		_wsplitpath(path.c_str(), pDrive, nullptr, nullptr, nullptr);
 		return std::wstring(pDrive);
 	}
 
 	static std::wstring GetFileNameWithoutExtension(const std::wstring& path)
 	{
 		wchar_t pFileName[_MAX_PATH];
-		_wsplitpath(path.c_str(), NULL, NULL, pFileName, NULL);
+		_wsplitpath(path.c_str(), nullptr, nullptr, pFileName, nullptr);
 		return std::wstring(pFileName);
 	}
 
 	static std::wstring GetFileExtension(const std::wstring& path)
 	{
 		wchar_t pExt[_MAX_PATH];
-		_wsplitpath(path.c_str(), NULL, NULL, NULL, pExt);
+		_wsplitpath(path.c_str(), nullptr, nullptr, nullptr, pExt);
 		return std::wstring(pExt);
 	}
 
@@ -198,7 +198,7 @@ public:
 	{
 		wchar_t modulePath[_MAX_PATH];
 		ZeroMemory(modulePath, sizeof(modulePath));
-		GetModuleFileName(NULL, modulePath, sizeof(modulePath) - 1); //実行ファイルパス取得
+		GetModuleFileName(nullptr, modulePath, sizeof(modulePath) - 1); //実行ファイルパス取得
 		return GetFileNameWithoutExtension(std::wstring(modulePath));
 	}
 
@@ -206,7 +206,7 @@ public:
 	{
 		wchar_t modulePath[_MAX_PATH];
 		ZeroMemory(modulePath, sizeof(modulePath));
-		GetModuleFileName(NULL, modulePath, sizeof(modulePath) - 1); //実行ファイルパス取得
+		GetModuleFileName(nullptr, modulePath, sizeof(modulePath) - 1); //実行ファイルパス取得
 		return GetFileDirectory(std::wstring(modulePath));
 	}
 	static std::wstring GetDirectoryWithoutModuleDirectory(const std::wstring& path)
@@ -236,7 +236,7 @@ public:
 		BOOL b = PathRelativePathTo(path, from.c_str(), FILE_ATTRIBUTE_DIRECTORY, to.c_str(), FILE_ATTRIBUTE_DIRECTORY);
 
 		std::wstring res;
-		if (b) {
+		if (b != 0) {
 			res = GetFileDirectory(path);
 		}
 		return res;
@@ -301,7 +301,7 @@ public:
 //IStringInfo
 class IStringInfo {
 public:
-	virtual ~IStringInfo() {}
+	virtual ~IStringInfo() = default;
 	virtual std::wstring GetInfoAsString()
 	{
 		int address = (int)this;
@@ -318,7 +318,7 @@ public:
 template <class T>
 class InnerClass {
 public:
-	InnerClass(T* outer = NULL) { outer_ = outer; }
+	InnerClass(T* outer = nullptr) { outer_ = outer; }
 
 protected:
 	T* _GetOuter() { return outer_; }
@@ -333,32 +333,32 @@ private:
 template <class T>
 class Singleton {
 public:
-	virtual ~Singleton(){};
+	virtual ~Singleton() = default;
 	static T* CreateInstance()
 	{
-		if (_This() == NULL)
+		if (_This() == nullptr)
 			_This() = new T();
 		return _This();
 	}
 	static T* GetInstance()
 	{
-		if (_This() == NULL) {
+		if (_This() == nullptr) {
 			throw std::exception("Singleton::GetInstance 未初期化");
 		}
 		return _This();
 	}
 	static void DeleteInstance()
 	{
-		if (_This() != NULL)
+		if (_This() != nullptr)
 			delete _This();
-		_This() = NULL;
+		_This() = nullptr;
 	}
 
 protected:
-	Singleton(){};
+	Singleton() = default;
 	inline static T*& _This()
 	{
-		static T* s = NULL;
+		static T* s = nullptr;
 		return s;
 	}
 };
@@ -418,7 +418,7 @@ public:
 		posStart_ = start;
 		posEnd_ = end;
 	}
-	virtual ~Token(){};
+	virtual ~Token() = default;
 
 	Type GetType() const { return type_; }
 	std::wstring GetElement() const { return element_; }
@@ -445,11 +445,6 @@ protected:
 };
 
 class Scanner {
-public:
-	enum {
-
-	};
-
 public:
 	Scanner(const char* str, int size);
 	Scanner(const std::string& str);
@@ -514,7 +509,7 @@ public:
 		};
 
 	public:
-		virtual ~Result(){};
+		virtual ~Result() = default;
 		int GetType() const { return type_; }
 		double GetReal() const
 		{
@@ -609,12 +604,12 @@ protected:
 template <class T, bool SYNC>
 class ObjectPool {
 public:
-	ObjectPool() {}
-	virtual ~ObjectPool() {}
+	ObjectPool() = default;
+	virtual ~ObjectPool() = default;
 	virtual gstd::ref_count_ptr<T, SYNC> GetPoolObject(int type)
 	{
-		gstd::ref_count_ptr<T, SYNC> res = NULL;
-		if (listCachePool_[type].size() > 0) {
+		gstd::ref_count_ptr<T, SYNC> res = nullptr;
+		if (!listCachePool_[type].empty()) {
 			res = listCachePool_[type].back();
 			listCachePool_[type].pop_back();
 		} else {
@@ -627,8 +622,8 @@ public:
 	int GetUsedPoolObjectCount() const
 	{
 		int res = 0;
-		for (int i = 0; i < listUsedPool_.size(); i++) {
-			res += listUsedPool_[i].size();
+		for (auto& usedPool : listUsedPool_) {
+			res += usedPool.size();
 		}
 		return res;
 	}
@@ -636,8 +631,8 @@ public:
 	int GetCachePoolObjectCount() const
 	{
 		int res = 0;
-		for (int i = 0; i < listCachePool_.size(); i++) {
-			res += listCachePool_[i].size();
+		for (auto& cachePool : listCachePool_) {
+			res += cachePool.size();
 		}
 		return res;
 	}
@@ -656,19 +651,18 @@ protected:
 	virtual void _ArrangePool()
 	{
 		int countType = listUsedPool_.size();
-		for (int iType = 0; iType < countType; iType++) {
+		for (int iType = 0; iType < countType; ++iType) {
 			std::list<gstd::ref_count_ptr<T, SYNC>>* listUsed = &listUsedPool_[iType];
 			std::vector<gstd::ref_count_ptr<T, SYNC>>* listCache = &listCachePool_[iType];
 
-			std::list<gstd::ref_count_ptr<T, SYNC>>::iterator itr = listUsed->begin();
-			for (; itr != listUsed->end();) {
+			for (auto itr = listUsed->begin(); itr != listUsed->end();) {
 				gstd::ref_count_ptr<T, SYNC> obj = (*itr);
 				if (obj.GetReferenceCount() == 2) {
 					itr = listUsed->erase(itr);
 					_ResetPoolObject(obj);
 					listCache->push_back(obj);
 				} else {
-					itr++;
+					++itr;
 				}
 			}
 		}

--- a/source/GcLib/gstd/Logger.cpp
+++ b/source/GcLib/gstd/Logger.cpp
@@ -5,15 +5,13 @@ using namespace gstd;
 /**********************************************************
 //Logger
 **********************************************************/
-Logger* Logger::top_ = NULL;
-Logger::Logger()
-{
-}
+Logger* Logger::top_ = nullptr;
+Logger::Logger() = default;
 Logger::~Logger()
 {
 	listLogger_.clear();
 	if (top_ == this)
-		top_ = NULL;
+		top_ = nullptr;
 }
 void Logger::_WriteChild(const SYSTEMTIME& time, const std::wstring& str)
 {
@@ -38,9 +36,7 @@ FileLogger::FileLogger()
 	sizeMax_ = 10 * 1024 * 1024; // 10MB
 }
 
-FileLogger::~FileLogger()
-{
-}
+FileLogger::~FileLogger() = default;
 void FileLogger::Clear()
 {
 	if (!bEnable_)
@@ -60,7 +56,7 @@ bool FileLogger::Initialize(bool bEnable)
 bool FileLogger::Initialize(std::wstring& path, bool bEnable)
 {
 	bEnable_ = bEnable;
-	if (path.size() == 0) {
+	if (path.empty()) {
 		path = PathProperty::GetModuleDirectory() + PathProperty::GetModuleName() + std::wstring(L".log");
 	}
 	return this->SetPath(path);
@@ -72,7 +68,7 @@ bool FileLogger::SetPath(const std::wstring& path)
 
 	path_ = path;
 	File file(path);
-	if (file.IsExists() == false) {
+	if (!file.IsExists()) {
 		file.CreateDirectory();
 		_CreateFile(file);
 	}
@@ -123,19 +119,17 @@ void FileLogger::_Write(const SYSTEMTIME& time, const std::wstring& str)
 /**********************************************************
 //WindowLogger
 **********************************************************/
-WindowLogger::WindowLogger()
-{
-}
+WindowLogger::WindowLogger() = default;
 WindowLogger::~WindowLogger()
 {
-	threadInfoCollect_ = NULL;
-	wndInfoPanel_ = NULL;
-	wndLogPanel_ = NULL;
-	wndStatus_ = NULL;
-	wndTab_ = NULL;
-	if (hWnd_ != NULL)
+	threadInfoCollect_ = nullptr;
+	wndInfoPanel_ = nullptr;
+	wndLogPanel_ = nullptr;
+	wndStatus_ = nullptr;
+	wndTab_ = nullptr;
+	if (hWnd_ != nullptr)
 		SendMessage(hWnd_, WM_ENDLOGGER, 0, 0);
-	if (threadWindow_ != NULL) {
+	if (threadWindow_ != nullptr) {
 		threadWindow_->Stop();
 		threadWindow_->Join(2000); //念のためにタイムアウト設定
 	}
@@ -149,7 +143,7 @@ bool WindowLogger::Initialize(bool bEnable)
 	threadWindow_ = new WindowThread(this);
 	threadWindow_->Start();
 
-	while (GetWindowHandle() == NULL) {
+	while (GetWindowHandle() == nullptr) {
 		Sleep(10); //ウィンドウが作成完了するまで待機
 	}
 
@@ -183,9 +177,9 @@ void WindowLogger::SaveState()
 
 		RecordBuffer recordPanel;
 		int panelCount = wndTab_->GetPageCount();
-		for (int iPanel = 0; iPanel < panelCount; iPanel++) {
+		for (int iPanel = 0; iPanel < panelCount; ++iPanel) {
 			ref_count_ptr<WindowLogger::Panel> panel = ref_count_ptr<WindowLogger::Panel>::DownCast(wndTab_->GetPanel(iPanel));
-			if (panel == NULL)
+			if (panel == nullptr)
 				continue;
 			panel->_WriteRecord(recordPanel);
 		}
@@ -218,7 +212,7 @@ void WindowLogger::LoadState()
 	int panelCount = wndTab_->GetPageCount();
 	for (int iPanel = 0; iPanel < panelCount; iPanel++) {
 		ref_count_ptr<WindowLogger::Panel> panel = ref_count_ptr<WindowLogger::Panel>::DownCast(wndTab_->GetPanel(iPanel));
-		if (panel == NULL)
+		if (panel == nullptr)
 			continue;
 
 		panel->_ReadRecord(recordPanel);
@@ -226,7 +220,7 @@ void WindowLogger::LoadState()
 }
 void WindowLogger::_CreateWindow()
 {
-	HINSTANCE hInst = ::GetModuleHandle(NULL);
+	HINSTANCE hInst = ::GetModuleHandle(nullptr);
 	std::wstring wName = L"LogWindow";
 
 	WNDCLASSEX wcex;
@@ -234,18 +228,18 @@ void WindowLogger::_CreateWindow()
 	wcex.cbSize = sizeof(WNDCLASSEX);
 	wcex.lpfnWndProc = (WNDPROC)WindowBase::_StaticWindowProcedure;
 	wcex.hInstance = hInst;
-	wcex.hIcon = NULL;
-	wcex.hCursor = LoadCursor(NULL, IDC_ARROW);
+	wcex.hIcon = nullptr;
+	wcex.hCursor = LoadCursor(nullptr, IDC_ARROW);
 	wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW);
-	wcex.lpszMenuName = NULL;
+	wcex.lpszMenuName = nullptr;
 	wcex.lpszClassName = wName.c_str();
-	wcex.hIconSm = NULL;
+	wcex.hIconSm = nullptr;
 	RegisterClassEx(&wcex);
 
 	hWnd_ = ::CreateWindow(wcex.lpszClassName,
 		wName.c_str(),
 		WS_OVERLAPPEDWINDOW,
-		0, 0, 640, 480, NULL, (HMENU)NULL, hInst, NULL);
+		0, 0, 640, 480, nullptr, (HMENU)nullptr, hInst, nullptr);
 	::ShowWindow(hWnd_, SW_HIDE);
 	this->Attach(hWnd_);
 
@@ -276,14 +270,14 @@ void WindowLogger::_Run()
 {
 	_CreateWindow();
 	MSG msg;
-	while (GetMessage(&msg, NULL, 0, 0)) { //メッセージループ
+	while (GetMessage(&msg, nullptr, 0, 0)) { //メッセージループ
 		TranslateMessage(&msg);
 		DispatchMessage(&msg);
 	}
 }
 void WindowLogger::_Write(const SYSTEMTIME& systemTime, const std::wstring& str)
 {
-	if (hWnd_ == NULL)
+	if (hWnd_ == nullptr)
 		return;
 
 	wchar_t timeStr[256];
@@ -321,7 +315,7 @@ LRESULT WindowLogger::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPAR
 
 		wndStatus_->SetBounds(wParam, lParam);
 		wndTab_->SetBounds(wx + 8, wy + 4, wWidth - 16, wHeight - 32);
-		::InvalidateRect(wndTab_->GetWindowHandle(), NULL, TRUE);
+		::InvalidateRect(wndTab_->GetWindowHandle(), nullptr, TRUE);
 
 		return FALSE;
 	}
@@ -369,14 +363,14 @@ LRESULT WindowLogger::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPAR
 
 void WindowLogger::SetInfo(int row, const std::wstring& textInfo, const std::wstring& textData)
 {
-	if (hWnd_ == NULL)
+	if (hWnd_ == nullptr)
 		return;
 	wndInfoPanel_->SetInfo(row, textInfo, textData);
 }
 
 bool WindowLogger::AddPanel(ref_count_ptr<Panel> panel, const std::wstring& name)
 {
-	if (hWnd_ == NULL)
+	if (hWnd_ == nullptr)
 		return false;
 
 	AddPanelEvent event;
@@ -389,7 +383,7 @@ bool WindowLogger::AddPanel(ref_count_ptr<Panel> panel, const std::wstring& name
 
 	::SendMessage(hWnd_, WM_ADDPANEL, 0, 0);
 
-	while (panel->GetWindowHandle() == NULL) {
+	while (panel->GetWindowHandle() == nullptr) {
 		Sleep(10); //ウィンドウが作成完了するまで待機
 	}
 	return true;
@@ -429,12 +423,8 @@ void WindowLogger::WindowThread::_Run()
 }
 
 //WindowLogger::LogPanel
-WindowLogger::LogPanel::LogPanel()
-{
-}
-WindowLogger::LogPanel::~LogPanel()
-{
-}
+WindowLogger::LogPanel::LogPanel() = default;
+WindowLogger::LogPanel::~LogPanel() = default;
 bool WindowLogger::LogPanel::_AddedLogger(HWND hTab)
 {
 	Create(hTab);
@@ -470,12 +460,8 @@ void WindowLogger::LogPanel::AddText(const std::wstring& text)
 	::SendMessage(hEdit, EM_REPLACESEL, 0, (LPARAM)text.c_str());
 }
 //WindowLogger::InfoPanel
-WindowLogger::InfoPanel::InfoPanel()
-{
-}
-WindowLogger::InfoPanel::~InfoPanel()
-{
-}
+WindowLogger::InfoPanel::InfoPanel() = default;
+WindowLogger::InfoPanel::~InfoPanel() = default;
 bool WindowLogger::InfoPanel::_AddedLogger(HWND hTab)
 {
 	Create(hTab);
@@ -513,7 +499,7 @@ WindowLogger::InfoCollectThread::~InfoCollectThread()
 {
 	this->Stop();
 	this->Join();
-	wndStatus_ = NULL;
+	wndStatus_ = nullptr;
 }
 void WindowLogger::InfoCollectThread::_Run()
 {
@@ -587,7 +573,7 @@ WindowLogger::InfoCollectThread::CpuInfo WindowLogger::InfoCollectThread::_GetCp
 			exitasm:
 		};
 
-		if (!cpuid_supported) { //CPUID 命令をサポートしてない
+		if (cpuid_supported == 0) { //CPUID 命令をサポートしてない
 			throw gstd::wexception();
 		}
 
@@ -743,13 +729,13 @@ double WindowLogger::InfoCollectThread::_GetCpuPerformance()
 	HCOUNTER hCounter;
 	PDH_FMT_COUNTERVALUE FmtValue;
 
-	PdhOpenQuery(NULL, 0, &hQuery);
+	PdhOpenQuery(nullptr, 0, &hQuery);
 	PdhAddCounter(hQuery, L"\\Processor(_Total)\\% Processor Time", 0, &hCounter);
 	Sleep(500);
 	PdhCollectQueryData(hQuery);
 	Sleep(500);
 	PdhCollectQueryData(hQuery);
-	PdhGetFormattedCounterValue(hCounter, PDH_FMT_DOUBLE, NULL, &FmtValue);
+	PdhGetFormattedCounterValue(hCounter, PDH_FMT_DOUBLE, nullptr, &FmtValue);
 	PdhCloseQuery(hQuery);
 	return FmtValue.doubleValue;
 }

--- a/source/GcLib/gstd/Logger.cpp
+++ b/source/GcLib/gstd/Logger.cpp
@@ -15,16 +15,15 @@ Logger::~Logger()
 	if (top_ == this)
 		top_ = NULL;
 }
-void Logger::_WriteChild(SYSTEMTIME& time, std::wstring str)
+void Logger::_WriteChild(const SYSTEMTIME& time, const std::wstring& str)
 {
 	_Write(time, str);
-	std::list<ref_count_ptr<Logger>>::iterator itr = listLogger_.begin();
-	for (; itr != listLogger_.end(); itr++) {
-		(*itr)->_Write(time, str);
+	for (auto& logger : listLogger_) {
+		logger->_Write(time, str);
 	}
 }
 
-void Logger::Write(std::wstring str)
+void Logger::Write(const std::wstring& str)
 {
 	SYSTEMTIME systemTime;
 	GetLocalTime(&systemTime);
@@ -56,9 +55,9 @@ void FileLogger::Clear()
 }
 bool FileLogger::Initialize(bool bEnable)
 {
-	return this->Initialize(L"", bEnable);
+	return this->Initialize(std::wstring(L""), bEnable);
 }
-bool FileLogger::Initialize(std::wstring path, bool bEnable)
+bool FileLogger::Initialize(std::wstring& path, bool bEnable)
 {
 	bEnable_ = bEnable;
 	if (path.size() == 0) {
@@ -66,7 +65,7 @@ bool FileLogger::Initialize(std::wstring path, bool bEnable)
 	}
 	return this->SetPath(path);
 }
-bool FileLogger::SetPath(std::wstring path)
+bool FileLogger::SetPath(const std::wstring& path)
 {
 	if (!bEnable_)
 		return false;
@@ -89,7 +88,7 @@ void FileLogger::_CreateFile(File& file)
 	file.WriteCharacter((unsigned char)0xFF);
 	file.WriteCharacter((unsigned char)0xFE);
 }
-void FileLogger::_Write(SYSTEMTIME& time, std::wstring str)
+void FileLogger::_Write(const SYSTEMTIME& time, const std::wstring& str)
 {
 	if (!bEnable_)
 		return;
@@ -282,7 +281,7 @@ void WindowLogger::_Run()
 		DispatchMessage(&msg);
 	}
 }
-void WindowLogger::_Write(SYSTEMTIME& systemTime, std::wstring str)
+void WindowLogger::_Write(const SYSTEMTIME& systemTime, const std::wstring& str)
 {
 	if (hWnd_ == NULL)
 		return;
@@ -368,14 +367,14 @@ LRESULT WindowLogger::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPAR
 	return _CallPreviousWindowProcedure(hWnd, uMsg, wParam, lParam);
 }
 
-void WindowLogger::SetInfo(int row, std::wstring textInfo, std::wstring textData)
+void WindowLogger::SetInfo(int row, const std::wstring& textInfo, const std::wstring& textData)
 {
 	if (hWnd_ == NULL)
 		return;
 	wndInfoPanel_->SetInfo(row, textInfo, textData);
 }
 
-bool WindowLogger::AddPanel(ref_count_ptr<Panel> panel, std::wstring name)
+bool WindowLogger::AddPanel(ref_count_ptr<Panel> panel, const std::wstring& name)
 {
 	if (hWnd_ == NULL)
 		return false;
@@ -395,7 +394,7 @@ bool WindowLogger::AddPanel(ref_count_ptr<Panel> panel, std::wstring name)
 	}
 	return true;
 }
-void WindowLogger::ShowLogWindow()
+void WindowLogger::ShowLogWindow() const
 {
 	if (!bEnable_)
 		return;
@@ -454,7 +453,7 @@ void WindowLogger::LogPanel::LocateParts()
 	int wHeight = GetClientHeight();
 	wndEdit_.SetBounds(wx, wy, wWidth, wHeight);
 }
-void WindowLogger::LogPanel::AddText(std::wstring text)
+void WindowLogger::LogPanel::AddText(const std::wstring& text)
 {
 	HWND hEdit = wndEdit_.GetWindowHandle();
 	int pos = GetWindowTextLength(hEdit);
@@ -499,7 +498,7 @@ void WindowLogger::InfoPanel::LocateParts()
 	int wHeight = GetClientHeight();
 	wndListView_.SetBounds(wx, wy, wWidth, wHeight);
 }
-void WindowLogger::InfoPanel::SetInfo(int row, std::wstring textInfo, std::wstring textData)
+void WindowLogger::InfoPanel::SetInfo(int row, const std::wstring& textInfo, const std::wstring& textData)
 {
 	wndListView_.SetText(row, ROW_INFO, textInfo);
 	wndListView_.SetText(row, ROW_DATA, textData);

--- a/source/GcLib/gstd/Logger.hpp
+++ b/source/GcLib/gstd/Logger.hpp
@@ -19,10 +19,10 @@ public:
 	virtual ~Logger();
 	virtual bool Initialize() { return true; }
 	void AddLogger(ref_count_ptr<Logger> logger) { listLogger_.push_back(logger); }
-	virtual void Write(std::wstring str);
+	virtual void Write(const std::wstring& str);
 
 	static void SetTop(Logger* logger) { top_ = logger; }
-	static void WriteTop(std::wstring str)
+	static void WriteTop(const std::wstring& str)
 	{
 		if (top_ != NULL)
 			top_->Write(str);
@@ -32,8 +32,8 @@ protected:
 	static Logger* top_;
 	gstd::CriticalSection lock_;
 	std::list<ref_count_ptr<Logger>> listLogger_; //子のロガ
-	virtual void _WriteChild(SYSTEMTIME& time, std::wstring str);
-	virtual void _Write(SYSTEMTIME& time, std::wstring str) = 0;
+	virtual void _WriteChild(const SYSTEMTIME& time, const std::wstring& str);
+	virtual void _Write(const SYSTEMTIME& time, const std::wstring& str) = 0;
 };
 
 /**********************************************************
@@ -45,8 +45,8 @@ public:
 	~FileLogger();
 	void Clear();
 	bool Initialize(bool bEnable = true);
-	bool Initialize(std::wstring path, bool bEnable = true);
-	bool SetPath(std::wstring path);
+	bool Initialize(std::wstring& path, bool bEnable = true);
+	bool SetPath(const std::wstring& path);
 	void SetMaxFileSize(int size) { sizeMax_ = size; }
 
 protected:
@@ -54,7 +54,7 @@ protected:
 	std::wstring path_;
 	std::wstring path2_;
 	int sizeMax_;
-	virtual void _Write(SYSTEMTIME& systemTime, std::wstring str);
+	virtual void _Write(const SYSTEMTIME& systemTime, const std::wstring& str);
 	void _CreateFile(File& file);
 };
 
@@ -90,10 +90,10 @@ public:
 	bool Initialize(bool bEnable = true);
 	void SaveState();
 	void LoadState();
-	void SetInfo(int row, std::wstring textInfo, std::wstring textData);
-	bool AddPanel(ref_count_ptr<Panel> panel, std::wstring name);
+	void SetInfo(int row, const std::wstring& textInfo, const std::wstring& textData);
+	bool AddPanel(ref_count_ptr<Panel> panel, const std::wstring& name);
 
-	void ShowLogWindow();
+	void ShowLogWindow() const;
 	static void InsertOpenCommandInSystemMenu(HWND hWnd);
 
 protected:
@@ -113,7 +113,7 @@ protected:
 
 	void _Run();
 	void _CreateWindow();
-	virtual void _Write(SYSTEMTIME& systemTime, std::wstring str);
+	virtual void _Write(const SYSTEMTIME& systemTime, const std::wstring& str);
 	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 };
 class WindowLogger::WindowThread : public gstd::Thread, public gstd::InnerClass<WindowLogger> {
@@ -138,7 +138,7 @@ public:
 	LogPanel();
 	~LogPanel();
 	virtual void LocateParts();
-	void AddText(std::wstring text);
+	void AddText(const std::wstring& text);
 
 protected:
 	virtual bool _AddedLogger(HWND hTab);
@@ -152,7 +152,7 @@ public:
 	InfoPanel();
 	~InfoPanel();
 	virtual void LocateParts();
-	void SetInfo(int row, std::wstring textInfo, std::wstring textData);
+	void SetInfo(int row, const std::wstring& textInfo, const std::wstring& textData);
 
 protected:
 	virtual bool _AddedLogger(HWND hTab);

--- a/source/GcLib/gstd/Logger.hpp
+++ b/source/GcLib/gstd/Logger.hpp
@@ -24,7 +24,7 @@ public:
 	static void SetTop(Logger* logger) { top_ = logger; }
 	static void WriteTop(const std::wstring& str)
 	{
-		if (top_ != NULL)
+		if (top_ != nullptr)
 			top_->Write(str);
 	} //トップのロガに出力します
 
@@ -42,7 +42,7 @@ protected:
 class FileLogger : public Logger {
 public:
 	FileLogger();
-	~FileLogger();
+	~FileLogger() override;
 	void Clear();
 	bool Initialize(bool bEnable = true);
 	bool Initialize(std::wstring& path, bool bEnable = true);
@@ -54,7 +54,7 @@ protected:
 	std::wstring path_;
 	std::wstring path2_;
 	int sizeMax_;
-	virtual void _Write(const SYSTEMTIME& systemTime, const std::wstring& str);
+	void _Write(const SYSTEMTIME& systemTime, const std::wstring& str) override;
 	void _CreateFile(File& file);
 };
 
@@ -86,7 +86,7 @@ public:
 
 public:
 	WindowLogger();
-	~WindowLogger();
+	~WindowLogger() override;
 	bool Initialize(bool bEnable = true);
 	void SaveState();
 	void LoadState();
@@ -113,8 +113,8 @@ protected:
 
 	void _Run();
 	void _CreateWindow();
-	virtual void _Write(const SYSTEMTIME& systemTime, const std::wstring& str);
-	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	void _Write(const SYSTEMTIME& systemTime, const std::wstring& str) override;
+	LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 };
 class WindowLogger::WindowThread : public gstd::Thread, public gstd::InnerClass<WindowLogger> {
 	friend WindowLogger;
@@ -136,12 +136,12 @@ protected:
 class WindowLogger::LogPanel : public WindowLogger::Panel {
 public:
 	LogPanel();
-	~LogPanel();
-	virtual void LocateParts();
+	~LogPanel() override;
+	void LocateParts() override;
 	void AddText(const std::wstring& text);
 
 protected:
-	virtual bool _AddedLogger(HWND hTab);
+	bool _AddedLogger(HWND hTab) override;
 
 private:
 	WEditBox wndEdit_;
@@ -150,12 +150,12 @@ private:
 class WindowLogger::InfoPanel : public WindowLogger::Panel {
 public:
 	InfoPanel();
-	~InfoPanel();
-	virtual void LocateParts();
+	~InfoPanel() override;
+	void LocateParts() override;
 	void SetInfo(int row, const std::wstring& textInfo, const std::wstring& textData);
 
 protected:
-	virtual bool _AddedLogger(HWND hTab);
+	bool _AddedLogger(HWND hTab) override;
 
 private:
 	enum {
@@ -168,7 +168,7 @@ private:
 class WindowLogger::InfoCollectThread : public Thread {
 public:
 	InfoCollectThread(ref_count_ptr<WStatusBar> wndStatus);
-	~InfoCollectThread();
+	~InfoCollectThread() override;
 
 protected:
 	//CPU情報構造体
@@ -187,11 +187,11 @@ protected:
 	};
 	ref_count_ptr<WStatusBar> wndStatus_;
 	CpuInfo infoCpu_;
-	virtual void _Run();
+	void _Run() override;
 	CpuInfo _GetCpuInformation();
 	double _GetCpuPerformance();
 };
 
-} // namespace gstd;
+}  // namespace gstd
 
 #endif

--- a/source/GcLib/gstd/MersenneTwister.cpp
+++ b/source/GcLib/gstd/MersenneTwister.cpp
@@ -19,16 +19,14 @@ const cardinal LOWER_MASK = 0x7fffffffUL;
 #define FIX32(value) value // 32bitの型が無い環境では value & 0xffffffffUL とか
 static cardinal const mag01[2] = { 0x0UL, MATRIX_A };
 
-MersenneTwister::MersenneTwister()
-	: actualTwister(0)
-	, seed(0)
-{
-}
+MersenneTwister::MersenneTwister() = default;
 MersenneTwister::MersenneTwister(unsigned long s)
 	: actualTwister(s)
 	, seed(s)
 {
 }
+MersenneTwister::~MersenneTwister() = default;
+
 unsigned long MersenneTwister::_GenrandInt32()
 {
 	std::uniform_int_distribution<long> new_param(0, maxInt);
@@ -61,14 +59,14 @@ long MersenneTwister::GetInt(long min, long max)
 	std::uniform_int_distribution<int> new_param(min, max);
 	return new_param(actualTwister);
 }
-_int64 MersenneTwister::GetInt64()
+int64_t MersenneTwister::GetInt64()
 {
-	std::uniform_int_distribution<_int64> new_param(0, maxInt64);
+	std::uniform_int_distribution<int64_t> new_param(0, maxInt64);
 	return new_param(actualTwister);
 }
-_int64 MersenneTwister::GetInt64(_int64 min, _int64 max)
+int64_t MersenneTwister::GetInt64(int64_t min, int64_t max)
 {
-	std::uniform_int_distribution<_int64> new_param(min, max);
+	std::uniform_int_distribution<int64_t> new_param(min, max);
 	return new_param(actualTwister);
 }
 long double MersenneTwister::GetReal()

--- a/source/GcLib/gstd/MersenneTwister.hpp
+++ b/source/GcLib/gstd/MersenneTwister.hpp
@@ -23,22 +23,22 @@ class MersenneTwister {
 	typedef struct mt_struct {
 		unsigned long mt[MT_N];
 		int mti;
-		virtual ~mt_struct() {}
+		virtual ~mt_struct() = default;
 	} mt_struct;
 	mt_struct mts;
 	unsigned long _GenrandInt32();
 
 private:
-	std::mt19937 actualTwister;
-	int seed;
-	long double maxReal = 3.402822e+38;
-	long maxInt = 2147483647;
-	unsigned long long maxInt64 = 9223372036854775807;
+	std::mt19937 actualTwister {0};
+	int seed {0};
+	long double maxReal {3.402822e+38};
+	long maxInt {2147483647};
+	unsigned long long maxInt64 {9223372036854775807};
 
 public:
 	MersenneTwister();
 	MersenneTwister(unsigned long s);
-	virtual ~MersenneTwister() {}
+	virtual ~MersenneTwister();
 	void Initialize(unsigned long s);
 	void Initialize(unsigned long* init_key, int key_length);
 
@@ -46,8 +46,8 @@ public:
 	int SeedRNG();
 	long GetInt();
 	long GetInt(long min, long max);
-	_int64 GetInt64();
-	_int64 GetInt64(_int64 min, _int64 max);
+	int64_t GetInt64();
+	int64_t GetInt64(int64_t min, int64_t max);
 	long double GetReal();
 	long double GetReal(long double min, long double max);
 };

--- a/source/GcLib/gstd/MersenneTwister.hpp
+++ b/source/GcLib/gstd/MersenneTwister.hpp
@@ -1,8 +1,8 @@
 #ifndef __GSTD_MERSENNETWISTER__
 #define __GSTD_MERSENNETWISTER__
 
-#include"GstdConstant.hpp"
-#include<random>
+#include "GstdConstant.hpp"
+#include <random>
 namespace gstd {
 
 /**********************************************************
@@ -42,7 +42,7 @@ public:
 	void Initialize(unsigned long s);
 	void Initialize(unsigned long* init_key, int key_length);
 
-	int GetSeed() { return seed; }
+	int GetSeed() const { return seed; }
 	int SeedRNG();
 	long GetInt();
 	long GetInt(long min, long max);

--- a/source/GcLib/gstd/Script.hpp
+++ b/source/GcLib/gstd/Script.hpp
@@ -34,8 +34,8 @@
 //-------- 汎用
 namespace gstd {
 
-std::string to_mbcs(std::wstring const& s);
-std::wstring to_wide(std::string const& s);
+std::string to_mbcs(const std::wstring& s);
+std::wstring to_wide(const std::string& s);
 
 template <typename T>
 class lightweight_vector {
@@ -51,7 +51,7 @@ public:
 	{
 	}
 
-	lightweight_vector(lightweight_vector const& source);
+	lightweight_vector(const lightweight_vector& source);
 
 	~lightweight_vector()
 	{
@@ -60,11 +60,11 @@ public:
 		}
 	}
 
-	lightweight_vector& operator=(lightweight_vector const& source);
+	lightweight_vector& operator=(const lightweight_vector& source);
 
 	void expand();
 
-	void push_back(T const& value)
+	void push_back(const T& value)
 	{
 		if (length == capacity)
 			expand();
@@ -105,7 +105,7 @@ public:
 		return at[i];
 	}
 
-	T const& operator[](unsigned i) const
+	const T & operator[](unsigned i) const
 	{
 		return at[i];
 	}
@@ -121,11 +121,11 @@ public:
 	}
 
 	void erase(T* pos);
-	void insert(T* pos, T const& value);
+	void insert(T* pos, const T & value);
 };
 
 template <typename T>
-lightweight_vector<T>::lightweight_vector(lightweight_vector const& source)
+lightweight_vector<T>::lightweight_vector(const lightweight_vector & source)
 {
 	length = source.length;
 	capacity = source.capacity;
@@ -139,7 +139,7 @@ lightweight_vector<T>::lightweight_vector(lightweight_vector const& source)
 }
 
 template <typename T>
-lightweight_vector<T>& lightweight_vector<T>::operator=(lightweight_vector<T> const& source)
+lightweight_vector<T>& lightweight_vector<T>::operator=(const lightweight_vector<T> & source)
 {
 	if (at != NULL)
 		delete[] at;
@@ -182,7 +182,7 @@ void lightweight_vector<T>::erase(T* pos)
 }
 
 template <typename T>
-void lightweight_vector<T>::insert(T* pos, T const& value)
+void lightweight_vector<T>::insert(T* pos, const T& value)
 {
 	if (length == capacity) {
 		unsigned pos_index = pos - at;
@@ -221,55 +221,50 @@ public:
 
 	//デストラクタはデフォルトに任せる
 
-	type_kind get_kind()
-	{
-		return kind;
-	}
-
-	type_data* get_element()
-	{
-		return element;
-	}
+	type_kind get_kind() const { return kind; }
+	type_data* get_element() const { return element; }
 
 private:
 	type_kind kind;
 	type_data* element;
 
-	type_data& operator=(type_data const& source);
+	type_data& operator=(const type_data& source);
 };
 
 class value {
 public:
 	value()
-		: data(NULL) {}
+		: data(NULL)
+	{
+	}
 
-	value(type_data* t, long double v)
+	value(type_data* type, long double val)
 	{
 		data = new body();
 		data->ref_count = 1;
-		data->type = t;
-		data->real_value = v;
+		data->type = type;
+		data->real_value = val;
 	}
 
-	value(type_data* t, wchar_t v)
+	value(type_data* type, wchar_t val)
 	{
 		data = new body();
 		data->ref_count = 1;
-		data->type = t;
-		data->char_value = v;
+		data->type = type;
+		data->char_value = val;
 	}
 
-	value(type_data* t, bool v)
+	value(type_data* type, bool val)
 	{
 		data = new body();
 		data->ref_count = 1;
-		data->type = t;
-		data->boolean_value = v;
+		data->type = type;
+		data->boolean_value = val;
 	}
 
-	value(type_data* t, std::wstring v);
+	value(type_data* type, const std::wstring& val);
 
-	value(value const& source)
+	value(const value& source)
 	{
 		data = source.data;
 		if (data != NULL)
@@ -281,7 +276,7 @@ public:
 		release();
 	}
 
-	value& operator=(value const& source)
+	value& operator=(const value& source)
 	{
 		if (source.data != NULL) {
 			++(source.data->ref_count);
@@ -296,29 +291,29 @@ public:
 		return data != NULL;
 	}
 
-	void set(type_data* t, long double v)
+	void set(type_data* type, long double val)
 	{
 		unique();
-		data->type = t;
-		data->real_value = v;
+		data->type = type;
+		data->real_value = val;
 	}
 
-	void set(type_data* t, bool v)
+	void set(type_data* type, bool val)
 	{
 		unique();
-		data->type = t;
-		data->boolean_value = v;
+		data->type = type;
+		data->boolean_value = val;
 	}
 
-	void append(type_data* t, value const& x);
-	void concatenate(value const& x);
+	void append(type_data* type, const value& val);
+	void concatenate(const value& val);
 
 	long double as_real() const;
 	wchar_t as_char() const;
 	bool as_boolean() const;
 	std::wstring as_string() const;
 	unsigned length_as_array() const;
-	value const& index_as_array(unsigned i) const;
+	const value& index_as_array(unsigned i) const;
 	value& index_as_array(unsigned i);
 	type_data* get_type() const;
 
@@ -335,7 +330,7 @@ public:
 		}
 	}
 
-	void overwrite(value const& source); //危険！外から呼ぶな
+	void overwrite(const value& source); //危険！外から呼ぶな
 
 private:
 	inline void release()
@@ -365,10 +360,10 @@ private:
 class script_engine;
 class script_machine;
 
-typedef value (*callback)(script_machine* machine, int argc, value const* argv);
+typedef value (*callback)(script_machine* machine, int argc, const value* argv);
 
 struct function {
-	char const* name;
+	const char* name;
 	callback func;
 	unsigned arguments;
 };
@@ -400,8 +395,8 @@ public:
 	type_data* get_array_type(type_data* element);
 
 private:
-	script_type_manager(script_type_manager const&);
-	script_type_manager& operator=(script_type_manager const& source);
+	script_type_manager(const script_type_manager&);
+	script_type_manager& operator=(const script_type_manager& source);
 
 	std::list<type_data> types; //中身のポインタを使うのでアドレスが変わらないようにlist
 	type_data* real_type;
@@ -412,65 +407,31 @@ private:
 
 class script_engine {
 public:
-	script_engine(script_type_manager* a_type_manager, std::string const& source, int funcc, function const* funcv);
-	script_engine(script_type_manager* a_type_manager, std::vector<char> const& source, int funcc, function const* funcv);
+	script_engine(script_type_manager* a_type_manager, const std::string& source, int funcc, const function* funcv);
+	script_engine(script_type_manager* a_type_manager, const std::vector<char>& source, int funcc, const function* funcv);
 	virtual ~script_engine();
 
 	void* data; //クライアント用空間
 
-	bool get_error()
-	{
-		return error;
-	}
-
-	std::wstring& get_error_message()
-	{
-		return error_message;
-	}
-
-	int get_error_line()
-	{
-		return error_line;
-	}
-
-	script_type_manager* get_type_manager()
-	{
-		return type_manager;
-	}
+	bool get_error() const { return error; }
+	std::wstring& get_error_message() { return error_message; }
+	int get_error_line() const { return error_line; }
+	script_type_manager* get_type_manager() { return type_manager; }
 
 	//compatibility
-	type_data* get_real_type()
-	{
-		return type_manager->get_real_type();
-	}
-
-	type_data* get_char_type()
-	{
-		return type_manager->get_char_type();
-	}
-
-	type_data* get_boolean_type()
-	{
-		return type_manager->get_boolean_type();
-	}
-
-	type_data* get_array_type(type_data* element)
-	{
-		return type_manager->get_array_type(element);
-	}
-
-	type_data* get_string_type()
-	{
-		return type_manager->get_string_type();
-	}
+	type_data* get_real_type() { return type_manager->get_real_type(); }
+	type_data* get_char_type() { return type_manager->get_char_type(); }
+	type_data* get_boolean_type() { return type_manager->get_boolean_type(); }
+	type_data* get_array_type(type_data* element) { return type_manager->get_array_type(element); }
+	type_data* get_string_type() { return type_manager->get_string_type(); }
 
 #ifndef _MSC_VER
 private:
 #endif
 
 	//コピー、代入演算子の自動生成を無効に
-	script_engine(script_engine const& source);
-	script_engine& operator=(script_engine const& source);
+	script_engine(const script_engine& source);
+	script_engine& operator=(const script_engine& source);
 
 	//エラー
 	bool error;
@@ -571,7 +532,7 @@ private:
 		{
 		}
 
-		code(int the_line, command_kind the_command, value const& the_data)
+		code(int the_line, command_kind the_command, const value& the_data)
 			: line(the_line)
 			, command(the_command)
 			, data(the_data)
@@ -632,7 +593,7 @@ public:
 	void* data; //クライアント用空間
 
 	void run();
-	void call(std::string event_name);
+	void call(const std::string& event_name);
 	void resume();
 
 	void stop()
@@ -641,38 +602,19 @@ public:
 		stopped = true;
 	}
 
-	bool get_stopped()
-	{
-		return stopped;
-	}
+	bool get_stopped() const { return stopped; }
+	bool get_resuming() const { return resuming; }
+	bool get_error() const { return error; }
+	std::wstring& get_error_message() { return error_message; }
+	int get_error_line() const { return error_line; }
 
-	bool get_resuming()
-	{
-		return resuming;
-	}
-
-	bool get_error()
-	{
-		return error;
-	}
-
-	std::wstring& get_error_message()
-	{
-		return error_message;
-	}
-
-	int get_error_line()
-	{
-		return error_line;
-	}
-
-	void raise_error(std::wstring const& message)
+	void raise_error(const std::wstring& message)
 	{
 		error = true;
 		error_message = message;
 		finished = true;
 	}
-	void terminate(std::wstring const& message)
+	void terminate(const std::wstring& message)
 	{
 		bTerminate = true;
 		error = true;
@@ -680,21 +622,18 @@ public:
 		finished = true;
 	}
 
-	script_engine* get_engine()
-	{
-		return engine;
-	}
+	script_engine* get_engine() { return engine; }
 
-	bool has_event(std::string event_name);
+	bool has_event(const std::string& event_name) const;
 
-	int get_current_line();
+	int get_current_line() const;
 
-	int get_thread_count() { return threads.size(); }
+	int get_thread_count() const { return threads.size(); }
 
 private:
 	script_machine();
-	script_machine(script_machine const& source);
-	script_machine& operator=(script_machine const& source);
+	script_machine(const script_machine& source);
+	script_machine& operator=(const script_machine& source);
 
 	script_engine* engine;
 
@@ -748,7 +687,7 @@ private:
 template <int num>
 class constant {
 public:
-	static value func(script_machine* machine, int argc, value const* argv)
+	static value func(script_machine* machine, int argc, const value* argv)
 	{
 		return value(machine->get_engine()->get_real_type(), (long double)num);
 	}

--- a/source/GcLib/gstd/Script.hpp
+++ b/source/GcLib/gstd/Script.hpp
@@ -40,14 +40,12 @@ std::wstring to_wide(const std::string& s);
 template <typename T>
 class lightweight_vector {
 public:
-	unsigned length;
-	unsigned capacity;
+	unsigned length {0};
+	unsigned capacity {0};
 	T* at;
 
 	lightweight_vector()
-		: length(0)
-		, capacity(0)
-		, at(NULL)
+		: at(nullptr)
 	{
 	}
 
@@ -55,7 +53,7 @@ public:
 
 	~lightweight_vector()
 	{
-		if (at != NULL) {
+		if (at != nullptr) {
 			delete[] at;
 		}
 	}
@@ -88,9 +86,9 @@ public:
 	void release()
 	{
 		length = 0;
-		if (at != NULL) {
+		if (at != nullptr) {
 			delete[] at;
-			at = NULL;
+			at = nullptr;
 			capacity = 0;
 		}
 	}
@@ -134,14 +132,14 @@ lightweight_vector<T>::lightweight_vector(const lightweight_vector & source)
 		for (int i = length - 1; i >= 0; --i)
 			at[i] = source.at[i];
 	} else {
-		at = NULL;
+		at = nullptr;
 	}
 }
 
 template <typename T>
 lightweight_vector<T>& lightweight_vector<T>::operator=(const lightweight_vector<T> & source)
 {
-	if (at != NULL)
+	if (at != nullptr)
 		delete[] at;
 	length = source.length;
 	capacity = source.capacity;
@@ -150,7 +148,7 @@ lightweight_vector<T>& lightweight_vector<T>::operator=(const lightweight_vector
 		for (int i = length - 1; i >= 0; --i)
 			at[i] = source.at[i];
 	} else {
-		at = NULL;
+		at = nullptr;
 	}
 	return *this;
 }
@@ -207,13 +205,13 @@ public:
 		tk_array
 	};
 
-	type_data(type_kind k, type_data* t = NULL)
+	type_data(type_kind k, type_data* t = nullptr)
 		: kind(k)
 		, element(t)
 	{
 	}
 
-	type_data(type_data const& source)
+	type_data(const type_data& source)
 		: kind(source.kind)
 		, element(source.element)
 	{
@@ -228,15 +226,12 @@ private:
 	type_kind kind;
 	type_data* element;
 
-	type_data& operator=(const type_data& source);
+	type_data& operator=(const type_data& source) = delete;
 };
 
 class value {
 public:
-	value()
-		: data(NULL)
-	{
-	}
+	value() = default;
 
 	value(type_data* type, long double val)
 	{
@@ -267,7 +262,7 @@ public:
 	value(const value& source)
 	{
 		data = source.data;
-		if (data != NULL)
+		if (data != nullptr)
 			++(data->ref_count);
 	}
 
@@ -278,7 +273,7 @@ public:
 
 	value& operator=(const value& source)
 	{
-		if (source.data != NULL) {
+		if (source.data != nullptr) {
 			++(source.data->ref_count);
 		}
 		release();
@@ -288,7 +283,7 @@ public:
 
 	bool has_data() const
 	{
-		return data != NULL;
+		return data != nullptr;
 	}
 
 	void set(type_data* type, long double val)
@@ -319,10 +314,10 @@ public:
 
 	void unique() const
 	{
-		if (data == NULL) {
+		if (data == nullptr) {
 			data = new body();
 			data->ref_count = 1;
-			data->type = NULL;
+			data->type = nullptr;
 		} else if (data->ref_count > 1) {
 			--(data->ref_count);
 			data = new body(*data);
@@ -335,7 +330,7 @@ public:
 private:
 	inline void release()
 	{
-		if (data != NULL) {
+		if (data != nullptr) {
 			--(data->ref_count);
 			if (data->ref_count == 0) {
 				delete data;
@@ -354,7 +349,7 @@ private:
 		};
 	};
 
-	mutable body* data;
+	mutable body* data {nullptr};
 };
 
 class script_engine;
@@ -395,8 +390,8 @@ public:
 	type_data* get_array_type(type_data* element);
 
 private:
-	script_type_manager(const script_type_manager&);
-	script_type_manager& operator=(const script_type_manager& source);
+	script_type_manager(const script_type_manager&) = delete;
+	script_type_manager& operator=(const script_type_manager& source) = delete;
 
 	std::list<type_data> types; //中身のポインタを使うのでアドレスが変わらないようにlist
 	type_data* real_type;
@@ -499,9 +494,7 @@ private:
 			};
 		};
 
-		code()
-		{
-		}
+		code() = default;
 
 		code(int the_line, command_kind the_command)
 			: line(the_line)
@@ -563,9 +556,7 @@ private:
 		block(int the_level, block_kind the_kind)
 			: level(the_level)
 			, arguments(0)
-			, name()
-			, func(NULL)
-			, codes()
+			, func(nullptr)
 			, kind(the_kind)
 		{
 		}
@@ -631,9 +622,9 @@ public:
 	int get_thread_count() const { return threads.size(); }
 
 private:
-	script_machine();
-	script_machine(const script_machine& source);
-	script_machine& operator=(const script_machine& source);
+	script_machine() = delete;
+	script_machine(const script_machine& source) = delete;
+	script_machine& operator=(const script_machine& source) = delete;
 
 	script_engine* engine;
 

--- a/source/GcLib/gstd/ScriptClient.cpp
+++ b/source/GcLib/gstd/ScriptClient.cpp
@@ -12,9 +12,7 @@ ScriptEngineData::ScriptEngineData()
 	encoding_ = Encoding::UNKNOWN;
 	mapLine_ = new ScriptFileLineMap();
 }
-ScriptEngineData::~ScriptEngineData()
-{
-}
+ScriptEngineData::~ScriptEngineData() = default;
 void ScriptEngineData::SetSource(const std::vector<char>& source)
 {
 	encoding_ = Encoding::SHIFT_JIS;
@@ -27,12 +25,8 @@ void ScriptEngineData::SetSource(const std::vector<char>& source)
 /**********************************************************
 //ScriptEngineCache
 **********************************************************/
-ScriptEngineCache::ScriptEngineCache()
-{
-}
-ScriptEngineCache::~ScriptEngineCache()
-{
-}
+ScriptEngineCache::ScriptEngineCache() = default;
+ScriptEngineCache::~ScriptEngineCache() = default;
 void ScriptEngineCache::Clear()
 {
 	cache_.clear();
@@ -44,7 +38,7 @@ void ScriptEngineCache::AddCache(const std::wstring& name, ref_count_ptr<ScriptE
 ref_count_ptr<ScriptEngineData> ScriptEngineCache::GetCache(const std::wstring& name)
 {
 	if (!IsExists(name))
-		return NULL;
+		return nullptr;
 	return cache_[name];
 }
 bool ScriptEngineCache::IsExists(const std::wstring& name) const
@@ -127,7 +121,7 @@ ScriptClientBase::ScriptClientBase()
 {
 	bError_ = false;
 	engine_ = new ScriptEngineData();
-	machine_ = NULL;
+	machine_ = nullptr;
 	mainThreadID_ = -1;
 	idScript_ = ID_SCRIPT_FREE;
 	valueRes_ = value();
@@ -139,10 +133,10 @@ ScriptClientBase::ScriptClientBase()
 }
 ScriptClientBase::~ScriptClientBase()
 {
-	if (machine_ != NULL)
+	if (machine_ != nullptr)
 		delete machine_;
-	machine_ = NULL;
-	engine_ = NULL;
+	machine_ = nullptr;
+	engine_ = nullptr;
 }
 
 void ScriptClientBase::_AddFunction(char const* name, callback f, unsigned arguments)
@@ -207,16 +201,16 @@ std::wstring ScriptClientBase::_GetErrorLineSource(int line)
 		if (encoding == Encoding::UTF16LE) {
 			wchar_t ch = (wchar_t&)*pbuf;
 			if (ch == L'\n')
-				tLine++;
+				++tLine;
 			pbuf += 2;
 
 		} else {
-			if (IsDBCSLeadByte(*pbuf))
+			if (IsDBCSLeadByte(*pbuf) != 0)
 				pbuf += 2;
 			else {
 				if (*pbuf == '\n')
-					tLine++;
-				pbuf++;
+					++tLine;
+				++pbuf;
 			}
 		}
 	}
@@ -232,7 +226,7 @@ std::wstring ScriptClientBase::_GetErrorLineSource(int line)
 	const int size = max(count - 1, 0);
 	std::wstring res;
 	if (encoding == Encoding::UTF16LE) {
-		const wchar_t* wbufS = (const wchar_t*)sbuf;
+		const auto* wbufS = (const wchar_t*)sbuf;
 		const wchar_t* wbufE = wbufS + size;
 		res = std::wstring(wbufS, wbufE);
 	} else {
@@ -271,7 +265,8 @@ std::vector<char> ScriptClientBase::_Include(std::vector<char>& source)
 			Token& tok = scanner.Next();
 			if (tok.GetType() == Token::TK_EOF) { //Eofの識別子が来たらファイルの調査終了
 				break;
-			} else if (tok.GetType() == Token::TK_SHARP) {
+			}
+			if (tok.GetType() == Token::TK_SHARP) {
 				int posInclude = scanner.GetCurrentPointer() - 1;
 				if (encoding == Encoding::UTF16LE)
 					posInclude--;
@@ -334,7 +329,7 @@ std::vector<char> ScriptClientBase::_Include(std::vector<char>& source)
 				std::vector<char> placement;
 				ref_count_ptr<FileReader> reader;
 				reader = fileManager->GetFileReader(wPath);
-				if (reader == NULL || !reader->Open()) {
+				if (reader == nullptr || !reader->Open()) {
 					int line = scanner.GetCurrentLine();
 					source = res;
 					engine_->SetSource(source);
@@ -443,10 +438,8 @@ std::vector<char> ScriptClientBase::_Include(std::vector<char>& source)
 					}
 
 					std::list<ScriptFileLineMap::Entry> listEntry = mapLine->GetEntryList();
-					std::list<ScriptFileLineMap::Entry>::iterator itr = listEntry.begin();
-					for (; itr != listEntry.end(); itr++) {
+					for (auto& entry : listEntry) {
 						if (encoding == Encoding::UTF16LE) {
-							ScriptFileLineMap::Entry entry = (*itr);
 							std::wstring strPath = entry.path_ + L"\r\n";
 							std::wstring strLineStart = StringUtility::Format(L"  lineStart   :%4d\r\n", entry.lineStart_);
 							std::wstring strLineEnd = StringUtility::Format(L"  lineEnd     :%4d\r\n", entry.lineEnd_);
@@ -460,7 +453,6 @@ std::vector<char> ScriptClientBase::_Include(std::vector<char>& source)
 							file.Write(&strLineEndOrg[0], strLineEndOrg.size() * sizeof(wchar_t));
 							file.Write(&strNewLineW[0], strNewLineW.size() * sizeof(wchar_t));
 						} else {
-							ScriptFileLineMap::Entry entry = (*itr);
 							std::string strPath = StringUtility::ConvertWideToMulti(entry.path_) + "\r\n";
 							std::string strLineStart = StringUtility::Format("  lineStart   :%4d\r\n", entry.lineStart_);
 							std::string strLineEnd = StringUtility::Format("  lineEnd     :%4d\r\n", entry.lineEnd_);
@@ -476,7 +468,7 @@ std::vector<char> ScriptClientBase::_Include(std::vector<char>& source)
 						}
 					}
 
-					countTest++;
+					++countTest;
 				}
 
 				break;
@@ -492,9 +484,9 @@ std::vector<char> ScriptClientBase::_Include(std::vector<char>& source)
 }
 bool ScriptClientBase::_CreateEngine()
 {
-	if (machine_ != NULL)
+	if (machine_ != nullptr)
 		delete machine_;
-	machine_ = NULL;
+	machine_ = nullptr;
 
 	const std::vector<char>& source = engine_->GetSource();
 
@@ -505,7 +497,7 @@ bool ScriptClientBase::_CreateEngine()
 bool ScriptClientBase::SetSourceFromFile(const std::wstring& p_path)
 {
 	std::wstring path = PathProperty::GetUnique(p_path);
-	if (cache_ != NULL && cache_->IsExists(path)) {
+	if (cache_ != nullptr && cache_->IsExists(path)) {
 		engine_ = cache_->GetCache(path);
 		return true;
 	}
@@ -513,10 +505,10 @@ bool ScriptClientBase::SetSourceFromFile(const std::wstring& p_path)
 	engine_->SetPath(path);
 	ref_count_ptr<FileReader> reader;
 	reader = FileManager::GetBase()->GetFileReader(path);
-	if (reader == NULL)
-		throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path).c_str());
+	if (reader == nullptr)
+		throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path));
 	if (!reader->Open())
-		throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path).c_str());
+		throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path));
 
 	int size = reader->GetFileSize();
 	std::vector<char> source;
@@ -540,7 +532,7 @@ void ScriptClientBase::SetSource(const std::vector<char>& source)
 }
 void ScriptClientBase::Compile()
 {
-	if (engine_->GetEngine() == NULL) {
+	if (engine_->GetEngine() == nullptr) {
 		std::vector<char> source = _Include(engine_->GetSource());
 		engine_->SetSource(source);
 
@@ -549,12 +541,12 @@ void ScriptClientBase::Compile()
 			bError_ = true;
 			_RaiseErrorFromEngine();
 		}
-		if (cache_ != NULL && engine_->GetPath().size() != 0) {
+		if (cache_ != nullptr && !engine_->GetPath().empty()) {
 			cache_->AddCache(engine_->GetPath(), engine_);
 		}
 	}
 
-	if (machine_ != NULL)
+	if (machine_ != nullptr)
 		delete machine_;
 	machine_ = new script_machine(engine_->GetEngine().GetPointer());
 	if (machine_->get_error()) {
@@ -603,7 +595,7 @@ bool ScriptClientBase::IsEventExists(const std::string& name) const
 }
 int ScriptClientBase::GetThreadCount() const
 {
-	if (machine_ == NULL)
+	if (machine_ == nullptr)
 		return 0;
 	int res = machine_->get_thread_count();
 	return res;
@@ -641,8 +633,8 @@ value ScriptClientBase::CreateRealArrayValue(const std::vector<long double>& lis
 {
 	script_type_manager* typeManager = GetEngine()->GetEngine().GetPointer()->get_type_manager();
 	value res(typeManager->get_string_type(), std::wstring());
-	for (int iData = 0; iData < list.size(); iData++) {
-		value data = CreateRealValue(list[iData]);
+	for (long double iData : list) {
+		value data = CreateRealValue(iData);
 		res.append(typeManager->get_array_type(typeManager->get_real_type()), data);
 	}
 
@@ -652,8 +644,8 @@ value ScriptClientBase::CreateStringArrayValue(const std::vector<std::string>& l
 {
 	script_type_manager* typeManager = GetEngine()->GetEngine().GetPointer()->get_type_manager();
 	value res(typeManager->get_string_type(), std::wstring());
-	for (int iData = 0; iData < list.size(); iData++) {
-		value data = CreateStringValue(list[iData]);
+	for (const auto& iData : list) {
+		value data = CreateStringValue(iData);
 		res.append(typeManager->get_array_type(typeManager->get_string_type()), data);
 	}
 
@@ -663,8 +655,8 @@ value ScriptClientBase::CreateStringArrayValue(const std::vector<std::wstring>& 
 {
 	script_type_manager* typeManager = GetEngine()->GetEngine().GetPointer()->get_type_manager();
 	value res(typeManager->get_string_type(), std::wstring());
-	for (int iData = 0; iData < list.size(); iData++) {
-		value data = CreateStringValue(list[iData]);
+	for (const auto& iData : list) {
+		value data = CreateStringValue(iData);
 		res.append(typeManager->get_array_type(typeManager->get_string_type()), data);
 	}
 
@@ -674,8 +666,7 @@ value ScriptClientBase::CreateValueArrayValue(const std::vector<value>& list)
 {
 	script_type_manager* typeManager = GetEngine()->GetEngine().GetPointer()->get_type_manager();
 	value res(typeManager->get_string_type(), std::wstring());
-	for (int iData = 0; iData < list.size(); iData++) {
-		value data = list[iData];
+	for (const auto& data : list) {
 		res.append(typeManager->get_array_type(typeManager->get_real_type()), data);
 	}
 	return res;
@@ -745,7 +736,7 @@ std::wstring ScriptClientBase::_ExtendPath(const std::wstring& path)
 //共通関数：スクリプト引数結果
 value ScriptClientBase::Func_GetScriptArgument(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	int index = (int)argv[0].as_real();
 	if (index < 0 || index >= script->listValueArg_.size()) {
 		std::wstring error;
@@ -757,13 +748,13 @@ value ScriptClientBase::Func_GetScriptArgument(script_machine* machine, int argc
 }
 value ScriptClientBase::Func_GetScriptArgumentCount(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	int res = script->listValueArg_.size();
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 value ScriptClientBase::Func_SetScriptResult(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	script->valueRes_ = argv[0];
 	return value();
 }
@@ -821,7 +812,7 @@ value ScriptClientBase::Func_Atan2(script_machine* machine, int argc, value cons
 }
 value ScriptClientBase::Func_Rand(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	script->CheckRunInMainThread();
 
 	double min = argv[0].as_real();
@@ -852,7 +843,7 @@ value ScriptClientBase::Func_RtoA(script_machine* machine, int argc, value const
 }
 value ScriptClientBase::Func_RtoS(script_machine* machine, int argc, value const* argv)
 {
-	std::string res = "";
+	std::string res;
 	std::string fmtV = to_mbcs(argv[0].as_string());
 	double num = argv[1].as_real();
 
@@ -862,26 +853,25 @@ value ScriptClientBase::Func_RtoS(script_machine* machine, int argc, value const
 		int countI0 = 0;
 		int countF = 0;
 
-		for (int iCh = 0; iCh < fmtV.size(); iCh++) {
-			char ch = fmtV[iCh];
+		for (char ch : fmtV) {
 			if (IsDBCSLeadByte(ch))
 				throw false;
 
 			if (ch == '#')
-				countIS++;
+				++countIS;
 			else if (ch == '.' && bF)
 				throw false;
 			else if (ch == '.')
 				bF = true;
 			else if (ch == '0') {
 				if (bF)
-					countF++;
+					++countF;
 				else
-					countI0++;
+					++countI0;
 			}
 		}
 
-		std::string fmt = "";
+		std::string fmt;
 		if (countI0 > 0 && countF >= 0) {
 			fmt += "%0";
 			fmt += StringUtility::Format("%d", countI0);
@@ -896,7 +886,7 @@ value ScriptClientBase::Func_RtoS(script_machine* machine, int argc, value const
 			fmt += "f";
 		}
 
-		if (fmt.size() > 0) {
+		if (!fmt.empty()) {
 			res = StringUtility::Format((char*)fmt.c_str(), num);
 		}
 	} catch (...) {
@@ -907,7 +897,7 @@ value ScriptClientBase::Func_RtoS(script_machine* machine, int argc, value const
 }
 value ScriptClientBase::Func_VtoS(script_machine* machine, int argc, value const* argv)
 {
-	std::string res = "";
+	std::string res;
 	std::string fmtV = to_mbcs(argv[0].as_string());
 
 	try {
@@ -916,8 +906,7 @@ value ScriptClientBase::Func_VtoS(script_machine* machine, int argc, value const
 		int countF = 0;
 
 		int advance = 0; //0:-, 1:0, 2:num, 3:[d,s,f], 4:., 5:num
-		for (int iCh = 0; iCh < fmtV.size(); iCh++) {
-			char ch = fmtV[iCh];
+		for (char ch : fmtV) {
 			if (IsDBCSLeadByte(ch))
 				throw false;
 			if (advance == 0 && ch == '-')
@@ -926,9 +915,9 @@ value ScriptClientBase::Func_VtoS(script_machine* machine, int argc, value const
 				advance = 2;
 			else if (advance == 2 && (ch == 'd' || ch == 's' || ch == 'f'))
 				advance = 4;
-			else if (advance == 2 && ('.'))
+			else if (advance == 2 && (('.') != 0))
 				advance = 5;
-			else if (advance == 4 && ('.'))
+			else if (advance == 4 && (('.') != 0))
 				advance = 5;
 			else if (advance == 5 && (ch >= '0' && ch <= '9'))
 				advance = 5;
@@ -940,11 +929,11 @@ value ScriptClientBase::Func_VtoS(script_machine* machine, int argc, value const
 
 		fmtV = std::string("%") + fmtV;
 		char* fmt = (char*)fmtV.c_str();
-		if (strstr(fmt, "d") != NULL)
+		if (strstr(fmt, "d") != nullptr)
 			res = StringUtility::Format(fmt, (int)argv[1].as_real());
-		else if (strstr(fmt, "f") != NULL)
+		else if (strstr(fmt, "f") != nullptr)
 			res = StringUtility::Format(fmt, argv[1].as_real());
-		else if (strstr(fmt, "s") != NULL)
+		else if (strstr(fmt, "s") != nullptr)
 			res = StringUtility::Format(fmt, to_mbcs(argv[1].as_string()).c_str());
 	} catch (...) {
 		res = "error format";
@@ -972,7 +961,7 @@ value ScriptClientBase::Func_TrimString(script_machine* machine, int argc, value
 }
 value ScriptClientBase::Func_SplitString(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	std::wstring str = argv[0].as_string();
 	std::wstring delim = argv[1].as_string();
 	std::vector<std::wstring> list = StringUtility::Split(str, delim);
@@ -989,14 +978,14 @@ value ScriptClientBase::Func_GetModuleDirectory(script_machine* machine, int arg
 }
 value ScriptClientBase::Func_GetMainScriptDirectory(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	std::wstring path = script->GetEngine()->GetPath();
 	std::wstring res = PathProperty::GetFileDirectory(path);
 	return value(machine->get_engine()->get_string_type(), res);
 }
 value ScriptClientBase::Func_GetCurrentScriptDirectory(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	int line = machine->get_current_line();
 	std::wstring path = script->GetEngine()->GetScriptFileLineMap()->GetPath(line);
 	std::wstring res = PathProperty::GetFileDirectory(path);
@@ -1004,7 +993,7 @@ value ScriptClientBase::Func_GetCurrentScriptDirectory(script_machine* machine, 
 }
 value ScriptClientBase::Func_GetFileDirectory(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	std::wstring path = argv[0].as_string();
 	// path = StringUtility::ReplaceAll(path, "/", "\\");
 	std::wstring res = PathProperty::GetFileDirectory(path);
@@ -1012,7 +1001,7 @@ value ScriptClientBase::Func_GetFileDirectory(script_machine* machine, int argc,
 }
 value ScriptClientBase::Func_GetFilePathList(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	std::wstring path = argv[0].as_string();
 	std::wstring dir = PathProperty::GetFileDirectory(path);
 	std::vector<std::wstring> listDir = File::GetFilePathList(dir);
@@ -1021,7 +1010,7 @@ value ScriptClientBase::Func_GetFilePathList(script_machine* machine, int argc, 
 }
 value ScriptClientBase::Func_GetDirectoryList(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	std::wstring path = argv[0].as_string();
 	std::wstring dir = PathProperty::GetFileDirectory(path);
 	std::vector<std::wstring> listDir = File::GetDirectoryPathList(dir);
@@ -1052,7 +1041,7 @@ value ScriptClientBase::Func_WriteLog(script_machine* machine, int argc, value c
 }
 value ScriptClientBase::Func_RaiseError(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	std::wstring msg = argv[0].as_string();
 	script->RaiseError(msg);
 
@@ -1062,7 +1051,7 @@ value ScriptClientBase::Func_RaiseError(script_machine* machine, int argc, value
 //共通関数：共通データ
 value ScriptClientBase::Func_SetDefaultCommonDataArea(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 
 	std::string name = to_mbcs(argv[0].as_string());
@@ -1071,7 +1060,7 @@ value ScriptClientBase::Func_SetDefaultCommonDataArea(script_machine* machine, i
 }
 value ScriptClientBase::Func_SetCommonData(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 	std::string area = commonDataManager->GetDefaultAreaName();
 
@@ -1085,7 +1074,7 @@ value ScriptClientBase::Func_SetCommonData(script_machine* machine, int argc, va
 }
 value ScriptClientBase::Func_GetCommonData(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 	std::string area = commonDataManager->GetDefaultAreaName();
 
@@ -1100,7 +1089,7 @@ value ScriptClientBase::Func_GetCommonData(script_machine* machine, int argc, va
 }
 value ScriptClientBase::Func_ClearCommonData(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 	std::string area = commonDataManager->GetDefaultAreaName();
 
@@ -1112,7 +1101,7 @@ value ScriptClientBase::Func_ClearCommonData(script_machine* machine, int argc, 
 }
 value ScriptClientBase::Func_DeleteCommonData(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 	std::string area = commonDataManager->GetDefaultAreaName();
 
@@ -1125,7 +1114,7 @@ value ScriptClientBase::Func_DeleteCommonData(script_machine* machine, int argc,
 }
 value ScriptClientBase::Func_SetAreaCommonData(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 
 	std::string area = to_mbcs(argv[0].as_string());
@@ -1140,7 +1129,7 @@ value ScriptClientBase::Func_SetAreaCommonData(script_machine* machine, int argc
 }
 value ScriptClientBase::Func_GetAreaCommonData(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 
 	std::string area = to_mbcs(argv[0].as_string());
@@ -1155,7 +1144,7 @@ value ScriptClientBase::Func_GetAreaCommonData(script_machine* machine, int argc
 }
 value ScriptClientBase::Func_ClearAreaCommonData(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 
 	std::string area = to_mbcs(argv[0].as_string());
@@ -1167,7 +1156,7 @@ value ScriptClientBase::Func_ClearAreaCommonData(script_machine* machine, int ar
 }
 value ScriptClientBase::Func_DeleteAreaCommonData(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 
 	std::string area = to_mbcs(argv[0].as_string());
@@ -1180,7 +1169,7 @@ value ScriptClientBase::Func_DeleteAreaCommonData(script_machine* machine, int a
 }
 value ScriptClientBase::Func_CreateCommonDataArea(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 
 	std::string area = to_mbcs(argv[0].as_string());
@@ -1189,7 +1178,7 @@ value ScriptClientBase::Func_CreateCommonDataArea(script_machine* machine, int a
 }
 value ScriptClientBase::Func_CopyCommonDataArea(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 
 	std::string areaDest = to_mbcs(argv[0].as_string());
@@ -1200,7 +1189,7 @@ value ScriptClientBase::Func_CopyCommonDataArea(script_machine* machine, int arg
 }
 value ScriptClientBase::Func_IsCommonDataAreaExists(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 
 	std::string area = to_mbcs(argv[0].as_string());
@@ -1209,7 +1198,7 @@ value ScriptClientBase::Func_IsCommonDataAreaExists(script_machine* machine, int
 }
 value ScriptClientBase::Func_GetCommonDataAreaKeyList(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 
 	std::vector<std::string> listKey = commonDataManager->GetKeyList();
@@ -1218,7 +1207,7 @@ value ScriptClientBase::Func_GetCommonDataAreaKeyList(script_machine* machine, i
 }
 value ScriptClientBase::Func_GetCommonDataValueKeyList(script_machine* machine, int argc, value const* argv)
 {
-	ScriptClientBase* script = (ScriptClientBase*)machine->data;
+	auto* script = (ScriptClientBase*)machine->data;
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 
 	std::vector<std::string> listKey;
@@ -1234,13 +1223,10 @@ value ScriptClientBase::Func_GetCommonDataValueKeyList(script_machine* machine, 
 /**********************************************************
 //ScriptFileLineMap
 **********************************************************/
-ScriptFileLineMap::ScriptFileLineMap()
-{
-}
-ScriptFileLineMap::~ScriptFileLineMap()
-{
-}
-void ScriptFileLineMap::AddEntry(std::wstring path, int lineAdd, int lineCount)
+ScriptFileLineMap::ScriptFileLineMap() = default;
+ScriptFileLineMap::~ScriptFileLineMap() = default;
+
+void ScriptFileLineMap::AddEntry(const std::wstring& path, int lineAdd, int lineCount)
 {
 	Entry entryNew;
 	entryNew.path_ = path;
@@ -1248,12 +1234,12 @@ void ScriptFileLineMap::AddEntry(std::wstring path, int lineAdd, int lineCount)
 	entryNew.lineEndOriginal_ = lineCount;
 	entryNew.lineStart_ = lineAdd;
 	entryNew.lineEnd_ = entryNew.lineStart_ + lineCount - 1;
-	if (listEntry_.size() == 0) {
+	if (listEntry_.empty()) {
 		listEntry_.push_back(entryNew);
 		return;
 	}
 
-	Entry* pEntryDivide = NULL;
+	Entry* pEntryDivide = nullptr;
 	std::list<Entry>::iterator itrInsert;
 	for (itrInsert = listEntry_.begin(); itrInsert != listEntry_.end(); itrInsert++) {
 		pEntryDivide = (Entry*)&*itrInsert;
@@ -1263,14 +1249,14 @@ void ScriptFileLineMap::AddEntry(std::wstring path, int lineAdd, int lineCount)
 
 	Entry& entryDivide = *pEntryDivide;
 	if (entryDivide.lineStart_ == lineAdd) {
-		entryDivide.lineStartOriginal_++;
+		++(entryDivide.lineStartOriginal_);
 		listEntry_.insert(itrInsert, entryNew);
 	} else if (entryDivide.lineEnd_ == lineAdd) {
-		entryDivide.lineEnd_--;
-		entryDivide.lineEndOriginal_--;
+		--(entryDivide.lineEnd_);
+		--(entryDivide.lineEndOriginal_);
 
 		listEntry_.insert(itrInsert, entryNew);
-		itrInsert++;
+		++itrInsert;
 	} else {
 		Entry entryNew2 = entryDivide;
 		entryDivide.lineEnd_ = lineAdd - 1;
@@ -1281,7 +1267,7 @@ void ScriptFileLineMap::AddEntry(std::wstring path, int lineAdd, int lineCount)
 		entryNew2.lineEnd_ += lineCount - 1;
 
 		if (itrInsert != listEntry_.end())
-			itrInsert++;
+			++itrInsert;
 		listEntry_.insert(itrInsert, entryNew);
 		listEntry_.insert(itrInsert, entryNew2);
 	}
@@ -1316,9 +1302,7 @@ ScriptCommonDataManager::ScriptCommonDataManager()
 	nameAreaDefailt_ = "";
 	CreateArea("");
 }
-ScriptCommonDataManager::~ScriptCommonDataManager()
-{
-}
+ScriptCommonDataManager::~ScriptCommonDataManager() = default;
 void ScriptCommonDataManager::Clear()
 {
 	mapData_.clear();
@@ -1343,7 +1327,7 @@ void ScriptCommonDataManager::CopyArea(const std::string& nameDest, const std::s
 gstd::ref_count_ptr<ScriptCommonData> ScriptCommonDataManager::GetData(const std::string& name)
 {
 	if (!IsExists(name))
-		return NULL;
+		return nullptr;
 	return mapData_[name];
 }
 void ScriptCommonDataManager::SetData(const std::string& name, gstd::ref_count_ptr<ScriptCommonData> commonData)
@@ -1363,12 +1347,8 @@ std::vector<std::string> ScriptCommonDataManager::GetKeyList()
 /**********************************************************
 //ScriptCommonData
 **********************************************************/
-ScriptCommonData::ScriptCommonData()
-{
-}
-ScriptCommonData::~ScriptCommonData()
-{
-}
+ScriptCommonData::ScriptCommonData() = default;
+ScriptCommonData::~ScriptCommonData() = default;
 void ScriptCommonData::Clear()
 {
 	mapValue_.clear();
@@ -1395,8 +1375,7 @@ void ScriptCommonData::Copy(gstd::ref_count_ptr<ScriptCommonData> dataSrc)
 {
 	mapValue_.clear();
 	std::vector<std::string> listSrcKey = dataSrc->GetKeyList();
-	for (int iKey = 0; iKey < listSrcKey.size(); iKey++) {
-		std::string key = listSrcKey[iKey];
+	for (const auto& key : listSrcKey) {
 		gstd::value vSrc = dataSrc->GetValue(key);
 		gstd::value vDest = vSrc;
 		vDest.unique();
@@ -1406,9 +1385,8 @@ void ScriptCommonData::Copy(gstd::ref_count_ptr<ScriptCommonData> dataSrc)
 std::vector<std::string> ScriptCommonData::GetKeyList()
 {
 	std::vector<std::string> res;
-	std::map<std::string, gstd::value>::iterator itrValue;
-	for (itrValue = mapValue_.begin(); itrValue != mapValue_.end(); itrValue++) {
-		std::string key = itrValue->first;
+	for (const auto& itrValue : mapValue_) {
+		std::string key = itrValue.first;
 		res.push_back(key);
 	}
 	return res;
@@ -1418,8 +1396,7 @@ void ScriptCommonData::ReadRecord(gstd::RecordBuffer& record)
 	mapValue_.clear();
 
 	std::vector<std::string> listKey = record.GetKeyList();
-	for (int iKey = 0; iKey < listKey.size(); iKey++) {
-		std::string key = listKey[iKey];
+	for (const auto& key : listKey) {
 		std::string keyValSize = StringUtility::Format("%s_size", key.c_str());
 		if (!record.IsExists(keyValSize)) //サイズ自身がキー登録されている
 			continue;
@@ -1436,7 +1413,7 @@ gstd::value ScriptCommonData::_ReadRecord(gstd::ByteBuffer& buffer)
 {
 	script_type_manager* scriptTypeManager = ScriptClientBase::GetDefaultScriptTypeManager();
 	gstd::value res;
-	type_data::type_kind kind = (type_data::type_kind)buffer.ReadInteger();
+	auto kind = (type_data::type_kind)buffer.ReadInteger();
 
 	if (kind == type_data::tk_real) {
 		long double data = buffer.ReadDouble();
@@ -1463,10 +1440,9 @@ gstd::value ScriptCommonData::_ReadRecord(gstd::ByteBuffer& buffer)
 }
 void ScriptCommonData::WriteRecord(gstd::RecordBuffer& record)
 {
-	std::map<std::string, gstd::value>::iterator itrValue;
-	for (itrValue = mapValue_.begin(); itrValue != mapValue_.end(); itrValue++) {
-		std::string key = itrValue->first;
-		gstd::value comVal = itrValue->second;
+	for (const auto& itrValue : mapValue_) {
+		std::string key = itrValue.first;
+		gstd::value comVal = itrValue.second;
 
 		gstd::ByteBuffer buffer;
 		_WriteRecord(buffer, comVal);
@@ -1491,7 +1467,7 @@ void ScriptCommonData::_WriteRecord(gstd::ByteBuffer& buffer, gstd::value& comVa
 		int arrayLength = comValue.length_as_array();
 		buffer.WriteInteger(arrayLength);
 
-		for (int iArray = 0; iArray < arrayLength; iArray++) {
+		for (int iArray = 0; iArray < arrayLength; ++iArray) {
 			value& arrayValue = comValue.index_as_array(iArray);
 			_WriteRecord(buffer, arrayValue);
 		}
@@ -1527,7 +1503,7 @@ bool ScriptCommonDataInfoPanel::_AddedLogger(HWND hTab)
 	wndListViewValue_.AddColumn(256, COL_VALUE, L"Value");
 
 	wndSplitter_.Create(hWnd_, WSplitter::TYPE_HORIZONTAL);
-	wndSplitter_.SetRatioY(0.25f);
+	wndSplitter_.SetRatioY(0.25F);
 
 	return true;
 }
@@ -1553,10 +1529,9 @@ void ScriptCommonDataInfoPanel::Update(gstd::ref_count_ptr<ScriptCommonDataManag
 		Lock lock(lock_);
 		commonDataManager_->Clear();
 
-		if (commonDataManager != NULL) {
+		if (commonDataManager != nullptr) {
 			std::vector<std::string> listKey = commonDataManager->GetKeyList();
-			for (int iKey = 0; iKey < listKey.size(); iKey++) {
-				std::string area = listKey[iKey];
+			for (const auto& area : listKey) {
 				gstd::ref_count_ptr<ScriptCommonData> dataSrc = commonDataManager->GetData(area);
 				gstd::ref_count_ptr<ScriptCommonData> dataDest = new ScriptCommonData();
 				dataDest->Copy(dataSrc);
@@ -1573,38 +1548,33 @@ void ScriptCommonDataInfoPanel::_UpdateListViewKey(WListView* listView, std::vec
 	std::set<std::string> listManageData;
 	std::set<std::string> listAdd;
 
-	int iKey = 0;
-	for (iKey = 0; iKey < listKey.size(); iKey++) {
-		std::string area = listKey[iKey];
+	for (const auto& area : listKey) {
 		listManageData.insert(area);
 		listAdd.insert(area);
 	}
 
 	int countView = listView->GetRowCount();
-	int iRow = 0;
-	for (iRow = 0; iRow < countView; iRow++) {
+	for (int iRow = 0; iRow < countView; ++iRow) {
 		std::wstring wArea = listView->GetText(iRow, COL_KEY);
 		std::string area = StringUtility::ConvertWideToMulti(wArea);
 		listAdd.erase(area);
 	}
 
 	//削除
-	for (iRow = 0; iRow < listView->GetRowCount();) {
+	for (int iRow = 0; iRow < listView->GetRowCount();) {
 		std::wstring wKey = listView->GetText(iRow, COL_KEY);
 		std::string key = StringUtility::ConvertWideToMulti(wKey);
 		if (listManageData.find(key) != listManageData.end())
-			iRow++;
+			++iRow;
 		else
 			listView->DeleteRow(iRow);
 	}
 
 	//追加
-	iRow = 0;
-	countView = listView->GetRowCount();
-	std::set<std::string>::iterator itr = listAdd.begin();
-	for (; itr != listAdd.end();) {
+	int iRow = 0;
+	for (auto itr = listAdd.begin(); itr != listAdd.end();) {
 		std::string str1 = *itr;
-		for (; iRow < listView->GetRowCount(); iRow++) {
+		for (; iRow < listView->GetRowCount(); ++iRow) {
 			std::wstring wstr2 = listView->GetText(iRow, COL_KEY);
 			std::string str2 = StringUtility::ConvertWideToMulti(wstr2);
 			int index = strcmp(str1.c_str(), str2.c_str());
@@ -1619,9 +1589,7 @@ void ScriptCommonDataInfoPanel::_UpdateListViewKey(WListView* listView, std::vec
 		itr = listAdd.erase(itr);
 	}
 
-	itr = listAdd.begin();
-	for (; itr != listAdd.end(); itr++) {
-		std::string str1 = *itr;
+	for (const auto& str1 : listAdd) {
 		std::wstring wstr1 = StringUtility::ConvertMultiToWide(str1);
 		listView->SetText(listView->GetRowCount(), COL_KEY, wstr1);
 	}
@@ -1647,7 +1615,7 @@ void ScriptCommonDataInfoPanel::_UpdateValueView()
 	_UpdateListViewKey(&wndListViewValue_, listKey);
 
 	int countView = wndListViewValue_.GetRowCount();
-	for (int iRow = 0; iRow < countView; iRow++) {
+	for (int iRow = 0; iRow < countView; ++iRow) {
 		std::wstring wKey = wndListViewValue_.GetText(iRow, COL_KEY);
 		std::string key = StringUtility::ConvertWideToMulti(wKey);
 		gstd::value val = commonData->GetValue(key);

--- a/source/GcLib/gstd/ScriptClient.hpp
+++ b/source/GcLib/gstd/ScriptClient.hpp
@@ -32,11 +32,11 @@ public:
 	ScriptEngineData();
 	virtual ~ScriptEngineData();
 
-	void SetPath(std::wstring path) { path_ = path; }
-	std::wstring GetPath() { return path_; }
-	void SetSource(std::vector<char>& source);
+	void SetPath(const std::wstring& path) { path_ = path; }
+	std::wstring GetPath() const { return path_; }
+	void SetSource(const std::vector<char>& source);
 	std::vector<char>& GetSource() { return source_; }
-	int GetEncoding() { return encoding_; }
+	int GetEncoding() const { return encoding_; }
 	void SetEngine(gstd::ref_count_ptr<script_engine> engine) { engine_ = engine; }
 	gstd::ref_count_ptr<script_engine> GetEngine() { return engine_; }
 	gstd::ref_count_ptr<ScriptFileLineMap> GetScriptFileLineMap() { return mapLine_; }
@@ -59,9 +59,9 @@ public:
 	virtual ~ScriptEngineCache();
 	void Clear();
 
-	void AddCache(std::wstring name, ref_count_ptr<ScriptEngineData> data);
-	ref_count_ptr<ScriptEngineData> GetCache(std::wstring name);
-	bool IsExists(std::wstring name);
+	void AddCache(const std::wstring& name, ref_count_ptr<ScriptEngineData> data);
+	ref_count_ptr<ScriptEngineData> GetCache(const std::wstring& name);
+	bool IsExists(const std::wstring& name) const;
 
 protected:
 	std::map<std::wstring, ref_count_ptr<ScriptEngineData>> cache_;
@@ -85,103 +85,103 @@ public:
 	virtual ~ScriptClientBase();
 	void SetScriptEngineCache(gstd::ref_count_ptr<ScriptEngineCache> cache) { cache_ = cache; }
 	gstd::ref_count_ptr<ScriptEngineData> GetEngine() { return engine_; }
-	virtual bool SetSourceFromFile(std::wstring path);
-	virtual void SetSource(std::vector<char>& source);
-	virtual void SetSource(std::string source);
+	virtual bool SetSourceFromFile(const std::wstring& path);
+	virtual void SetSource(const std::vector<char>& source);
+	virtual void SetSource(const std::string& source);
 
 	std::wstring GetPath() { return engine_->GetPath(); }
-	void SetPath(std::wstring path) { engine_->SetPath(path); }
+	void SetPath(const std::wstring& path) { engine_->SetPath(path); }
 
 	virtual void Compile();
 	virtual bool Run();
-	virtual bool Run(std::string target);
-	bool IsEventExists(std::string name);
-	void RaiseError(std::wstring error) { _RaiseError(machine_->get_error_line(), error); }
-	void Terminate(std::wstring error) { machine_->terminate(error); }
-	_int64 GetScriptID() { return idScript_; }
-	int GetThreadCount();
+	virtual bool Run(const std::string& target);
+	bool IsEventExists(const std::string& name) const;
+	void RaiseError(const std::wstring& error) { _RaiseError(machine_->get_error_line(), error); }
+	void Terminate(const std::wstring& error) { machine_->terminate(error); }
+	_int64 GetScriptID() const { return idScript_; }
+	int GetThreadCount() const;
 
 	void AddArgumentValue(value v) { listValueArg_.push_back(v); }
 	void SetArgumentValue(value v, int index = 0);
-	value GetResultValue() { return valueRes_; }
+	value GetResultValue() const { return valueRes_; }
 
 	value CreateRealValue(long double r);
 	value CreateBooleanValue(bool b);
-	value CreateStringValue(std::string s);
-	value CreateStringValue(std::wstring s);
-	value CreateRealArrayValue(std::vector<long double>& list);
-	value CreateStringArrayValue(std::vector<std::string>& list);
-	value CreateStringArrayValue(std::vector<std::wstring>& list);
-	value CreateValueArrayValue(std::vector<value>& list);
-	bool IsRealValue(value& v);
-	bool IsBooleanValue(value& v);
-	bool IsStringValue(value& v);
-	bool IsRealArrayValue(value& v);
+	value CreateStringValue(const std::string& s);
+	value CreateStringValue(const std::wstring& s);
+	value CreateRealArrayValue(const std::vector<long double>& list);
+	value CreateStringArrayValue(const std::vector<std::string>& list);
+	value CreateStringArrayValue(const std::vector<std::wstring>& list);
+	value CreateValueArrayValue(const std::vector<value>& list);
+	bool IsRealValue(const value& v);
+	bool IsBooleanValue(const value& v);
+	bool IsStringValue(const value& v);
+	bool IsRealArrayValue(const value& v);
 
 	void CheckRunInMainThread();
 	ScriptCommonDataManager* GetCommonDataManager() { return commonDataManager_.GetPointer(); }
 
 	//共通関数：スクリプト引数結果
-	static value Func_GetScriptArgument(script_machine* machine, int argc, value const* argv);
-	static value Func_GetScriptArgumentCount(script_machine* machine, int argc, value const* argv);
-	static value Func_SetScriptResult(script_machine* machine, int argc, value const* argv);
+	static value Func_GetScriptArgument(script_machine* machine, int argc, const value* argv);
+	static value Func_GetScriptArgumentCount(script_machine* machine, int argc, const value* argv);
+	static value Func_SetScriptResult(script_machine* machine, int argc, const value* argv);
 
 	//共通関数：数学系
-	static value Func_Min(script_machine* machine, int argc, value const* argv);
-	static value Func_Max(script_machine* machine, int argc, value const* argv);
-	static value Func_Log(script_machine* machine, int argc, value const* argv);
-	static value Func_Log10(script_machine* machine, int argc, value const* argv);
-	static value Func_Cos(script_machine* machine, int argc, value const* argv);
-	static value Func_Sin(script_machine* machine, int argc, value const* argv);
-	static value Func_Tan(script_machine* machine, int argc, value const* argv);
-	static value Func_Acos(script_machine* machine, int argc, value const* argv);
-	static value Func_Asin(script_machine* machine, int argc, value const* argv);
-	static value Func_Atan(script_machine* machine, int argc, value const* argv);
-	static value Func_Atan2(script_machine* machine, int argc, value const* argv);
-	static value Func_Rand(script_machine* machine, int argc, value const* argv);
+	static value Func_Min(script_machine* machine, int argc, const value* argv);
+	static value Func_Max(script_machine* machine, int argc, const value* argv);
+	static value Func_Log(script_machine* machine, int argc, const value* argv);
+	static value Func_Log10(script_machine* machine, int argc, const value* argv);
+	static value Func_Cos(script_machine* machine, int argc, const value* argv);
+	static value Func_Sin(script_machine* machine, int argc, const value* argv);
+	static value Func_Tan(script_machine* machine, int argc, const value* argv);
+	static value Func_Acos(script_machine* machine, int argc, const value* argv);
+	static value Func_Asin(script_machine* machine, int argc, const value* argv);
+	static value Func_Atan(script_machine* machine, int argc, const value* argv);
+	static value Func_Atan2(script_machine* machine, int argc, const value* argv);
+	static value Func_Rand(script_machine* machine, int argc, const value* argv);
 
 	//共通関数：文字列操作
-	static value Func_ToString(script_machine* machine, int argc, value const* argv);
-	static value Func_IntToString(script_machine* machine, int argc, value const* argv);
-	static value Func_ItoA(script_machine* machine, int argc, value const* argv);
-	static value Func_RtoA(script_machine* machine, int argc, value const* argv);
-	static value Func_RtoS(script_machine* machine, int argc, value const* argv);
-	static value Func_VtoS(script_machine* machine, int argc, value const* argv);
-	static value Func_AtoI(script_machine* machine, int argc, value const* argv);
-	static value Func_AtoR(script_machine* machine, int argc, value const* argv);
-	static value Func_TrimString(script_machine* machine, int argc, value const* argv);
-	static value Func_SplitString(script_machine* machine, int argc, value const* argv);
+	static value Func_ToString(script_machine* machine, int argc, const value* argv);
+	static value Func_IntToString(script_machine* machine, int argc, const value* argv);
+	static value Func_ItoA(script_machine* machine, int argc, const value* argv);
+	static value Func_RtoA(script_machine* machine, int argc, const value* argv);
+	static value Func_RtoS(script_machine* machine, int argc, const value* argv);
+	static value Func_VtoS(script_machine* machine, int argc, const value* argv);
+	static value Func_AtoI(script_machine* machine, int argc, const value* argv);
+	static value Func_AtoR(script_machine* machine, int argc, const value* argv);
+	static value Func_TrimString(script_machine* machine, int argc, const value* argv);
+	static value Func_SplitString(script_machine* machine, int argc, const value* argv);
 
 	//共通関数：パス関連
-	static value Func_GetModuleDirectory(script_machine* machine, int argc, value const* argv);
-	static value Func_GetMainScriptDirectory(script_machine* machine, int argc, value const* argv);
-	static value Func_GetCurrentScriptDirectory(script_machine* machine, int argc, value const* argv);
-	static value Func_GetFileDirectory(script_machine* machine, int argc, value const* argv);
-	static value Func_GetFilePathList(script_machine* machine, int argc, value const* argv);
-	static value Func_GetDirectoryList(script_machine* machine, int argc, value const* argv);
+	static value Func_GetModuleDirectory(script_machine* machine, int argc, const value* argv);
+	static value Func_GetMainScriptDirectory(script_machine* machine, int argc, const value* argv);
+	static value Func_GetCurrentScriptDirectory(script_machine* machine, int argc, const value* argv);
+	static value Func_GetFileDirectory(script_machine* machine, int argc, const value* argv);
+	static value Func_GetFilePathList(script_machine* machine, int argc, const value* argv);
+	static value Func_GetDirectoryList(script_machine* machine, int argc, const value* argv);
 
 	//共通関数：時刻関連
-	static value Func_GetCurrentDateTimeS(script_machine* machine, int argc, value const* argv);
+	static value Func_GetCurrentDateTimeS(script_machine* machine, int argc, const value* argv);
 
 	//共通関数：デバッグ関連
-	static value Func_WriteLog(script_machine* machine, int argc, value const* argv);
-	static value Func_RaiseError(script_machine* machine, int argc, value const* argv);
+	static value Func_WriteLog(script_machine* machine, int argc, const value* argv);
+	static value Func_RaiseError(script_machine* machine, int argc, const value* argv);
 
 	//共通関数：共通データ
-	static value Func_SetDefaultCommonDataArea(script_machine* machine, int argc, value const* argv);
-	static value Func_SetCommonData(script_machine* machine, int argc, value const* argv);
-	static value Func_GetCommonData(script_machine* machine, int argc, value const* argv);
-	static value Func_ClearCommonData(script_machine* machine, int argc, value const* argv);
-	static value Func_DeleteCommonData(script_machine* machine, int argc, value const* argv);
-	static value Func_SetAreaCommonData(script_machine* machine, int argc, value const* argv);
-	static value Func_GetAreaCommonData(script_machine* machine, int argc, value const* argv);
-	static value Func_ClearAreaCommonData(script_machine* machine, int argc, value const* argv);
-	static value Func_DeleteAreaCommonData(script_machine* machine, int argc, value const* argv);
-	static value Func_CreateCommonDataArea(script_machine* machine, int argc, value const* argv);
-	static value Func_CopyCommonDataArea(script_machine* machine, int argc, value const* argv);
-	static value Func_IsCommonDataAreaExists(script_machine* machine, int argc, value const* argv);
-	static value Func_GetCommonDataAreaKeyList(script_machine* machine, int argc, value const* argv);
-	static value Func_GetCommonDataValueKeyList(script_machine* machine, int argc, value const* argv);
+	static value Func_SetDefaultCommonDataArea(script_machine* machine, int argc, const value* argv);
+	static value Func_SetCommonData(script_machine* machine, int argc, const value* argv);
+	static value Func_GetCommonData(script_machine* machine, int argc, const value* argv);
+	static value Func_ClearCommonData(script_machine* machine, int argc, const value* argv);
+	static value Func_DeleteCommonData(script_machine* machine, int argc, const value* argv);
+	static value Func_SetAreaCommonData(script_machine* machine, int argc, const value* argv);
+	static value Func_GetAreaCommonData(script_machine* machine, int argc, const value* argv);
+	static value Func_ClearAreaCommonData(script_machine* machine, int argc, const value* argv);
+	static value Func_DeleteAreaCommonData(script_machine* machine, int argc, const value* argv);
+	static value Func_CreateCommonDataArea(script_machine* machine, int argc, const value* argv);
+	static value Func_CopyCommonDataArea(script_machine* machine, int argc, const value* argv);
+	static value Func_IsCommonDataAreaExists(script_machine* machine, int argc, const value* argv);
+	static value Func_GetCommonDataAreaKeyList(script_machine* machine, int argc, const value* argv);
+	static value Func_GetCommonDataValueKeyList(script_machine* machine, int argc, const value* argv);
 
 protected:
 	bool bError_;
@@ -200,15 +200,15 @@ protected:
 	std::vector<gstd::value> listValueArg_;
 	gstd::value valueRes_;
 
-	void _AddFunction(char const* name, callback f, unsigned arguments);
+	void _AddFunction(const char* name, callback f, unsigned arguments);
 	void _AddFunction(const function* f, int count);
 	void _RaiseErrorFromEngine();
 	void _RaiseErrorFromMachine();
-	void _RaiseError(int line, std::wstring message);
+	void _RaiseError(int line, const std::wstring& message);
 	std::wstring _GetErrorLineSource(int line);
 	virtual std::vector<char> _Include(std::vector<char>& source);
 	virtual bool _CreateEngine();
-	std::wstring _ExtendPath(std::wstring path);
+	std::wstring _ExtendPath(const std::wstring& path);
 };
 
 /**********************************************************
@@ -228,9 +228,9 @@ public:
 	ScriptFileLineMap();
 	virtual ~ScriptFileLineMap();
 	void AddEntry(std::wstring path, int lineAdd, int lineCount);
-	Entry GetEntry(int line);
-	std::wstring GetPath(int line);
-	std::list<Entry> GetEntryList() { return listEntry_; }
+	Entry GetEntry(int line) const;
+	std::wstring GetPath(int line) const;
+	std::list<Entry> GetEntryList() const { return listEntry_; }
 
 protected:
 	std::list<Entry> listEntry_;
@@ -246,13 +246,13 @@ public:
 	virtual ~ScriptCommonDataManager();
 	void Clear();
 
-	std::string GetDefaultAreaName() { return nameAreaDefailt_; }
-	void SetDefaultAreaName(std::string name) { nameAreaDefailt_ = name; }
-	bool IsExists(std::string name);
-	void CreateArea(std::string name);
-	void CopyArea(std::string nameDest, std::string nameSrc);
-	gstd::ref_count_ptr<ScriptCommonData> GetData(std::string name);
-	void SetData(std::string name, gstd::ref_count_ptr<ScriptCommonData> commonData);
+	std::string GetDefaultAreaName() const { return nameAreaDefailt_; }
+	void SetDefaultAreaName(const std::string& name) { nameAreaDefailt_ = name; }
+	bool IsExists(const std::string& name);
+	void CreateArea(const std::string& name);
+	void CopyArea(const std::string& nameDest, const std::string& nameSrc);
+	gstd::ref_count_ptr<ScriptCommonData> GetData(const std::string& name);
+	void SetData(const std::string& name, gstd::ref_count_ptr<ScriptCommonData> commonData);
 	std::vector<std::string> GetKeyList();
 
 	gstd::CriticalSection& GetLock() { return lock_; }
@@ -271,10 +271,10 @@ public:
 	ScriptCommonData();
 	virtual ~ScriptCommonData();
 	void Clear();
-	bool IsExists(std::string name);
-	gstd::value GetValue(std::string name);
-	void SetValue(std::string name, gstd::value v);
-	void DeleteValue(std::string name);
+	bool IsExists(const std::string& name);
+	gstd::value GetValue(const std::string& name);
+	void SetValue(const std::string& name, const gstd::value& val);
+	void DeleteValue(const std::string& name);
 	void Copy(gstd::ref_count_ptr<ScriptCommonData> dataSrc);
 	std::vector<std::string> GetKeyList();
 

--- a/source/GcLib/gstd/ScriptClient.hpp
+++ b/source/GcLib/gstd/ScriptClient.hpp
@@ -19,9 +19,9 @@ class ScriptCommonDataManager;
 class ScriptException : public gstd::wexception {
 public:
 	ScriptException()
-		: gstd::wexception(L""){};
+		: gstd::wexception(L"") {}
 	ScriptException(std::wstring str)
-		: gstd::wexception(str.c_str()){};
+		: gstd::wexception(str) {}
 };
 
 /**********************************************************
@@ -98,7 +98,7 @@ public:
 	bool IsEventExists(const std::string& name) const;
 	void RaiseError(const std::wstring& error) { _RaiseError(machine_->get_error_line(), error); }
 	void Terminate(const std::wstring& error) { machine_->terminate(error); }
-	_int64 GetScriptID() const { return idScript_; }
+	int64_t GetScriptID() const { return idScript_; }
 	int GetThreadCount() const;
 
 	void AddArgumentValue(value v) { listValueArg_.push_back(v); }
@@ -193,7 +193,7 @@ protected:
 	ref_count_ptr<MersenneTwister> mt_;
 	gstd::ref_count_ptr<ScriptCommonDataManager> commonDataManager_;
 	int mainThreadID_;
-	_int64 idScript_;
+	int64_t idScript_;
 
 	gstd::CriticalSection criticalSection_;
 
@@ -227,7 +227,7 @@ public:
 public:
 	ScriptFileLineMap();
 	virtual ~ScriptFileLineMap();
-	void AddEntry(std::wstring path, int lineAdd, int lineCount);
+	void AddEntry(const std::wstring& path, int lineAdd, int lineCount);
 	Entry GetEntry(int line) const;
 	std::wstring GetPath(int line) const;
 	std::list<Entry> GetEntryList() const { return listEntry_; }
@@ -295,7 +295,7 @@ class ScriptCommonDataInfoPanel : public WindowLogger::Panel {
 public:
 	ScriptCommonDataInfoPanel();
 	void SetUpdateInterval(int time) { timeUpdateInterval_ = time; }
-	virtual void LocateParts();
+	void LocateParts() override;
 	virtual void Update(gstd::ref_count_ptr<ScriptCommonDataManager> commonDataManager);
 
 protected:
@@ -314,7 +314,7 @@ protected:
 	int timeLastUpdate_;
 	int timeUpdateInterval_;
 
-	virtual bool _AddedLogger(HWND hTab);
+	bool _AddedLogger(HWND hTab) override;
 	void _UpdateListViewKey(WListView* listView, std::vector<std::string> listKey);
 	void _UpdateAreaView();
 	void _UpdateValueView();

--- a/source/GcLib/gstd/SmartPointer.hpp
+++ b/source/GcLib/gstd/SmartPointer.hpp
@@ -45,9 +45,9 @@ struct ref_count_ptr_info {
 
 	ref_count_ptr_info()
 	{
-		countRef_ = NULL;
-		countWeak_ = NULL;
-		pPtr_ = NULL;
+		countRef_ = nullptr;
+		countWeak_ = nullptr;
+		pPtr_ = nullptr;
 	}
 };
 
@@ -70,7 +70,7 @@ public:
 public:
 	ref_count_ptr()
 	{
-		SetPointer(NULL);
+		SetPointer(nullptr);
 	}
 	// デフォルトコンストラクタ
 	//explicit 必要?
@@ -163,45 +163,45 @@ public:
 	}
 
 	// *間接演算子
-	T& operator*() { return *info_.pPtr_; }
-	const T& operator*() const { return *info_.pPtr_; }
+	T& operator*() { return *get(); }
+	const T& operator*() const { return *get(); }
 
 	// ->メンバ選択演算子
-	T* operator->() { return info_.pPtr_; }
-	const T* operator->() const { return info_.pPtr_; }
+	T* operator->() { return get(); }
+	const T* operator->() const { return get(); }
 
 	// []配列参照演算子
-	T& operator[](int n) { return info_.pPtr_[n]; }
-	const T& operator[](int n) const { return info_.pPtr_[n]; }
+	T& operator[](int n) { return get()[n]; }
+	const T& operator[](int n) const { return get()[n]; }
 
 	// ==比較演算子
 	bool operator==(const T* p) const
 	{
-		return info_.pPtr_ == p;
+		return get() == p;
 	}
 	bool operator==(const ref_count_ptr<T, SYNC>& p) const
 	{
-		return info_.pPtr_ == p.info_.pPtr_;
+		return get() == p.get();
 	}
 	template <class D>
-	bool operator==(ref_count_ptr<D, SYNC>& p) const
+	bool operator==(const ref_count_ptr<D, SYNC>& p) const
 	{
-		return info_.pPtr_ == p.GetPointer();
+		return get() == p.get();
 	}
 
 	// !=比較演算子
 	bool operator!=(const T* p) const
 	{
-		return info_.pPtr_ != p;
+		return get() != p;
 	}
 	bool operator!=(const ref_count_ptr<T, SYNC>& p) const
 	{
-		return info_.pPtr_ != p.info_.pPtr_;
+		return get() != p.get();
 	}
 	template <class D>
-	bool operator!=(ref_count_ptr<D, SYNC>& p) const
+	bool operator!=(const ref_count_ptr<D, SYNC>& p) const
 	{
-		return info_.pPtr_ != p.GetPointer();
+		return get() != p.get();
 	}
 
 	// ポインタの明示的な登録
@@ -209,9 +209,9 @@ public:
 	{
 		// 参照カウンタを減らした後に再初期化
 		_Release();
-		if (src == NULL) {
-			info_.countRef_ = NULL;
-			info_.countWeak_ = NULL;
+		if (src == nullptr) {
+			info_.countRef_ = nullptr;
+			info_.countWeak_ = nullptr;
 		} else {
 			info_.countRef_ = new long;
 			*info_.countRef_ = add;
@@ -225,11 +225,13 @@ public:
 	// ポインタの貸し出し
 	T* GetPointer() { return info_.pPtr_; }
 	const T* GetPointer() const { return info_.pPtr_; }
+	T* get() { return GetPointer(); }
+	const T* get() const { return GetPointer(); }
 
 	// 参照カウンタへのポインタを取得
 	long* _GetReferenceCountPointer() { return info_.countRef_; } //この関数は外部からしようしないこと
 	long* _GetWeakCountPointer() { return info_.countWeak_; } //この関数は外部からしようしないこと
-	int GetReferenceCount() const { return info_.countRef_ != NULL ? (int)*info_.countRef_ : 0; }
+	int GetReferenceCount() const { return info_.countRef_ != nullptr ? (int)*info_.countRef_ : 0; }
 
 	template <class T2>
 	static ref_count_ptr<T, SYNC> DownCast(ref_count_ptr<T2, SYNC>& src)
@@ -239,7 +241,7 @@ public:
 		// ダウンキャスト可能な場合はオブジェクトを返す
 		ref_count_ptr<T, SYNC> res;
 		T* castPtr = dynamic_cast<T*>(src.GetPointer());
-		if (castPtr != NULL) {
+		if (castPtr != nullptr) {
 			// ダウンキャスト可能
 			res._Release(); //現在の参照を破棄する必要がある
 			res.info_.countRef_ = src._GetReferenceCountPointer();
@@ -256,7 +258,7 @@ private:
 	// 参照カウンタ増加
 	void _AddRef()
 	{
-		if (info_.countRef_ == NULL)
+		if (info_.countRef_ == nullptr)
 			return;
 
 		if (SYNC) {
@@ -271,30 +273,30 @@ private:
 	// 参照カウンタ減少
 	void _Release()
 	{
-		if (info_.countRef_ == NULL)
+		if (info_.countRef_ == nullptr)
 			return;
 
 		if (SYNC) {
 			if (InterlockedDecrement(info_.countRef_) == 0) {
 				delete[] info_.pPtr_;
-				info_.pPtr_ = NULL;
+				info_.pPtr_ = nullptr;
 			}
 			if (InterlockedDecrement(info_.countWeak_) == 0) {
 				delete info_.countRef_;
-				info_.countRef_ = NULL;
+				info_.countRef_ = nullptr;
 				delete info_.countWeak_;
-				info_.countWeak_ = NULL;
+				info_.countWeak_ = nullptr;
 			}
 		} else {
 			if (--(*info_.countRef_) == 0) {
 				delete[] info_.pPtr_;
-				info_.pPtr_ = NULL;
+				info_.pPtr_ = nullptr;
 			}
 			if (--(*info_.countWeak_) == 0) {
 				delete info_.countRef_;
-				info_.countRef_ = NULL;
+				info_.countRef_ = nullptr;
 				delete info_.countWeak_;
-				info_.countWeak_ = NULL;
+				info_.countWeak_ = nullptr;
 			}
 		}
 	}
@@ -308,12 +310,10 @@ public:
 	typedef ref_count_weak_ptr<T, false> unsync; //排他なし版
 
 public:
-	ref_count_weak_ptr()
-	{
-	}
+	ref_count_weak_ptr() = default;
 	ref_count_weak_ptr(T* src)
 	{
-		if (src != NULL)
+		if (src != nullptr)
 			throw std::exception("ref_count_weak_ptrコンストラクタに非NULLを代入しようとしました");
 	}
 	// コピーコンストラクタ
@@ -355,12 +355,12 @@ public:
 	// =代入演算子
 	ref_count_weak_ptr<T, SYNC>& operator=(T* src)
 	{
-		if (src != NULL)
+		if (src != nullptr)
 			throw std::exception("ref_count_weak_ptr =に非NULLを代入しようとしました");
 		_Release();
 		info_.pPtr_ = src;
-		info_.countRef_ = NULL;
-		info_.countWeak_ = NULL;
+		info_.countRef_ = nullptr;
+		info_.countWeak_ = nullptr;
 		return (*this);
 	}
 	ref_count_weak_ptr<T, SYNC>& operator=(const ref_count_weak_ptr<T, SYNC>& src)
@@ -442,45 +442,49 @@ public:
 	// ==比較演算子
 	bool operator==(const T* p) const
 	{
-		return IsExists() ? (info_.pPtr_ == p) : (NULL == p);
+		return get() == p;
 	}
 	bool operator==(const ref_count_weak_ptr<T, SYNC>& p) const
 	{
-		return IsExists() ? (info_.pPtr_ == p.info_.pPtr_) : (NULL == p.info_.pPtr_);
+		return get() == p.get();
 	}
 	template <class D>
 	bool operator==(ref_count_weak_ptr<D, SYNC>& p) const
 	{
-		return IsExists() ? (info_.pPtr_ == p.GetPointer()) : (NULL == p.GetPointer());
+		return get() == p.get();
 	}
 
 	// !=比較演算子
 	bool operator!=(const T* p) const
 	{
-		return IsExists() ? (info_.pPtr_ != p) : (NULL != p);
+		return get() != p;
 	}
 	bool operator!=(const ref_count_weak_ptr<T, SYNC>& p) const
 	{
-		return IsExists() ? (info_.pPtr_ != p.info_.pPtr_) : (NULL != p.info_.pPtr_);
+		return get() != p.get();
 	}
 	template <class D>
 	bool operator!=(ref_count_weak_ptr<D, SYNC>& p) const
 	{
-		return IsExists() ? (info_.pPtr_ != p.GetPointer()) : (NULL != p.GetPointer());
+		return get() != p.get();
 	}
 
 	// ポインタの貸し出し
-	T* GetPointer() { return IsExists() ? info_.pPtr_ : NULL; }
+	T* GetPointer() { return IsExists() ? info_.pPtr_ : nullptr; }
+	const T* GetPointer() const { return IsExists() ? info_.pPtr_ : nullptr; }
+	T* get() { return GetPointer(); }
+	const T* get() const { return GetPointer(); }
+
 
 	// 参照カウンタへのポインタを取得
 	long* _GetReferenceCountPointer() { return info_.countRef_; } //この関数は外部からしようしないこと
 	long* _GetWeakCountPointer() { return info_.countWeak_; } //この関数は外部からしようしないこと
 	int GetReferenceCount() const
 	{
-		int res = info_.countRef_ != NULL ? (int)*info_.countRef_ : 0;
+		int res = info_.countRef_ != nullptr ? (int)*info_.countRef_ : 0;
 		return res;
 	}
-	bool IsExists() const { return info_.countRef_ != NULL ? (*info_.countRef_ > 0) : false; }
+	bool IsExists() const { return info_.countRef_ != nullptr ? (*info_.countRef_ > 0) : false; }
 
 	template <class T2>
 	static ref_count_weak_ptr<T, SYNC> DownCast(ref_count_weak_ptr<T2, SYNC>& src)
@@ -490,7 +494,7 @@ public:
 		// ダウンキャスト可能な場合はオブジェクトを返す
 		ref_count_weak_ptr<T, SYNC> res;
 		T* castPtr = dynamic_cast<T*>(src.GetPointer());
-		if (castPtr != NULL) {
+		if (castPtr != nullptr) {
 			// ダウンキャスト可能
 			res._Release(); //現在の参照を破棄する必要がある
 			res.info_.countRef_ = src._GetReferenceCountPointer();
@@ -507,7 +511,7 @@ private:
 	// 参照カウンタ増加
 	void _AddRef()
 	{
-		if (info_.countRef_ == NULL)
+		if (info_.countRef_ == nullptr)
 			return;
 
 		if (SYNC) {
@@ -520,22 +524,22 @@ private:
 	// 参照カウンタ減少
 	void _Release()
 	{
-		if (info_.countRef_ == NULL)
+		if (info_.countRef_ == nullptr)
 			return;
 
 		if (SYNC) {
 			if (InterlockedDecrement(info_.countWeak_) == 0) {
 				delete info_.countRef_;
-				info_.countRef_ = NULL;
+				info_.countRef_ = nullptr;
 				delete info_.countWeak_;
-				info_.countWeak_ = NULL;
+				info_.countWeak_ = nullptr;
 			}
 		} else {
 			if (--(*info_.countWeak_) == 0) {
 				delete info_.countRef_;
-				info_.countRef_ = NULL;
+				info_.countRef_ = nullptr;
 				delete info_.countWeak_;
-				info_.countWeak_ = NULL;
+				info_.countWeak_ = nullptr;
 			}
 		}
 	}

--- a/source/GcLib/gstd/SmartPointer.hpp
+++ b/source/GcLib/gstd/SmartPointer.hpp
@@ -164,15 +164,18 @@ public:
 
 	// *間接演算子
 	T& operator*() { return *info_.pPtr_; }
+	const T& operator*() const { return *info_.pPtr_; }
 
 	// ->メンバ選択演算子
 	T* operator->() { return info_.pPtr_; }
+	const T* operator->() const { return info_.pPtr_; }
 
 	// []配列参照演算子
 	T& operator[](int n) { return info_.pPtr_[n]; }
+	const T& operator[](int n) const { return info_.pPtr_[n]; }
 
 	// ==比較演算子
-	bool operator==(const T* p)
+	bool operator==(const T* p) const
 	{
 		return info_.pPtr_ == p;
 	}
@@ -187,7 +190,7 @@ public:
 	}
 
 	// !=比較演算子
-	bool operator!=(const T* p)
+	bool operator!=(const T* p) const
 	{
 		return info_.pPtr_ != p;
 	}
@@ -198,7 +201,7 @@ public:
 	template <class D>
 	bool operator!=(ref_count_ptr<D, SYNC>& p) const
 	{
-		return info_.pPtr_ != p.info_.pPtr_;
+		return info_.pPtr_ != p.GetPointer();
 	}
 
 	// ポインタの明示的な登録
@@ -220,16 +223,13 @@ public:
 	}
 
 	// ポインタの貸し出し
-	inline T* GetPointer() { return info_.pPtr_; }
+	T* GetPointer() { return info_.pPtr_; }
+	const T* GetPointer() const { return info_.pPtr_; }
 
 	// 参照カウンタへのポインタを取得
-	inline long* _GetReferenceCountPointer() { return info_.countRef_; } //この関数は外部からしようしないこと
-	inline long* _GetWeakCountPointer() { return info_.countWeak_; } //この関数は外部からしようしないこと
-	int GetReferenceCount()
-	{
-		int res = info_.countRef_ != NULL ? (int)*info_.countRef_ : 0;
-		return res;
-	}
+	long* _GetReferenceCountPointer() { return info_.countRef_; } //この関数は外部からしようしないこと
+	long* _GetWeakCountPointer() { return info_.countWeak_; } //この関数は外部からしようしないこと
+	int GetReferenceCount() const { return info_.countRef_ != NULL ? (int)*info_.countRef_ : 0; }
 
 	template <class T2>
 	static ref_count_ptr<T, SYNC> DownCast(ref_count_ptr<T2, SYNC>& src)
@@ -440,7 +440,7 @@ public:
 	T& operator[](int n) { return info_.pPtr_[n]; }
 
 	// ==比較演算子
-	bool operator==(const T* p)
+	bool operator==(const T* p) const
 	{
 		return IsExists() ? (info_.pPtr_ == p) : (NULL == p);
 	}
@@ -455,7 +455,7 @@ public:
 	}
 
 	// !=比較演算子
-	bool operator!=(const T* p)
+	bool operator!=(const T* p) const
 	{
 		return IsExists() ? (info_.pPtr_ != p) : (NULL != p);
 	}
@@ -470,17 +470,17 @@ public:
 	}
 
 	// ポインタの貸し出し
-	inline T* GetPointer() { return IsExists() ? info_.pPtr_ : NULL; }
+	T* GetPointer() { return IsExists() ? info_.pPtr_ : NULL; }
 
 	// 参照カウンタへのポインタを取得
-	inline long* _GetReferenceCountPointer() { return info_.countRef_; } //この関数は外部からしようしないこと
-	inline long* _GetWeakCountPointer() { return info_.countWeak_; } //この関数は外部からしようしないこと
-	int GetReferenceCount()
+	long* _GetReferenceCountPointer() { return info_.countRef_; } //この関数は外部からしようしないこと
+	long* _GetWeakCountPointer() { return info_.countWeak_; } //この関数は外部からしようしないこと
+	int GetReferenceCount() const
 	{
 		int res = info_.countRef_ != NULL ? (int)*info_.countRef_ : 0;
 		return res;
 	}
-	bool IsExists() { return info_.countRef_ != NULL ? (*info_.countRef_ > 0) : false; }
+	bool IsExists() const { return info_.countRef_ != NULL ? (*info_.countRef_ > 0) : false; }
 
 	template <class T2>
 	static ref_count_weak_ptr<T, SYNC> DownCast(ref_count_weak_ptr<T2, SYNC>& src)

--- a/source/GcLib/gstd/Task.hpp
+++ b/source/GcLib/gstd/Task.hpp
@@ -30,12 +30,12 @@ protected:
 public:
 	TaskFunction()
 	{
-		task_ = NULL;
+		task_ = nullptr;
 		id_ = TASK_FREE_ID;
 		bEnable_ = true;
 		delay_ = 0;
 	}
-	virtual ~TaskFunction() {}
+	~TaskFunction() override = default;
 	virtual void Call() = 0;
 
 	ref_count_ptr<TaskBase> GetTask() { return task_; }
@@ -46,7 +46,7 @@ public:
 	void SetDelay(int delay) { delay_ = delay; }
 	bool IsDelay() const { return delay_ > 0; }
 
-	virtual std::wstring GetInfoAsString();
+	std::wstring GetInfoAsString() override;
 };
 
 template <class T>
@@ -60,9 +60,9 @@ public:
 		task_ = task;
 		pFunc = func;
 	}
-	virtual void Call()
+	void Call() override
 	{
-		if (task_ != NULL)
+		if (task_ != nullptr)
 			((T*)task_.GetPointer()->*pFunc)();
 	}
 
@@ -88,12 +88,12 @@ class TaskBase : public IStringInfo {
 
 public:
 	TaskBase();
-	virtual ~TaskBase();
+	~TaskBase() override;
 	int GetTaskID() const { return idTask_; }
-	_int64 GetTaskIndex() const { return indexTask_; }
+	int64_t GetTaskIndex() const { return indexTask_; }
 
 protected:
-	_int64 indexTask_; //TaskManagerによってつけられる一意のインデックス
+	int64_t indexTask_; //TaskManagerによってつけられる一意のインデックス
 	int idTask_; //ID
 	int idTaskGroup_; //グループID
 };
@@ -110,7 +110,7 @@ public:
 
 public:
 	TaskManager();
-	virtual ~TaskManager();
+	~TaskManager() override;
 	void Clear(); //全タスク削除
 	void ClearTask();
 	void AddTask(ref_count_ptr<TaskBase> task); //タスクを追加
@@ -146,7 +146,7 @@ protected:
 	static gstd::CriticalSection lockStatic_;
 	std::list<ref_count_ptr<TaskBase>> listTask_; //タスクの元クラス
 	function_map mapFunc_; //タスク機能のリスト(divFunc, priority, func)
-	_int64 indexTaskManager_; //一意のインデックス
+	int64_t indexTaskManager_; //一意のインデックス
 	ref_count_ptr<TaskInfoPanel> panelInfo_;
 
 	void _ArrangeTask(); //必要のなくなった領域削除
@@ -160,7 +160,7 @@ class TaskInfoPanel : public WindowLogger::Panel {
 public:
 	TaskInfoPanel();
 	void SetUpdateInterval(int time) { timeUpdateInterval_ = time; }
-	virtual void LocateParts();
+	void LocateParts() override;
 	virtual void Update(TaskManager* taskManager);
 
 protected:
@@ -180,7 +180,7 @@ protected:
 	int timeUpdateInterval_;
 	int addressLastFindManager_;
 
-	virtual bool _AddedLogger(HWND hTab);
+	bool _AddedLogger(HWND hTab) override;
 	void _UpdateTreeView(TaskManager* taskManager, ref_count_ptr<WTreeView::Item> item);
 	void _UpdateListView(TaskManager* taskManager);
 };
@@ -192,7 +192,7 @@ protected:
 class WorkRenderTaskManager : public TaskManager {
 public:
 	WorkRenderTaskManager();
-	~WorkRenderTaskManager();
+	~WorkRenderTaskManager() override;
 	virtual void InitializeFunctionDivision(int maxPriWork, int maxPriRender);
 
 	//動作機能

--- a/source/GcLib/gstd/Task.hpp
+++ b/source/GcLib/gstd/Task.hpp
@@ -39,12 +39,12 @@ public:
 	virtual void Call() = 0;
 
 	ref_count_ptr<TaskBase> GetTask() { return task_; }
-	int GetID() { return id_; }
-	bool IsEnable() { return bEnable_; }
+	int GetID() const { return id_; }
+	bool IsEnable() const { return bEnable_; }
 
-	int GetDelay() { return delay_; }
+	int GetDelay() const { return delay_; }
 	void SetDelay(int delay) { delay_ = delay; }
-	bool IsDelay() { return delay_ > 0; }
+	bool IsDelay() const { return delay_ > 0; }
 
 	virtual std::wstring GetInfoAsString();
 };
@@ -89,8 +89,8 @@ class TaskBase : public IStringInfo {
 public:
 	TaskBase();
 	virtual ~TaskBase();
-	int GetTaskID() { return idTask_; }
-	_int64 GetTaskIndex() { return indexTask_; }
+	int GetTaskID() const { return idTask_; }
+	_int64 GetTaskIndex() const { return indexTask_; }
 
 protected:
 	_int64 indexTask_; //TaskManagerによってつけられる一意のインデックス
@@ -129,7 +129,7 @@ public:
 	void RemoveFunction(TaskBase* task); //タスク機能削除
 	void RemoveFunction(TaskBase* task, int divFunc, int idFunc); //タスク機能削除
 	void RemoveFunction(const std::type_info& info); //タスク機能削除
-	function_map GetFunctionMap() { return mapFunc_; }
+	function_map GetFunctionMap() const { return mapFunc_; }
 
 	void SetFunctionEnable(bool bEnable); //全タスク機能の状態を切り替える
 	void SetFunctionEnable(bool bEnable, int divFunc); //タスク機能の状態を切り替える

--- a/source/GcLib/gstd/Thread.cpp
+++ b/source/GcLib/gstd/Thread.cpp
@@ -7,7 +7,7 @@ using namespace gstd;
 //Thread
 Thread::Thread()
 {
-	hThread_ = NULL;
+	hThread_ = nullptr;
 	idThread_ = 0;
 	status_ = STOP;
 }
@@ -15,16 +15,16 @@ Thread::~Thread()
 {
 	this->Stop();
 	this->Join();
-	if (hThread_ != NULL) {
+	if (hThread_ != nullptr) {
 		::CloseHandle(hThread_);
-		hThread_ = NULL;
+		hThread_ = nullptr;
 		idThread_ = 0;
 	}
 }
 unsigned int __stdcall Thread::_StaticRun(LPVOID data)
 {
 	try {
-		Thread* thread = reinterpret_cast<Thread*>(data);
+		auto* thread = reinterpret_cast<Thread*>(data);
 		thread->status_ = RUN;
 		thread->_Run();
 		thread->status_ = STOP;
@@ -40,7 +40,7 @@ void Thread::Start()
 		this->Join();
 	}
 
-	hThread_ = (HANDLE)_beginthreadex(NULL, 0, _StaticRun, (void*)this, 0, &idThread_);
+	hThread_ = (HANDLE)_beginthreadex(nullptr, 0, _StaticRun, (void*)this, 0, &idThread_);
 }
 void Thread::Stop()
 {
@@ -49,20 +49,20 @@ void Thread::Stop()
 }
 bool Thread::IsStop() const
 {
-	return hThread_ == NULL || status_ == STOP;
+	return hThread_ == nullptr || status_ == STOP;
 }
 DWORD Thread::Join(int mills)
 {
 	DWORD res = WAIT_OBJECT_0;
 
-	if (hThread_ != NULL) {
+	if (hThread_ != nullptr) {
 		res = ::WaitForSingleObject(hThread_, mills);
 	}
 
-	if (hThread_ != NULL) {
+	if (hThread_ != nullptr) {
 		if (res != WAIT_TIMEOUT)
 			::CloseHandle(hThread_); //タイムアウトの場合クローズできない
-		hThread_ = NULL;
+		hThread_ = nullptr;
 		idThread_ = 0;
 		status_ = STOP;
 	}
@@ -84,7 +84,7 @@ CriticalSection::~CriticalSection()
 void CriticalSection::Enter()
 {
 	if (::GetCurrentThreadId() == idThread_) { //カレントスレッド
-		countLock_++;
+		++countLock_;
 		return;
 	}
 
@@ -95,7 +95,7 @@ void CriticalSection::Enter()
 void CriticalSection::Leave()
 {
 	if (::GetCurrentThreadId() == idThread_) {
-		countLock_--;
+		--countLock_;
 		if (countLock_ != 0)
 			return;
 		if (countLock_ < 0)
@@ -112,7 +112,7 @@ void CriticalSection::Leave()
 ThreadSignal::ThreadSignal(bool bManualReset)
 {
 	BOOL bManual = bManualReset ? TRUE : FALSE;
-	hEvent_ = ::CreateEvent(NULL, bManual, FALSE, NULL);
+	hEvent_ = ::CreateEvent(nullptr, bManual, FALSE, nullptr);
 }
 ThreadSignal::~ThreadSignal()
 {
@@ -122,7 +122,7 @@ DWORD ThreadSignal::Wait(int mills)
 {
 	DWORD res = WAIT_OBJECT_0;
 
-	if (hEvent_ != NULL) {
+	if (hEvent_ != nullptr) {
 		res = ::WaitForSingleObject(hEvent_, mills);
 	}
 

--- a/source/GcLib/gstd/Thread.cpp
+++ b/source/GcLib/gstd/Thread.cpp
@@ -47,7 +47,7 @@ void Thread::Stop()
 	if (status_ == RUN)
 		status_ = REQUEST_STOP;
 }
-bool Thread::IsStop()
+bool Thread::IsStop() const
 {
 	return hThread_ == NULL || status_ == STOP;
 }

--- a/source/GcLib/gstd/Thread.hpp
+++ b/source/GcLib/gstd/Thread.hpp
@@ -20,10 +20,10 @@ public:
 	virtual ~Thread();
 	virtual void Start();
 	virtual void Stop();
-	bool IsStop();
+	bool IsStop() const;
 	DWORD Join(int mills = INFINITE);
 
-	Status GetStatus() { return status_; }
+	Status GetStatus() const { return status_; }
 
 protected:
 	volatile HANDLE hThread_;

--- a/source/GcLib/gstd/Window.cpp
+++ b/source/GcLib/gstd/Window.cpp
@@ -338,13 +338,13 @@ void WEditBox::Create(HWND hWndParent, WEditBox::Style& style)
 	this->Attach(hWnd_);
 	::SendMessage(hWnd_, WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT), MAKELPARAM(FALSE, 0));
 }
-void WEditBox::SetText(std::wstring text)
+void WEditBox::SetText(const std::wstring& text)
 {
 	if (text == GetText())
 		return;
 	::SetWindowText(hWnd_, text.c_str());
 }
-std::wstring WEditBox::GetText()
+std::wstring WEditBox::GetText() const
 {
 	if (GetTextLength() == 0)
 		return L"";
@@ -355,7 +355,7 @@ std::wstring WEditBox::GetText()
 	::GetWindowText(hWnd_, &res[0], count);
 	return res;
 }
-int WEditBox::GetTextLength()
+int WEditBox::GetTextLength() const
 {
 	return ::GetWindowTextLength(hWnd_);
 }
@@ -502,7 +502,7 @@ void WListView::Clear()
 {
 	ListView_DeleteAllItems(hWnd_);
 }
-void WListView::AddColumn(int cx, int sub, DWORD fmt, std::wstring text)
+void WListView::AddColumn(int cx, int sub, DWORD fmt, const std::wstring& text)
 {
 	LV_COLUMN lvcol;
 	lvcol.mask = LVCF_FMT | LVCF_WIDTH | LVCF_TEXT | LVCF_SUBITEM;
@@ -512,14 +512,14 @@ void WListView::AddColumn(int cx, int sub, DWORD fmt, std::wstring text)
 	lvcol.iSubItem = sub;
 	ListView_InsertColumn(hWnd_, sub, &lvcol);
 }
-void WListView::SetColumnText(int cx, std::wstring text)
+void WListView::SetColumnText(int cx, const std::wstring& text)
 {
 	LV_COLUMN lvcol;
 	ListView_GetColumn(hWnd_, cx, &lvcol);
 	lvcol.pszText = (wchar_t*)text.c_str();
 	ListView_SetColumn(hWnd_, cx, &lvcol);
 }
-void WListView::AddRow(std::wstring text)
+void WListView::AddRow(const std::wstring& text)
 {
 	LVITEM item;
 	item.mask = LVIF_TEXT | LVIF_PARAM;
@@ -529,7 +529,7 @@ void WListView::AddRow(std::wstring text)
 	item.lParam = ListView_GetItemCount(hWnd_);
 	ListView_InsertItem(hWnd_, &item);
 }
-void WListView::SetText(int row, int column, std::wstring text)
+void WListView::SetText(int row, int column, const std::wstring& text)
 {
 	std::wstring pre = GetText(row, column);
 	if (pre == text)
@@ -569,7 +569,7 @@ std::wstring WListView::GetText(int row, int column)
 	res = buf;
 	return res;
 }
-bool WListView::IsExistsInColumn(std::wstring value, int column)
+bool WListView::IsExistsInColumn(const std::wstring& value, int column)
 {
 	int count = ListView_GetItemCount(hWnd_);
 	for (int iRow = 0; iRow <= count; iRow++) {
@@ -579,7 +579,7 @@ bool WListView::IsExistsInColumn(std::wstring value, int column)
 	}
 	return false;
 }
-int WListView::GetIndexInColumn(std::wstring value, int column)
+int WListView::GetIndexInColumn(const std::wstring& value, int column)
 {
 	int res = -1;
 	if (column == 0) {
@@ -626,7 +626,7 @@ WTreeView::~WTreeView()
 {
 	this->Clear();
 }
-void WTreeView::Create(HWND hWndParent, Style& style)
+void WTreeView::Create(HWND hWndParent, const Style& style)
 {
 	//TVS_HASLINES | TVS_HASBUTTONS | TVS_LINESATROOT
 	HINSTANCE hInst = (HINSTANCE)::GetWindowLong(hWndParent, GWL_HINSTANCE);

--- a/source/GcLib/gstd/Window.hpp
+++ b/source/GcLib/gstd/Window.hpp
@@ -44,12 +44,12 @@ public:
 		return rect.bottom - rect.top;
 	}
 
-	void SetWindowEnable(bool bEnable) { ::EnableWindow(hWnd_, bEnable); }
+	void SetWindowEnable(bool bEnable) { ::EnableWindow(hWnd_, static_cast<BOOL>(bEnable)); }
 	void SetWindowVisible(bool bVisible) { ::ShowWindow(hWnd_, bVisible ? SW_SHOW : SW_HIDE); }
-	bool IsWindowVisible() { return ::IsWindowVisible(hWnd_) ? true : false; }
+	bool IsWindowVisible() { return ::IsWindowVisible(hWnd_) != 0 ? true : false; }
 	void SetParentWindow(HWND hParentWnd)
 	{
-		if (hWnd_ != NULL)
+		if (hWnd_ != nullptr)
 			::SetParent(hWnd_, hParentWnd);
 	}
 	DWORD SetWindowStyle(DWORD style)
@@ -94,7 +94,7 @@ public:
 		style_ = 0;
 		styleEx_ = 0;
 	}
-	virtual ~Style() {}
+	virtual ~Style() = default;
 	DWORD GetStyle() const { return style_; }
 	DWORD SetStyle(DWORD style)
 	{
@@ -147,7 +147,7 @@ public:
 	void Create(HWND hWndParent);
 
 protected:
-	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam); //オーバーライド用プロシージャ
+	LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override; //オーバーライド用プロシージャ
 };
 
 /**********************************************************
@@ -157,7 +157,7 @@ class WLabel : public WindowBase {
 public:
 	WLabel();
 	void Create(HWND hWndParent);
-	void SetText(std::wstring text);
+	void SetText(const std::wstring& text);
 	void SetTextColor(int color);
 	void SetBackColor(int color);
 
@@ -167,7 +167,7 @@ public:
 private:
 	int colorText_;
 	int colorBack_;
-	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 };
 
 /**********************************************************
@@ -179,8 +179,8 @@ public:
 
 public:
 	void Create(HWND hWndParent);
-	void Create(HWND hWndParent, WButton::Style& style);
-	void SetText(std::wstring text);
+	void Create(HWND hWndParent, const WButton::Style& style);
+	void SetText(const std::wstring& text);
 	bool IsChecked();
 };
 class WButton::Style : public WindowBase::Style {
@@ -192,7 +192,7 @@ class WButton::Style : public WindowBase::Style {
 class WGroupBox : public WindowBase {
 public:
 	void Create(HWND hWndParent);
-	void SetText(std::wstring text);
+	void SetText(const std::wstring& text);
 };
 
 /**********************************************************
@@ -221,14 +221,14 @@ public:
 	class Style;
 
 public:
-	void Create(HWND hWndParent, WListBox::Style& style);
+	void Create(HWND hWndParent, const WListBox::Style& style);
 
 	void Clear();
 	int GetCount();
 	void SetSelectedIndex(int index);
 	int GetSelectedIndex();
-	void AddString(std::wstring str);
-	void InsertString(int index, std::wstring str);
+	void AddString(const std::wstring& str);
+	void InsertString(int index, const std::wstring& str);
 	void DeleteString(int index);
 	std::wstring GetText(int index);
 };
@@ -243,7 +243,7 @@ public:
 	class Style;
 
 public:
-	void Create(HWND hWndParent, WComboBox::Style& style);
+	void Create(HWND hWndParent, const WComboBox::Style& style);
 
 	void SetItemHeight(int height);
 	void SetDropDownListWidth(int width);
@@ -253,8 +253,8 @@ public:
 	void SetSelectedIndex(int index);
 	int GetSelectedIndex();
 	std::wstring GetSelectedText();
-	void AddString(std::wstring str);
-	void InsertString(int index, std::wstring str);
+	void AddString(const std::wstring& str);
+	void InsertString(int index, const std::wstring& str);
 };
 class WComboBox::Style : public WindowBase::Style {
 };
@@ -267,7 +267,7 @@ public:
 	class Style;
 
 public:
-	void Create(HWND hWndParent, Style& style);
+	void Create(HWND hWndParent, const Style& style);
 	void Clear();
 	void AddColumn(int cx, int sub, DWORD fmt, const std::wstring& text);
 	void AddColumn(int cx, int sub, const std::wstring& text) { AddColumn(cx, sub, LVCFMT_LEFT, text); }
@@ -315,11 +315,11 @@ public:
 
 public:
 	WTreeView();
-	~WTreeView();
+	~WTreeView() override;
 	void Create(HWND hWndParent, const Style& style);
 	void Clear()
 	{
-		itemRoot_ = NULL;
+		itemRoot_ = nullptr;
 		TreeView_DeleteAllItems(hWnd_);
 	}
 	void CreateRootItem(ItemStyle& style);
@@ -365,10 +365,10 @@ class WTreeView::Style : public WindowBase::Style {
 **********************************************************/
 class WTabControll : public WindowBase {
 public:
-	~WTabControll();
+	~WTabControll() override;
 	void Create(HWND hWndParent);
-	void AddTab(std::wstring text);
-	void AddTab(std::wstring text, ref_count_ptr<WPanel> panel);
+	void AddTab(const std::wstring& text);
+	void AddTab(const std::wstring& text, ref_count_ptr<WPanel> panel);
 	void ShowPage();
 	int GetCurrentPage() { return TabCtrl_GetCurSel(hWnd_); }
 	void SetCurrentPage(int page)
@@ -378,10 +378,10 @@ public:
 	}
 	ref_count_ptr<WPanel> GetPanel(int page) { return vectPanel_[page]; }
 	int GetPageCount() const { return vectPanel_.size(); }
-	virtual void LocateParts();
+	void LocateParts() override;
 
 protected:
-	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
 private:
 	std::vector<ref_count_ptr<WPanel>> vectPanel_;
@@ -410,7 +410,7 @@ public:
 
 public:
 	WSplitter();
-	~WSplitter();
+	~WSplitter() override;
 	void Create(HWND hWndParent, SplitType type);
 	void SetRatioX(float ratio) { ratioX_ = ratio; }
 	float GetRatioX() const { return ratioX_; }
@@ -422,7 +422,7 @@ protected:
 	bool bCapture_;
 	float ratioX_;
 	float ratioY_;
-	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 };
 
 /**********************************************************

--- a/source/GcLib/gstd/Window.hpp
+++ b/source/GcLib/gstd/Window.hpp
@@ -22,7 +22,7 @@ public:
 
 	bool Attach(HWND hWnd); //セット
 	bool Detach(); //解除
-	int GetWindowId() { return idWindow_; }
+	int GetWindowId() const { return idWindow_; }
 
 	virtual void SetBounds(int x, int y, int width, int height) { ::MoveWindow(hWnd_, x, y, width, height, TRUE); }
 	RECT GetClientRect()
@@ -95,7 +95,7 @@ public:
 		styleEx_ = 0;
 	}
 	virtual ~Style() {}
-	DWORD GetStyle() { return style_; }
+	DWORD GetStyle() const { return style_; }
 	DWORD SetStyle(DWORD style)
 	{
 		style_ |= style;
@@ -107,7 +107,7 @@ public:
 		return style_;
 	}
 
-	DWORD GetStyleEx() { return styleEx_; }
+	DWORD GetStyleEx() const { return styleEx_; }
 	DWORD SetStyleEx(DWORD style)
 	{
 		styleEx_ |= style;
@@ -204,9 +204,9 @@ public:
 
 public:
 	void Create(HWND hWndParent, WEditBox::Style& style);
-	void SetText(std::wstring text);
-	std::wstring GetText();
-	int GetTextLength();
+	void SetText(const std::wstring& text);
+	std::wstring GetText() const;
+	int GetTextLength() const;
 	int GetMaxTextLength() { return ::SendMessage(hWnd_, EM_GETLIMITTEXT, 0, 0); }
 	void SetMaxTextLength(int length) { ::SendMessage(hWnd_, EM_SETLIMITTEXT, (WPARAM)length, 0); }
 };
@@ -269,16 +269,16 @@ public:
 public:
 	void Create(HWND hWndParent, Style& style);
 	void Clear();
-	void AddColumn(int cx, int sub, DWORD fmt, std::wstring text);
-	void AddColumn(int cx, int sub, std::wstring text) { AddColumn(cx, sub, LVCFMT_LEFT, text); }
-	void SetColumnText(int cx, std::wstring text);
-	void AddRow(std::wstring text);
-	void SetText(int row, int column, std::wstring text);
+	void AddColumn(int cx, int sub, DWORD fmt, const std::wstring& text);
+	void AddColumn(int cx, int sub, const std::wstring& text) { AddColumn(cx, sub, LVCFMT_LEFT, text); }
+	void SetColumnText(int cx, const std::wstring& text);
+	void AddRow(const std::wstring& text);
+	void SetText(int row, int column, const std::wstring& text);
 	void DeleteRow(int row);
 	int GetRowCount();
 	std::wstring GetText(int row, int column);
-	bool IsExistsInColumn(std::wstring value, int column);
-	int GetIndexInColumn(std::wstring value, int column);
+	bool IsExistsInColumn(const std::wstring& value, int column);
+	int GetIndexInColumn(const std::wstring& value, int column);
 	void SetSelectedRow(int index);
 	int GetSelectedRow();
 	void ClearSelection();
@@ -286,7 +286,7 @@ public:
 class WListView::Style : public WindowBase::Style {
 public:
 	Style() { styleListViewEx_ = 0; }
-	DWORD GetListViewStyleEx() { return styleListViewEx_; }
+	DWORD GetListViewStyleEx() const { return styleListViewEx_; }
 	DWORD SetListViewStyleEx(DWORD style)
 	{
 		styleListViewEx_ |= style;
@@ -316,7 +316,7 @@ public:
 public:
 	WTreeView();
 	~WTreeView();
-	void Create(HWND hWndParent, Style& style);
+	void Create(HWND hWndParent, const Style& style);
 	void Clear()
 	{
 		itemRoot_ = NULL;
@@ -377,7 +377,7 @@ public:
 		ShowPage();
 	}
 	ref_count_ptr<WPanel> GetPanel(int page) { return vectPanel_[page]; }
-	int GetPageCount() { return vectPanel_.size(); }
+	int GetPageCount() const { return vectPanel_.size(); }
 	virtual void LocateParts();
 
 protected:
@@ -413,9 +413,9 @@ public:
 	~WSplitter();
 	void Create(HWND hWndParent, SplitType type);
 	void SetRatioX(float ratio) { ratioX_ = ratio; }
-	float GetRatioX() { return ratioX_; }
+	float GetRatioX() const { return ratioX_; }
 	void SetRatioY(float ratio) { ratioY_ = ratio; }
-	float GetRatioY() { return ratioY_; }
+	float GetRatioY() const { return ratioY_; }
 
 protected:
 	SplitType type_;

--- a/source/TouhouDanmakufu/Common/DnhCommon.cpp
+++ b/source/TouhouDanmakufu/Common/DnhCommon.cpp
@@ -11,12 +11,12 @@ const std::wstring ScriptInformation::DEFAULT = L"DEFAULT";
 ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(const std::wstring& pathScript, bool bNeedHeader)
 {
 	ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(pathScript);
-	if (reader == NULL || !reader->Open()) {
+	if (reader == nullptr || !reader->Open()) {
 		Logger::WriteTop(ErrorUtility::GetFileNotFoundErrorMessage(pathScript));
-		return NULL;
+		return nullptr;
 	}
 
-	std::string source = "";
+	std::string source;
 	int size = reader->GetFileSize();
 	source.resize(size);
 	reader->Read(&source[0], size);
@@ -26,7 +26,7 @@ ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(cons
 }
 ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(const std::wstring& pathScript, const std::wstring& pathArchive, const std::string& source, bool bNeedHeader)
 {
-	ref_count_ptr<ScriptInformation> res = NULL;
+	ref_count_ptr<ScriptInformation> res = nullptr;
 
 	Scanner scanner(source);
 	int encoding = scanner.GetEncoding();
@@ -37,21 +37,22 @@ ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(cons
 			type = TYPE_UNKNOWN;
 			bScript = true;
 		}
-		std::wstring idScript = L"";
-		std::wstring title = L"";
-		std::wstring text = L"";
-		std::wstring pathImage = L"";
+		std::wstring idScript;
+		std::wstring title;
+		std::wstring text;
+		std::wstring pathImage;
 		std::wstring pathSystem = DEFAULT;
 		std::wstring pathBackground = DEFAULT;
 		std::wstring pathBGM = DEFAULT;
 		std::vector<std::wstring> listPlayer;
-		std::wstring replayName = L"";
+		std::wstring replayName;
 
 		while (scanner.HasNext()) {
 			Token& tok = scanner.Next();
 			if (tok.GetType() == Token::TK_EOF) { //Eofの識別子が来たらファイルの調査終了
 				break;
-			} else if (tok.GetType() == Token::TK_SHARP) {
+			}
+			if (tok.GetType() == Token::TK_SHARP) {
 				tok = scanner.Next();
 				std::wstring element = tok.GetElement();
 				bool bShiftJisDanmakufu = false;
@@ -106,10 +107,10 @@ ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(cons
 
 		if (bScript) {
 			//IDがなかった場合はしょうがないのでファイル名にする。
-			if (idScript.size() == 0)
+			if (idScript.empty())
 				idScript = PathProperty::GetFileNameWithoutExtension(pathScript);
 
-			if (replayName.size() == 0) {
+			if (replayName.empty()) {
 				replayName = idScript;
 				if (replayName.size() > 8)
 					replayName = replayName.substr(0, 8);
@@ -138,7 +139,7 @@ ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(cons
 			res->SetReplayName(replayName);
 		}
 	} catch (...) {
-		res = NULL;
+		res = nullptr;
 	}
 
 	return res;
@@ -171,7 +172,7 @@ std::vector<std::wstring> ScriptInformation::_GetStringList(Scanner& scanner)
 		int type = tok.GetType();
 		if (type == Token::TK_CLOSEB)
 			break;
-		else if (type == Token::TK_STRING) {
+		if (type == Token::TK_STRING) {
 			std::wstring wstr = tok.GetString();
 			res.push_back(wstr);
 		}
@@ -183,23 +184,22 @@ std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::CreatePlayerScr
 	std::vector<ref_count_ptr<ScriptInformation>> res;
 	std::vector<std::wstring> listPlayerPath = GetPlayerList();
 	std::wstring dirInfo = PathProperty::GetFileDirectory(GetScriptPath());
-	for (int iPath = 0; iPath < listPlayerPath.size(); iPath++) {
-		std::wstring pathPlayer = listPlayerPath[iPath];
+	for (const auto& pathPlayer : listPlayerPath) {
 		std::wstring path = EPathProperty::ExtendRelativeToFull(dirInfo, pathPlayer);
 
 		ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-		if (reader == NULL || !reader->Open()) {
+		if (reader == nullptr || !reader->Open()) {
 			Logger::WriteTop(ErrorUtility::GetFileNotFoundErrorMessage(path));
 			continue;
 		}
 
-		std::string source = "";
+		std::string source;
 		int size = reader->GetFileSize();
 		source.resize(size);
 		reader->Read(&source[0], size);
 
 		ref_count_ptr<ScriptInformation> info = ScriptInformation::CreateScriptInformation(path, L"", source);
-		if (info != NULL && info->GetType() == ScriptInformation::TYPE_PLAYER) {
+		if (info != nullptr && info->GetType() == ScriptInformation::TYPE_PLAYER) {
 			res.push_back(info);
 		}
 	}
@@ -225,10 +225,9 @@ std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::CreateScriptInf
 			return res;
 
 		std::multimap<std::wstring, ref_count_ptr<ArchiveFileEntry>> mapEntry = archive.GetEntryMap();
-		std::multimap<std::wstring, ref_count_ptr<ArchiveFileEntry>>::iterator itr = mapEntry.begin();
-		for (; itr != mapEntry.end(); itr++) {
+		for (auto& itr : mapEntry) {
 			//明らかに関係なさそうな拡張子は除外
-			ref_count_ptr<ArchiveFileEntry> entry = itr->second;
+			ref_count_ptr<ArchiveFileEntry> entry = itr.second;
 			std::wstring dir = PathProperty::GetFileDirectory(path);
 			std::wstring tPath = dir + entry->GetDirectory() + entry->GetName();
 
@@ -237,13 +236,13 @@ std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::CreateScriptInf
 				continue;
 
 			ref_count_ptr<gstd::ByteBuffer> buffer = ArchiveFile::CreateEntryBuffer(entry);
-			std::string source = "";
+			std::string source;
 			int size = buffer->GetSize();
 			source.resize(size);
 			buffer->Read(&source[0], size);
 
 			ref_count_ptr<ScriptInformation> info = CreateScriptInformation(tPath, path, source, bNeedHeader);
-			if (info != NULL)
+			if (info != nullptr)
 				res.push_back(info);
 		}
 	} else {
@@ -254,13 +253,13 @@ std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::CreateScriptInf
 			return res;
 
 		file.SetFilePointerBegin();
-		std::string source = "";
+		std::string source;
 		int size = file.GetSize();
 		source.resize(size);
 		file.Read(&source[0], size);
 
 		ref_count_ptr<ScriptInformation> info = CreateScriptInformation(path, L"", source, bNeedHeader);
-		if (info != NULL)
+		if (info != nullptr)
 			res.push_back(info);
 	}
 
@@ -281,8 +280,8 @@ std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::FindPlayerScrip
 			tDir += L"\\";
 
 			std::vector<ref_count_ptr<ScriptInformation>> list = FindPlayerScriptInformationList(tDir);
-			for (std::vector<ref_count_ptr<ScriptInformation>>::iterator itr = list.begin(); itr != list.end(); itr++) {
-				res.push_back(*itr);
+			for (auto& itr : list) {
+				res.push_back(itr);
 			}
 			continue;
 		}
@@ -294,9 +293,8 @@ std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::FindPlayerScrip
 
 		//スクリプト解析
 		std::vector<ref_count_ptr<ScriptInformation>> listInfo = CreateScriptInformationList(path, true);
-		for (int iInfo = 0; iInfo < listInfo.size(); iInfo++) {
-			ref_count_ptr<ScriptInformation> info = listInfo[iInfo];
-			if (info != NULL && info->GetType() == ScriptInformation::TYPE_PLAYER) {
+		for (auto& info : listInfo) {
+			if (info != nullptr && info->GetType() == ScriptInformation::TYPE_PLAYER) {
 				res.push_back(info);
 			}
 		}
@@ -310,7 +308,7 @@ std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::FindPlayerScrip
 /**********************************************************
 //ErrorDialog
 **********************************************************/
-HWND ErrorDialog::hWndParentStatic_ = NULL;
+HWND ErrorDialog::hWndParentStatic_ = nullptr;
 ErrorDialog::ErrorDialog(HWND hParent)
 {
 	hParent_ = hParent;
@@ -360,7 +358,7 @@ LRESULT ErrorDialog::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 }
 bool ErrorDialog::ShowModal(const std::wstring& msg)
 {
-	HINSTANCE hInst = ::GetModuleHandle(NULL);
+	HINSTANCE hInst = ::GetModuleHandle(nullptr);
 	std::wstring wName = L"ErrorWindow";
 
 	WNDCLASSEX wcex;
@@ -368,18 +366,18 @@ bool ErrorDialog::ShowModal(const std::wstring& msg)
 	wcex.cbSize = sizeof(WNDCLASSEX);
 	wcex.lpfnWndProc = (WNDPROC)WindowBase::_StaticWindowProcedure;
 	wcex.hInstance = hInst;
-	wcex.hIcon = NULL;
-	wcex.hCursor = LoadCursor(NULL, IDC_ARROW);
+	wcex.hIcon = nullptr;
+	wcex.hCursor = LoadCursor(nullptr, IDC_ARROW);
 	wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW);
-	wcex.lpszMenuName = NULL;
+	wcex.lpszMenuName = nullptr;
 	wcex.lpszClassName = wName.c_str();
-	wcex.hIconSm = NULL;
+	wcex.hIconSm = nullptr;
 	RegisterClassEx(&wcex);
 
 	hWnd_ = ::CreateWindow(wcex.lpszClassName,
 		wName.c_str(),
 		WS_OVERLAPPEDWINDOW,
-		0, 0, 480, 320, hParent_, (HMENU)NULL, hInst, NULL);
+		0, 0, 480, 320, hParent_, (HMENU)nullptr, hInst, nullptr);
 	::ShowWindow(hWnd_, SW_HIDE);
 	this->Attach(hWnd_);
 
@@ -437,9 +435,7 @@ DnhConfiguration::DnhConfiguration()
 	LoadConfigFile();
 	_LoadDefintionFile();
 }
-DnhConfiguration::~DnhConfiguration()
-{
-}
+DnhConfiguration::~DnhConfiguration() = default;
 bool DnhConfiguration::_LoadDefintionFile()
 {
 	std::wstring path = PathProperty::GetModuleDirectory() + L"th_dnh.def";
@@ -448,7 +444,7 @@ bool DnhConfiguration::_LoadDefintionFile()
 		return false;
 
 	pathPackageScript_ = prop.GetString(L"package.script.main", L"");
-	if (pathPackageScript_.size() > 0) {
+	if (!pathPackageScript_.empty()) {
 		pathPackageScript_ = PathProperty::GetModuleDirectory() + pathPackageScript_;
 	}
 
@@ -489,7 +485,7 @@ bool DnhConfiguration::LoadConfigFile()
 	record.GetRecord("mapKey", bufKey.GetPointer(), bufKey.GetSize());
 	int mapKeyCount = bufKey.ReadInteger();
 	if (mapKeyCount == mapKey_.size()) {
-		for (int iKey = 0; iKey < mapKeyCount; iKey++) {
+		for (int iKey = 0; iKey < mapKeyCount; ++iKey) {
 			int id = bufKey.ReadInteger();
 			int keyCode = bufKey.ReadInteger();
 			int padIndex = bufKey.ReadInteger();
@@ -519,10 +515,9 @@ bool DnhConfiguration::SaveConfigFile()
 	record.SetRecordAsInteger("padIndex", padIndex_);
 	ByteBuffer bufKey;
 	bufKey.WriteInteger(mapKey_.size());
-	std::map<int, ref_count_ptr<VirtualKey>>::iterator itrKey = mapKey_.begin();
-	for (; itrKey != mapKey_.end(); itrKey++) {
-		int id = itrKey->first;
-		ref_count_ptr<VirtualKey> vk = itrKey->second;
+	for (auto& itrKey : mapKey_) {
+		int id = itrKey.first;
+		ref_count_ptr<VirtualKey> vk = itrKey.second;
 
 		bufKey.WriteInteger(id);
 		bufKey.WriteInteger(vk->GetKeyCode());
@@ -542,7 +537,7 @@ bool DnhConfiguration::SaveConfigFile()
 ref_count_ptr<VirtualKey> DnhConfiguration::GetVirtualKey(int id)
 {
 	if (mapKey_.find(id) == mapKey_.end())
-		return NULL;
+		return nullptr;
 
 	ref_count_ptr<VirtualKey> res = mapKey_[id];
 	return res;

--- a/source/TouhouDanmakufu/Common/DnhCommon.cpp
+++ b/source/TouhouDanmakufu/Common/DnhCommon.cpp
@@ -8,7 +8,7 @@
 **********************************************************/
 const std::wstring ScriptInformation::DEFAULT = L"DEFAULT";
 
-ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(std::wstring pathScript, bool bNeedHeader)
+ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(const std::wstring& pathScript, bool bNeedHeader)
 {
 	ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(pathScript);
 	if (reader == NULL || !reader->Open()) {
@@ -24,7 +24,7 @@ ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(std:
 	ref_count_ptr<ScriptInformation> res = CreateScriptInformation(pathScript, L"", source, bNeedHeader);
 	return res;
 }
-ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(std::wstring pathScript, std::wstring pathArchive, std::string source, bool bNeedHeader)
+ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(const std::wstring& pathScript, const std::wstring& pathArchive, const std::string& source, bool bNeedHeader)
 {
 	ref_count_ptr<ScriptInformation> res = NULL;
 
@@ -143,7 +143,7 @@ ref_count_ptr<ScriptInformation> ScriptInformation::CreateScriptInformation(std:
 
 	return res;
 }
-bool ScriptInformation::IsExcludeExtention(std::wstring ext)
+bool ScriptInformation::IsExcludeExtension(const std::wstring& ext)
 {
 	bool res = false;
 	if (ext == L".dat" || ext == L".mid" || ext == L".wav" || ext == L".mp3" || ext == L".ogg" || ext == L".bmp" || ext == L".png" || ext == L"jpg" || ext == L".mqo" || ext == L".elem") {
@@ -205,7 +205,7 @@ std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::CreatePlayerScr
 	}
 	return res;
 }
-std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::CreateScriptInformationList(std::wstring path, bool bNeedHeader)
+std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::CreateScriptInformationList(const std::wstring& path, bool bNeedHeader)
 {
 	std::vector<ref_count_ptr<ScriptInformation>> res;
 	File file(path);
@@ -233,7 +233,7 @@ std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::CreateScriptInf
 			std::wstring tPath = dir + entry->GetDirectory() + entry->GetName();
 
 			std::wstring ext = PathProperty::GetFileExtension(tPath);
-			if (ScriptInformation::IsExcludeExtention(ext))
+			if (ScriptInformation::IsExcludeExtension(ext))
 				continue;
 
 			ref_count_ptr<gstd::ByteBuffer> buffer = ArchiveFile::CreateEntryBuffer(entry);
@@ -250,7 +250,7 @@ std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::CreateScriptInf
 
 		//明らかに関係なさそうな拡張子は除外
 		std::wstring ext = PathProperty::GetFileExtension(path);
-		if (ScriptInformation::IsExcludeExtention(ext))
+		if (ScriptInformation::IsExcludeExtension(ext))
 			return res;
 
 		file.SetFilePointerBegin();
@@ -266,7 +266,7 @@ std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::CreateScriptInf
 
 	return res;
 }
-std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::FindPlayerScriptInformationList(std::wstring dir)
+std::vector<ref_count_ptr<ScriptInformation>> ScriptInformation::FindPlayerScriptInformationList(const std::wstring& dir)
 {
 	std::vector<ref_count_ptr<ScriptInformation>> res;
 	WIN32_FIND_DATA data;
@@ -358,7 +358,7 @@ LRESULT ErrorDialog::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 	}
 	return _CallPreviousWindowProcedure(hWnd, uMsg, wParam, lParam);
 }
-bool ErrorDialog::ShowModal(std::wstring msg)
+bool ErrorDialog::ShowModal(const std::wstring& msg)
 {
 	HINSTANCE hInst = ::GetModuleHandle(NULL);
 	std::wstring wName = L"ErrorWindow";

--- a/source/TouhouDanmakufu/Common/DnhCommon.hpp
+++ b/source/TouhouDanmakufu/Common/DnhCommon.hpp
@@ -25,42 +25,42 @@ public:
 public:
 	ScriptInformation() {}
 	virtual ~ScriptInformation() {}
-	int GetType() { return type_; }
+	int GetType() const { return type_; }
 	void SetType(int type) { type_ = type; }
-	std::wstring GetArchivePath() { return pathArchive_; }
-	void SetArchivePath(std::wstring path) { pathArchive_ = path; }
-	std::wstring GetScriptPath() { return pathScript_; }
-	void SetScriptPath(std::wstring path) { pathScript_ = path; }
+	std::wstring GetArchivePath() const { return pathArchive_; }
+	void SetArchivePath(const std::wstring& path) { pathArchive_ = path; }
+	std::wstring GetScriptPath() const { return pathScript_; }
+	void SetScriptPath(const std::wstring& path) { pathScript_ = path; }
 
-	std::wstring GetID() { return id_; }
-	void SetID(std::wstring id) { id_ = id; }
-	std::wstring GetTitle() { return title_; }
-	void SetTitle(std::wstring title) { title_ = title; }
-	std::wstring GetText() { return text_; }
-	void SetText(std::wstring text) { text_ = text; }
-	std::wstring GetImagePath() { return pathImage_; }
-	void SetImagePath(std::wstring path) { pathImage_ = path; }
-	std::wstring GetSystemPath() { return pathSystem_; }
-	void SetSystemPath(std::wstring path) { pathSystem_ = path; }
-	std::wstring GetBackgroundPath() { return pathBackground_; }
-	void SetBackgroundPath(std::wstring path) { pathBackground_ = path; }
-	std::wstring GetBgmPath() { return pathBGM_; }
-	void SetBgmPath(std::wstring path) { pathBGM_ = path; }
-	std::vector<std::wstring> GetPlayerList() { return listPlayer_; }
-	void SetPlayerList(std::vector<std::wstring> list) { listPlayer_ = list; }
+	std::wstring GetID() const { return id_; }
+	void SetID(const std::wstring& id) { id_ = id; }
+	std::wstring GetTitle() const { return title_; }
+	void SetTitle(const std::wstring& title) { title_ = title; }
+	std::wstring GetText() const { return text_; }
+	void SetText(const std::wstring& text) { text_ = text; }
+	std::wstring GetImagePath() const { return pathImage_; }
+	void SetImagePath(const std::wstring& path) { pathImage_ = path; }
+	std::wstring GetSystemPath() const { return pathSystem_; }
+	void SetSystemPath(const std::wstring& path) { pathSystem_ = path; }
+	std::wstring GetBackgroundPath() const { return pathBackground_; }
+	void SetBackgroundPath(const std::wstring& path) { pathBackground_ = path; }
+	std::wstring GetBgmPath() const { return pathBGM_; }
+	void SetBgmPath(const std::wstring& path) { pathBGM_ = path; }
+	std::vector<std::wstring> GetPlayerList() const { return listPlayer_; }
+	void SetPlayerList(const std::vector<std::wstring>& list) { listPlayer_ = list; }
 
-	std::wstring GetReplayName() { return replayName_; }
-	void SetReplayName(std::wstring name) { replayName_ = name; }
+	std::wstring GetReplayName() const { return replayName_; }
+	void SetReplayName(const std::wstring& name) { replayName_ = name; }
 
 	std::vector<ref_count_ptr<ScriptInformation>> CreatePlayerScriptInformationList();
 
 public:
-	static ref_count_ptr<ScriptInformation> CreateScriptInformation(std::wstring pathScript, bool bNeedHeader = true);
-	static ref_count_ptr<ScriptInformation> CreateScriptInformation(std::wstring pathScript, std::wstring pathArchive, std::string source, bool bNeedHeader = true);
+	static ref_count_ptr<ScriptInformation> CreateScriptInformation(const std::wstring& pathScript, bool bNeedHeader = true);
+	static ref_count_ptr<ScriptInformation> CreateScriptInformation(const std::wstring& pathScript, const std::wstring& pathArchive, const std::string& source, bool bNeedHeader = true);
 
-	static std::vector<ref_count_ptr<ScriptInformation>> CreateScriptInformationList(std::wstring path, bool bNeedHeader = true);
-	static std::vector<ref_count_ptr<ScriptInformation>> FindPlayerScriptInformationList(std::wstring dir);
-	static bool IsExcludeExtention(std::wstring ext);
+	static std::vector<ref_count_ptr<ScriptInformation>> CreateScriptInformationList(const std::wstring& path, bool bNeedHeader = true);
+	static std::vector<ref_count_ptr<ScriptInformation>> FindPlayerScriptInformationList(const std::wstring& dir);
+	static bool IsExcludeExtension(const std::wstring& ext);
 
 private:
 	static std::wstring _GetString(Scanner& scanner);
@@ -85,7 +85,7 @@ private:
 
 class ScriptInformation::Sort {
 public:
-	BOOL operator()(const ref_count_ptr<ScriptInformation>& lf, const ref_count_ptr<ScriptInformation>& rf)
+	BOOL operator()(const ref_count_ptr<ScriptInformation>& lf, const ref_count_ptr<ScriptInformation>& rf) const
 	{
 		ref_count_ptr<ScriptInformation> lsp = lf;
 		ref_count_ptr<ScriptInformation> rsp = rf;
@@ -100,7 +100,7 @@ public:
 };
 
 struct ScriptInformation::PlayerListSort {
-	BOOL operator()(const ref_count_ptr<ScriptInformation>& lf, const ref_count_ptr<ScriptInformation>& rf)
+	BOOL operator()(const ref_count_ptr<ScriptInformation>& lf, const ref_count_ptr<ScriptInformation>& rf) const
 	{
 		ref_count_ptr<ScriptInformation> lsp = lf;
 		ref_count_ptr<ScriptInformation> rsp = rf;
@@ -118,10 +118,10 @@ struct ScriptInformation::PlayerListSort {
 class ErrorDialog : public ModalDialog {
 public:
 	ErrorDialog(HWND hParent);
-	bool ShowModal(std::wstring msg);
+	bool ShowModal(const std::wstring& msg);
 
 	static void SetParentWindowHandle(HWND hWndParent) { hWndParentStatic_ = hWndParent; }
-	static void ShowErrorDialog(std::wstring msg)
+	static void ShowErrorDialog(const std::wstring& msg)
 	{
 		ErrorDialog dialog(hWndParentStatic_);
 		dialog.ShowModal(msg);
@@ -163,28 +163,28 @@ public:
 	bool LoadConfigFile();
 	bool SaveConfigFile();
 
-	int GetScreenMode() { return modeScreen_; }
+	int GetScreenMode() const { return modeScreen_; }
 	void SetScreenMode(int mode) { modeScreen_ = mode; }
-	int GetWindowSize() { return sizeWindow_; }
+	int GetWindowSize() const { return sizeWindow_; }
 	void SetWindowSize(int size) { sizeWindow_ = size; }
-	int GetFpsType() { return fpsType_; }
+	int GetFpsType() const { return fpsType_; }
 	void SetFpsType(int type) { fpsType_ = type; }
 
 	int GetPadIndex() { return padIndex_; }
 	void SetPadIndex(int index) { padIndex_ = index; }
 	ref_count_ptr<VirtualKey> GetVirtualKey(int id);
 
-	bool IsLogWindow() { return bLogWindow_; }
+	bool IsLogWindow() const { return bLogWindow_; }
 	void SetLogWindow(bool b) { bLogWindow_ = b; }
-	bool IsLogFile() { return bLogFile_; }
+	bool IsLogFile() const { return bLogFile_; }
 	void SetLogFile(bool b) { bLogFile_ = b; }
-	bool IsMouseVisible() { return bMouseVisible_; }
+	bool IsMouseVisible() const { return bMouseVisible_; }
 	void SetMouseVisible(bool b) { bMouseVisible_ = b; }
 
-	std::wstring GetPackageScriptPath() { return pathPackageScript_; }
-	std::wstring GetWindowTitle() { return windowTitle_; }
-	int GetScreenWidth() { return screenWidth_; }
-	int GetScreenHeight() { return screenHeight_; }
+	std::wstring GetPackageScriptPath() const { return pathPackageScript_; }
+	std::wstring GetWindowTitle() const { return windowTitle_; }
+	int GetScreenWidth() const { return screenWidth_; }
+	int GetScreenHeight() const { return screenHeight_; }
 
 private:
 	int modeScreen_; //DirectGraphics::SCREENMODE_FULLSCREEN,SCREENMODE_WINDOW

--- a/source/TouhouDanmakufu/Common/DnhCommon.hpp
+++ b/source/TouhouDanmakufu/Common/DnhCommon.hpp
@@ -23,8 +23,8 @@ public:
 	struct PlayerListSort;
 
 public:
-	ScriptInformation() {}
-	virtual ~ScriptInformation() {}
+	ScriptInformation() = default;
+	virtual ~ScriptInformation() = default;
 	int GetType() const { return type_; }
 	void SetType(int type) { type_ = type; }
 	std::wstring GetArchivePath() const { return pathArchive_; }
@@ -89,8 +89,8 @@ public:
 	{
 		ref_count_ptr<ScriptInformation> lsp = lf;
 		ref_count_ptr<ScriptInformation> rsp = rf;
-		ScriptInformation* lp = (ScriptInformation*)lsp.GetPointer();
-		ScriptInformation* rp = (ScriptInformation*)rsp.GetPointer();
+		auto* lp = (ScriptInformation*)lsp.GetPointer();
+		auto* rp = (ScriptInformation*)rsp.GetPointer();
 		std::wstring lPath = lp->GetScriptPath();
 		std::wstring rPath = rp->GetScriptPath();
 		BOOL res = CompareString(LOCALE_SYSTEM_DEFAULT, NORM_IGNORECASE,
@@ -133,7 +133,7 @@ protected:
 	WEditBox edit_;
 	WButton button_;
 
-	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 };
 
 /**********************************************************
@@ -159,7 +159,7 @@ public:
 
 public:
 	DnhConfiguration();
-	virtual ~DnhConfiguration();
+	~DnhConfiguration() override;
 	bool LoadConfigFile();
 	bool SaveConfigFile();
 

--- a/source/TouhouDanmakufu/Common/DnhGcLibImpl.cpp
+++ b/source/TouhouDanmakufu/Common/DnhGcLibImpl.cpp
@@ -64,7 +64,7 @@ std::wstring EPathProperty::ExtendRelativeToFull(const std::wstring& dir, const 
 	}
 
 	std::wstring drive = PathProperty::GetDriveName(newPath);
-	if (drive.size() == 0) {
+	if (drive.empty()) {
 		newPath = GetModuleDirectory() + newPath;
 	}
 
@@ -74,9 +74,7 @@ std::wstring EPathProperty::ExtendRelativeToFull(const std::wstring& dir, const 
 /**********************************************************
 //ELogger
 **********************************************************/
-ELogger::ELogger()
-{
-}
+ELogger::ELogger() = default;
 void ELogger::Initialize(bool bFile, bool bWindow)
 {
 	gstd::ref_count_ptr<gstd::FileLogger> fileLogger = new gstd::FileLogger();
@@ -103,14 +101,14 @@ EFpsController::EFpsController()
 	DnhConfiguration* config = DnhConfiguration::GetInstance();
 	int fpsType = config->GetFpsType();
 	if (fpsType == DnhConfiguration::FPS_NORMAL || fpsType == DnhConfiguration::FPS_1_2 || fpsType == DnhConfiguration::FPS_1_3) {
-		StaticFpsController* controller = new StaticFpsController();
+		auto* controller = new StaticFpsController();
 		if (fpsType == DnhConfiguration::FPS_1_2)
 			controller->SetSkipRate(1);
 		else if (fpsType == DnhConfiguration::FPS_1_3)
 			controller->SetSkipRate(2);
 		controller_ = controller;
 	} else {
-		AutoSkipFpsController* controller = new AutoSkipFpsController();
+		auto* controller = new AutoSkipFpsController();
 		controller_ = controller;
 	}
 
@@ -142,7 +140,7 @@ bool ETextureManager::Initialize()
 {
 	bool res = TextureManager::Initialize();
 
-	for (int iRender = 0; iRender < MAX_RESERVED_RENDERTARGET; iRender++) {
+	for (int iRender = 0; iRender < MAX_RESERVED_RENDERTARGET; ++iRender) {
 		std::wstring name = GetReservedRenderTargetName(iRender);
 		ref_count_ptr<Texture> texture = new Texture();
 		res &= texture->CreateRenderTarget(name);

--- a/source/TouhouDanmakufu/Common/DnhGcLibImpl.cpp
+++ b/source/TouhouDanmakufu/Common/DnhGcLibImpl.cpp
@@ -40,35 +40,35 @@ std::wstring EPathProperty::GetPlayerScriptRootDirectory()
 	std::wstring path = GetModuleDirectory() + L"script/player/";
 	return path;
 }
-std::wstring EPathProperty::GetReplaySaveDirectory(std::wstring scriptPath)
+std::wstring EPathProperty::GetReplaySaveDirectory(const std::wstring& scriptPath)
 {
 	std::wstring scriptName = PathProperty::GetFileNameWithoutExtension(scriptPath);
 	std::wstring dir = PathProperty::GetFileDirectory(scriptPath) + L"replay/";
 	return dir;
 }
-std::wstring EPathProperty::GetCommonDataPath(std::wstring scriptPath, std::wstring area)
+std::wstring EPathProperty::GetCommonDataPath(const std::wstring& scriptPath, const std::wstring& area)
 {
 	std::wstring dirSave = PathProperty::GetFileDirectory(scriptPath) + L"data/";
 	std::wstring nameMain = PathProperty::GetFileNameWithoutExtension(scriptPath);
 	std::wstring path = dirSave + nameMain + StringUtility::Format(L"_common_%s.dat", area.c_str());
 	return path;
 }
-std::wstring EPathProperty::ExtendRelativeToFull(std::wstring dir, std::wstring path)
+std::wstring EPathProperty::ExtendRelativeToFull(const std::wstring& dir, const std::wstring& path)
 {
-	path = StringUtility::ReplaceAll(path, L"\\", L"/");
-	if (path.size() >= 2) {
-		if (path[0] == L'.' && path[1] == L'/') {
-			path = path.substr(2);
-			path = dir + path;
+	std::wstring newPath = StringUtility::ReplaceAll(path, L"\\", L"/");
+	if (newPath.size() >= 2) {
+		if (newPath[0] == L'.' && newPath[1] == L'/') {
+			newPath = newPath.substr(2);
+			newPath = dir + newPath;
 		}
 	}
 
-	std::wstring drive = PathProperty::GetDriveName(path);
+	std::wstring drive = PathProperty::GetDriveName(newPath);
 	if (drive.size() == 0) {
-		path = GetModuleDirectory() + path;
+		newPath = GetModuleDirectory() + newPath;
 	}
 
-	return path;
+	return newPath;
 }
 
 /**********************************************************

--- a/source/TouhouDanmakufu/Common/DnhGcLibImpl.hpp
+++ b/source/TouhouDanmakufu/Common/DnhGcLibImpl.hpp
@@ -17,10 +17,10 @@ public:
 	static std::wstring GetStgDefaultScriptDirectory();
 	static std::wstring GetPlayerScriptRootDirectory();
 
-	static std::wstring GetReplaySaveDirectory(std::wstring scriptPath);
-	static std::wstring GetCommonDataPath(std::wstring scriptPath, std::wstring area);
+	static std::wstring GetReplaySaveDirectory(const std::wstring& scriptPath);
+	static std::wstring GetCommonDataPath(const std::wstring& scriptPath, const std::wstring& area);
 
-	static std::wstring ExtendRelativeToFull(std::wstring dir, std::wstring path);
+	static std::wstring ExtendRelativeToFull(const std::wstring& dir, const std::wstring& path);
 };
 
 /**********************************************************
@@ -46,22 +46,22 @@ public:
 	EFpsController();
 
 	void SetFps(int fps) { controller_->SetFps(fps); }
-	int GetFps() { return controller_->GetFps(); }
+	int GetFps() const { return controller_->GetFps(); }
 	void SetTimerEnable(bool b) { controller_->SetTimerEnable(b); }
 
 	void Wait() { controller_->Wait(); }
-	bool IsSkip() { return controller_->IsSkip(); }
+	bool IsSkip() const { return controller_->IsSkip(); }
 	void SetCriticalFrame() { controller_->SetCriticalFrame(); }
-	float GetCurrentFps() { return controller_->GetCurrentFps(); }
-	float GetCurrentWorkFps() { return controller_->GetCurrentWorkFps(); }
-	float GetCurrentRenderFps() { return controller_->GetCurrentRenderFps(); }
-	bool IsFastMode() { return controller_->IsFastMode(); }
+	float GetCurrentFps() const { return controller_->GetCurrentFps(); }
+	float GetCurrentWorkFps() const { return controller_->GetCurrentWorkFps(); }
+	float GetCurrentRenderFps() const { return controller_->GetCurrentRenderFps(); }
+	bool IsFastMode() const { return controller_->IsFastMode(); }
 	void SetFastMode(bool b) { controller_->SetFastMode(b); }
 
 	void AddFpsControlObject(ref_count_weak_ptr<FpsControlObject> obj) { controller_->AddFpsControlObject(obj); }
 	void RemoveFpsControlObject(ref_count_weak_ptr<FpsControlObject> obj) { controller_->RemoveFpsControlObject(obj); }
 
-	int GetFastModeKey() { return fastModeKey_; }
+	int GetFastModeKey() const { return fastModeKey_; }
 	void SetFastModeKey(int key) { fastModeKey_ = key; }
 
 private:
@@ -161,7 +161,7 @@ public:
 public:
 	virtual bool Initialize(HWND hWnd);
 	void ResetVirtualKeyMap();
-	int GetPadIndex() { return padIndex_; }
+	int GetPadIndex() const { return padIndex_; }
 };
 
 #endif

--- a/source/TouhouDanmakufu/Common/DnhGcLibImpl.hpp
+++ b/source/TouhouDanmakufu/Common/DnhGcLibImpl.hpp
@@ -99,7 +99,7 @@ class ETextureManager : public Singleton<ETextureManager>, public TextureManager
 	};
 
 public:
-	virtual bool Initialize();
+	bool Initialize() override;
 	std::wstring GetReservedRenderTargetName(int index);
 };
 
@@ -159,7 +159,7 @@ public:
 	int padIndex_;
 
 public:
-	virtual bool Initialize(HWND hWnd);
+	bool Initialize(HWND hWnd) override;
 	void ResetVirtualKeyMap();
 	int GetPadIndex() const { return padIndex_; }
 };

--- a/source/TouhouDanmakufu/Common/DnhReplay.cpp
+++ b/source/TouhouDanmakufu/Common/DnhReplay.cpp
@@ -8,16 +8,13 @@ ReplayInformation::ReplayInformation()
 {
 	userData_ = new ScriptCommonData();
 }
-ReplayInformation::~ReplayInformation()
-{
-}
+ReplayInformation::~ReplayInformation() = default;
 std::vector<int> ReplayInformation::GetStageIndexList()
 {
 	std::vector<int> res;
 
-	std::map<int, ref_count_ptr<StageData>>::iterator itr = mapStageData_.begin();
-	for (; itr != mapStageData_.end(); itr++) {
-		int stage = itr->first;
+	for (auto& itr : mapStageData_) {
+		int stage = itr.first;
 		res.push_back(stage);
 	}
 
@@ -77,8 +74,7 @@ bool ReplayInformation::SaveToFile(const std::wstring& scriptPath, int index)
 	std::vector<int> listStage = GetStageIndexList();
 	rec.SetRecordAsInteger("stageCount", listStage.size());
 	rec.SetRecord("stageIndexList", &listStage[0], sizeof(int) * listStage.size());
-	for (int iStage = 0; iStage < listStage.size(); iStage++) {
-		int stage = listStage[iStage];
+	for (int stage : listStage) {
 		std::string key = StringUtility::Format("stage%d", stage);
 
 		ref_count_ptr<StageData> data = mapStageData_[stage];
@@ -104,11 +100,11 @@ ref_count_ptr<ReplayInformation> ReplayInformation::CreateFromFile(const std::ws
 {
 	RecordBuffer rec;
 	if (!rec.ReadFromFile(path, "REPLAY"))
-		return NULL;
+		return nullptr;
 
 	int version = rec.GetRecordAsInteger("version");
 	if (version != 1)
-		return NULL;
+		return nullptr;
 
 	ref_count_ptr<ReplayInformation> res = new ReplayInformation();
 	res->path_ = path;
@@ -133,8 +129,7 @@ ref_count_ptr<ReplayInformation> ReplayInformation::CreateFromFile(const std::ws
 	std::vector<int> listStage;
 	listStage.resize(stageCount);
 	rec.GetRecord("stageIndexList", &listStage[0], sizeof(int) * stageCount);
-	for (int iStage = 0; iStage < listStage.size(); iStage++) {
-		int stage = listStage[iStage];
+	for (int stage : listStage) {
 		std::string key = StringUtility::Format("stage%d", stage);
 		ref_count_ptr<StageData> data = new StageData();
 		gstd::RecordBuffer recStage;
@@ -150,11 +145,11 @@ ref_count_ptr<ReplayInformation> ReplayInformation::CreateFromFile(const std::ws
 double ReplayInformation::StageData::GetFramePerSecondAvarage() const
 {
 	double res = 0;
-	for (int iFrame = 0; iFrame < listFramePerSecond_.size(); iFrame++) {
-		res += listFramePerSecond_[iFrame];
+	for (float iFrame : listFramePerSecond_) {
+		res += iFrame;
 	}
 
-	if (listFramePerSecond_.size() > 0)
+	if (!listFramePerSecond_.empty())
 		res /= listFramePerSecond_.size();
 	return res;
 }
@@ -179,7 +174,7 @@ ref_count_ptr<ScriptCommonData> ReplayInformation::StageData::GetCommonData(cons
 void ReplayInformation::StageData::SetCommonData(const std::string& area, ref_count_ptr<ScriptCommonData> commonData)
 {
 	ref_count_ptr<RecordBuffer> record = new RecordBuffer();
-	if (commonData != NULL)
+	if (commonData != nullptr)
 		commonData->WriteRecord(*record);
 	mapCommonData_[area] = record;
 }
@@ -190,11 +185,11 @@ void ReplayInformation::StageData::ReadRecord(gstd::RecordBuffer& record)
 	mainScriptName_ = record.GetRecordAsStringW("mainScriptName");
 	mainScriptRelativePath_ = record.GetRecordAsStringW("mainScriptRelativePath");
 	if (record.IsExists("scoreStart"))
-		record.GetRecord("scoreStart", &scoreStart_, sizeof(_int64));
+		record.GetRecord("scoreStart", &scoreStart_, sizeof(int64_t));
 	if (record.IsExists("scoreLast"))
-		record.GetRecord("scoreLast", &scoreLast_, sizeof(_int64));
-	record.GetRecord("graze", &graze_, sizeof(_int64));
-	record.GetRecord("point", &point_, sizeof(_int64));
+		record.GetRecord("scoreLast", &scoreLast_, sizeof(int64_t));
+	record.GetRecord("graze", &graze_, sizeof(int64_t));
+	record.GetRecord("point", &point_, sizeof(int64_t));
 	frameEnd_ = record.GetRecordAsInteger("frameEnd");
 	randSeed_ = record.GetRecordAsInteger("randSeed");
 	record.GetRecordAsRecordBuffer("recordKey", *recordKey_);
@@ -207,8 +202,7 @@ void ReplayInformation::StageData::ReadRecord(gstd::RecordBuffer& record)
 	gstd::RecordBuffer recComMap;
 	record.GetRecordAsRecordBuffer("mapCommonData", recComMap);
 	std::vector<std::string> listKeyCommonData = recComMap.GetKeyList();
-	for (int iCommonData = 0; iCommonData < listKeyCommonData.size(); iCommonData++) {
-		std::string key = listKeyCommonData[iCommonData];
+	for (auto key : listKeyCommonData) {
 		ref_count_ptr<RecordBuffer> recComData = new RecordBuffer();
 		recComMap.GetRecordAsRecordBuffer(key, *recComData);
 		mapCommonData_[key] = recComData;
@@ -228,10 +222,10 @@ void ReplayInformation::StageData::WriteRecord(gstd::RecordBuffer& record)
 	record.SetRecordAsStringW("mainScriptID", mainScriptID_);
 	record.SetRecordAsStringW("mainScriptName", mainScriptName_);
 	record.SetRecordAsStringW("mainScriptRelativePath", mainScriptRelativePath_);
-	record.SetRecord("scoreStart", &scoreStart_, sizeof(_int64));
-	record.SetRecord("scoreLast", &scoreLast_, sizeof(_int64));
-	record.SetRecord("graze", &graze_, sizeof(_int64));
-	record.SetRecord("point", &point_, sizeof(_int64));
+	record.SetRecord("scoreStart", &scoreStart_, sizeof(int64_t));
+	record.SetRecord("scoreLast", &scoreLast_, sizeof(int64_t));
+	record.SetRecord("graze", &graze_, sizeof(int64_t));
+	record.SetRecord("point", &point_, sizeof(int64_t));
 	record.SetRecordAsInteger("frameEnd", frameEnd_);
 	record.SetRecordAsInteger("randSeed", randSeed_);
 	record.SetRecordAsRecordBuffer("recordKey", *recordKey_);
@@ -263,12 +257,8 @@ void ReplayInformation::StageData::WriteRecord(gstd::RecordBuffer& record)
 /**********************************************************
 //ReplayInformationManager
 **********************************************************/
-ReplayInformationManager::ReplayInformationManager()
-{
-}
-ReplayInformationManager::~ReplayInformationManager()
-{
-}
+ReplayInformationManager::ReplayInformationManager() = default;
+ReplayInformationManager::~ReplayInformationManager() = default;
 void ReplayInformationManager::UpdateInformationList(const std::wstring& pathScript)
 {
 	mapInfo_.clear();
@@ -279,16 +269,14 @@ void ReplayInformationManager::UpdateInformationList(const std::wstring& pathScr
 	std::vector<std::wstring> listPath = File::GetFilePathList(dir);
 
 	int indexFree = ReplayInformation::INDEX_USER;
-	std::vector<std::wstring>::iterator itr;
-	for (itr = listPath.begin(); itr != listPath.end(); itr++) {
-		std::wstring path = *itr;
+	for (auto& path : listPath) {
 		std::wstring fileName = PathProperty::GetFileName(path);
 
 		if (fileName.find(fileNameHead) == std::wstring::npos)
 			continue;
 
 		ref_count_ptr<ReplayInformation> info = ReplayInformation::CreateFromFile(pathScript, fileName);
-		if (info == NULL)
+		if (info == nullptr)
 			continue;
 
 		std::wstring strKey = fileName.substr(fileNameHead.size());
@@ -298,7 +286,7 @@ void ReplayInformationManager::UpdateInformationList(const std::wstring& pathScr
 			strKey = StringUtility::Format(L"%d", index);
 		} else {
 			index = indexFree;
-			indexFree++;
+			++indexFree;
 			strKey = StringUtility::Format(L"%d", index);
 		}
 
@@ -309,16 +297,16 @@ void ReplayInformationManager::UpdateInformationList(const std::wstring& pathScr
 std::vector<int> ReplayInformationManager::GetIndexList()
 {
 	std::vector<int> res;
-	std::map<int, ref_count_ptr<ReplayInformation>>::iterator itr;
-	for (itr = mapInfo_.begin(); itr != mapInfo_.end(); itr++) {
-		int key = itr->first;
+	for (auto& infoItr : mapInfo_) {
+		int key = infoItr.first;
 		res.push_back(key);
 	}
 	return res;
 }
 ref_count_ptr<ReplayInformation> ReplayInformationManager::GetInformation(int index)
 {
-	if (mapInfo_.find(index) == mapInfo_.end())
-		return NULL;
-	return mapInfo_[index];
+	auto infoItr = mapInfo_.find(index);
+	if (infoItr != mapInfo_.end())
+		return infoItr->second;
+	return nullptr;
 }

--- a/source/TouhouDanmakufu/Common/DnhReplay.cpp
+++ b/source/TouhouDanmakufu/Common/DnhReplay.cpp
@@ -33,22 +33,22 @@ std::wstring ReplayInformation::GetDateAsString()
 
 	return res;
 }
-void ReplayInformation::SetUserData(std::string key, gstd::value val)
+void ReplayInformation::SetUserData(const std::string& key, const gstd::value& val)
 {
 	userData_->SetValue(key, val);
 }
-gstd::value ReplayInformation::GetUserData(std::string key)
+gstd::value ReplayInformation::GetUserData(const std::string& key)
 {
 	gstd::value res = userData_->GetValue(key);
 	return res;
 }
-bool ReplayInformation::IsUserDataExists(std::string key)
+bool ReplayInformation::IsUserDataExists(const std::string& key)
 {
 	bool res = userData_->IsExists(key);
 	return res;
 }
 
-bool ReplayInformation::SaveToFile(std::wstring scriptPath, int index)
+bool ReplayInformation::SaveToFile(const std::wstring& scriptPath, int index)
 {
 	std::wstring dir = EPathProperty::GetReplaySaveDirectory(scriptPath);
 	std::wstring scriptName = PathProperty::GetFileNameWithoutExtension(scriptPath);
@@ -90,7 +90,7 @@ bool ReplayInformation::SaveToFile(std::wstring scriptPath, int index)
 	rec.WriteToFile(path, "REPLAY");
 	return true;
 }
-ref_count_ptr<ReplayInformation> ReplayInformation::CreateFromFile(std::wstring scriptPath, std::wstring fileName)
+ref_count_ptr<ReplayInformation> ReplayInformation::CreateFromFile(const std::wstring& scriptPath, const std::wstring& fileName)
 {
 	std::wstring dir = EPathProperty::GetReplaySaveDirectory(scriptPath);
 	// std::string scriptName = PathProperty::GetFileNameWithoutExtension(scriptPath);
@@ -100,7 +100,7 @@ ref_count_ptr<ReplayInformation> ReplayInformation::CreateFromFile(std::wstring 
 	ref_count_ptr<ReplayInformation> res = CreateFromFile(path);
 	return res;
 }
-ref_count_ptr<ReplayInformation> ReplayInformation::CreateFromFile(std::wstring path)
+ref_count_ptr<ReplayInformation> ReplayInformation::CreateFromFile(const std::wstring& path)
 {
 	RecordBuffer rec;
 	if (!rec.ReadFromFile(path, "REPLAY"))
@@ -147,7 +147,7 @@ ref_count_ptr<ReplayInformation> ReplayInformation::CreateFromFile(std::wstring 
 }
 
 //ReplayInformation::StageData
-double ReplayInformation::StageData::GetFramePerSecondAvarage()
+double ReplayInformation::StageData::GetFramePerSecondAvarage() const
 {
 	double res = 0;
 	for (int iFrame = 0; iFrame < listFramePerSecond_.size(); iFrame++) {
@@ -158,17 +158,16 @@ double ReplayInformation::StageData::GetFramePerSecondAvarage()
 		res /= listFramePerSecond_.size();
 	return res;
 }
-std::set<std::string> ReplayInformation::StageData::GetCommonDataAreaList()
+std::set<std::string> ReplayInformation::StageData::GetCommonDataAreaList() const
 {
 	std::set<std::string> res;
-	std::map<std::string, ref_count_ptr<RecordBuffer>>::iterator itrCommonData;
-	for (itrCommonData = mapCommonData_.begin(); itrCommonData != mapCommonData_.end(); itrCommonData++) {
-		std::string key = itrCommonData->first;
+	for (const auto& commonData : mapCommonData_) {
+		const auto& key = commonData.first;
 		res.insert(key);
 	}
 	return res;
 }
-ref_count_ptr<ScriptCommonData> ReplayInformation::StageData::GetCommonData(std::string area)
+ref_count_ptr<ScriptCommonData> ReplayInformation::StageData::GetCommonData(const std::string& area)
 {
 	ref_count_ptr<ScriptCommonData> res = new ScriptCommonData();
 	if (mapCommonData_.find(area) != mapCommonData_.end()) {
@@ -177,7 +176,7 @@ ref_count_ptr<ScriptCommonData> ReplayInformation::StageData::GetCommonData(std:
 	}
 	return res;
 }
-void ReplayInformation::StageData::SetCommonData(std::string area, ref_count_ptr<ScriptCommonData> commonData)
+void ReplayInformation::StageData::SetCommonData(const std::string& area, ref_count_ptr<ScriptCommonData> commonData)
 {
 	ref_count_ptr<RecordBuffer> record = new RecordBuffer();
 	if (commonData != NULL)
@@ -270,7 +269,7 @@ ReplayInformationManager::ReplayInformationManager()
 ReplayInformationManager::~ReplayInformationManager()
 {
 }
-void ReplayInformationManager::UpdateInformationList(std::wstring pathScript)
+void ReplayInformationManager::UpdateInformationList(const std::wstring& pathScript)
 {
 	mapInfo_.clear();
 

--- a/source/TouhouDanmakufu/Common/DnhReplay.hpp
+++ b/source/TouhouDanmakufu/Common/DnhReplay.hpp
@@ -25,7 +25,7 @@ private:
 
 	std::wstring comment_;
 	std::wstring userName_;
-	_int64 totalScore_;
+	int64_t totalScore_;
 	double fpsAvarage_;
 	SYSTEMTIME date_;
 	ref_count_ptr<ScriptCommonData> userData_;
@@ -47,8 +47,8 @@ public:
 	void SetComment(const std::wstring& comment) { comment_ = comment; }
 	std::wstring GetUserName() const { return userName_; }
 	void SetUserName(const std::wstring& name) { userName_ = name; }
-	_int64 GetTotalScore() const { return totalScore_; }
-	void SetTotalScore(_int64 score) { totalScore_ = score; }
+	int64_t GetTotalScore() const { return totalScore_; }
+	void SetTotalScore(int64_t score) { totalScore_ = score; }
 	double GetAvarageFps() const { return fpsAvarage_; }
 	void SetAvarageFps(double fps) { fpsAvarage_ = fps; }
 	SYSTEMTIME GetDate() { return date_; }
@@ -76,7 +76,7 @@ public:
 		scoreStart_ = 0;
 		scoreLast_ = 0;
 	}
-	virtual ~StageData() {}
+	virtual ~StageData() = default;
 
 	std::wstring GetMainScriptID() const { return mainScriptID_; }
 	void SetMainScriptID(std::wstring id) { mainScriptID_ = id; }
@@ -84,14 +84,14 @@ public:
 	void SetMainScriptName(std::wstring name) { mainScriptName_ = name; }
 	std::wstring GetMainScriptRelativePath() const { return mainScriptRelativePath_; }
 	void SetMainScriptRelativePath(std::wstring path) { mainScriptRelativePath_ = path; }
-	_int64 GetStartScore() const { return scoreStart_; }
-	void SetStartScore(_int64 score) { scoreStart_ = score; }
-	_int64 GetLastScore() const { return scoreLast_; }
-	void SetLastScore(_int64 score) { scoreLast_ = score; }
-	_int64 GetGraze() const { return graze_; }
-	void SetGraze(_int64 graze) { graze_ = graze; }
-	_int64 GetPoint() const { return point_; }
-	void SetPoint(_int64 point) { point_ = point; }
+	int64_t GetStartScore() const { return scoreStart_; }
+	void SetStartScore(int64_t score) { scoreStart_ = score; }
+	int64_t GetLastScore() const { return scoreLast_; }
+	void SetLastScore(int64_t score) { scoreLast_ = score; }
+	int64_t GetGraze() const { return graze_; }
+	void SetGraze(int64_t graze) { graze_ = graze; }
+	int64_t GetPoint() const { return point_; }
+	void SetPoint(int64_t point) { point_ = point; }
 	int GetEndFrame() const { return frameEnd_; }
 	void SetEndFrame(int frame) { frameEnd_ = frame; }
 	int GetRandSeed() const { return randSeed_; }
@@ -134,10 +134,10 @@ private:
 	std::wstring mainScriptName_;
 	std::wstring mainScriptRelativePath_;
 
-	_int64 scoreStart_;
-	_int64 scoreLast_;
-	_int64 graze_;
-	_int64 point_;
+	int64_t scoreStart_;
+	int64_t scoreLast_;
+	int64_t graze_;
+	int64_t point_;
 	int frameEnd_;
 	int randSeed_;
 	std::vector<float> listFramePerSecond_;

--- a/source/TouhouDanmakufu/Common/DnhReplay.hpp
+++ b/source/TouhouDanmakufu/Common/DnhReplay.hpp
@@ -35,37 +35,37 @@ public:
 	ReplayInformation();
 	virtual ~ReplayInformation();
 
-	std::wstring GetPath() { return path_; }
-	std::wstring GetPlayerScriptID() { return playerScriptID_; }
-	void SetPlayerScriptID(std::wstring id) { playerScriptID_ = id; }
-	std::wstring GetPlayerScriptFileName() { return playerScriptFileName_; }
-	void SetPlayerScriptFileName(std::wstring name) { playerScriptFileName_ = name; }
-	std::wstring GetPlayerScriptReplayName() { return playerScriptReplayName_; }
-	void SetPlayerScriptReplayName(std::wstring name) { playerScriptReplayName_ = name; }
+	std::wstring GetPath() const { return path_; }
+	std::wstring GetPlayerScriptID() const { return playerScriptID_; }
+	void SetPlayerScriptID(const std::wstring& id) { playerScriptID_ = id; }
+	std::wstring GetPlayerScriptFileName() const { return playerScriptFileName_; }
+	void SetPlayerScriptFileName(const std::wstring& name) { playerScriptFileName_ = name; }
+	std::wstring GetPlayerScriptReplayName() const { return playerScriptReplayName_; }
+	void SetPlayerScriptReplayName(const std::wstring& name) { playerScriptReplayName_ = name; }
 
-	std::wstring GetComment() { return comment_; }
-	void SetComment(std::wstring comment) { comment_ = comment; }
-	std::wstring GetUserName() { return userName_; }
-	void SetUserName(std::wstring name) { userName_ = name; }
-	_int64 GetTotalScore() { return totalScore_; }
+	std::wstring GetComment() const { return comment_; }
+	void SetComment(const std::wstring& comment) { comment_ = comment; }
+	std::wstring GetUserName() const { return userName_; }
+	void SetUserName(const std::wstring& name) { userName_ = name; }
+	_int64 GetTotalScore() const { return totalScore_; }
 	void SetTotalScore(_int64 score) { totalScore_ = score; }
-	double GetAvarageFps() { return fpsAvarage_; }
+	double GetAvarageFps() const { return fpsAvarage_; }
 	void SetAvarageFps(double fps) { fpsAvarage_ = fps; }
 	SYSTEMTIME GetDate() { return date_; }
 	void SetDate(SYSTEMTIME date) { date_ = date; }
 	std::wstring GetDateAsString();
 
-	void SetUserData(std::string key, gstd::value val);
-	gstd::value GetUserData(std::string key);
-	bool IsUserDataExists(std::string key);
+	void SetUserData(const std::string& key, const gstd::value& val);
+	gstd::value GetUserData(const std::string& key);
+	bool IsUserDataExists(const std::string& key);
 
 	ref_count_ptr<StageData> GetStageData(int stage) { return mapStageData_[stage]; }
 	void SetStageData(int stage, ref_count_ptr<StageData> data) { mapStageData_[stage] = data; }
 	std::vector<int> GetStageIndexList();
 
-	bool SaveToFile(std::wstring scriptPath, int index);
-	static ref_count_ptr<ReplayInformation> CreateFromFile(std::wstring scriptPath, std::wstring fileName);
-	static ref_count_ptr<ReplayInformation> CreateFromFile(std::wstring path);
+	bool SaveToFile(const std::wstring& scriptPath, int index);
+	static ref_count_ptr<ReplayInformation> CreateFromFile(const std::wstring& scriptPath, const std::wstring& fileName);
+	static ref_count_ptr<ReplayInformation> CreateFromFile(const std::wstring& path);
 };
 
 class ReplayInformation::StageData {
@@ -78,51 +78,51 @@ public:
 	}
 	virtual ~StageData() {}
 
-	std::wstring GetMainScriptID() { return mainScriptID_; }
+	std::wstring GetMainScriptID() const { return mainScriptID_; }
 	void SetMainScriptID(std::wstring id) { mainScriptID_ = id; }
-	std::wstring GetMainScriptName() { return mainScriptName_; }
+	std::wstring GetMainScriptName() const { return mainScriptName_; }
 	void SetMainScriptName(std::wstring name) { mainScriptName_ = name; }
-	std::wstring GetMainScriptRelativePath() { return mainScriptRelativePath_; }
+	std::wstring GetMainScriptRelativePath() const { return mainScriptRelativePath_; }
 	void SetMainScriptRelativePath(std::wstring path) { mainScriptRelativePath_ = path; }
-	_int64 GetStartScore() { return scoreStart_; }
+	_int64 GetStartScore() const { return scoreStart_; }
 	void SetStartScore(_int64 score) { scoreStart_ = score; }
-	_int64 GetLastScore() { return scoreLast_; }
+	_int64 GetLastScore() const { return scoreLast_; }
 	void SetLastScore(_int64 score) { scoreLast_ = score; }
-	_int64 GetGraze() { return graze_; }
+	_int64 GetGraze() const { return graze_; }
 	void SetGraze(_int64 graze) { graze_ = graze; }
-	_int64 GetPoint() { return point_; }
+	_int64 GetPoint() const { return point_; }
 	void SetPoint(_int64 point) { point_ = point; }
-	int GetEndFrame() { return frameEnd_; }
+	int GetEndFrame() const { return frameEnd_; }
 	void SetEndFrame(int frame) { frameEnd_ = frame; }
-	int GetRandSeed() { return randSeed_; }
+	int GetRandSeed() const { return randSeed_; }
 	void SetRandSeed(int seed) { randSeed_ = seed; }
-	float GetFramePerSecond(int frame)
+	float GetFramePerSecond(int frame) const
 	{
 		int index = frame / 60;
 		int res = index < listFramePerSecond_.size() ? listFramePerSecond_[index] : 0;
 		return res;
 	}
 	void AddFramePerSecond(float frame) { listFramePerSecond_.push_back(frame); }
-	double GetFramePerSecondAvarage();
+	double GetFramePerSecondAvarage() const;
 	ref_count_ptr<gstd::RecordBuffer> GetReplayKeyRecord() { return recordKey_; }
 	void SetReplayKeyRecord(ref_count_ptr<gstd::RecordBuffer> rec) { recordKey_ = rec; }
-	std::set<std::string> GetCommonDataAreaList();
-	ref_count_ptr<ScriptCommonData> GetCommonData(std::string area);
-	void SetCommonData(std::string area, ref_count_ptr<ScriptCommonData> commonData);
+	std::set<std::string> GetCommonDataAreaList() const;
+	ref_count_ptr<ScriptCommonData> GetCommonData(const std::string& area);
+	void SetCommonData(const std::string& area, ref_count_ptr<ScriptCommonData> commonData);
 
-	std::wstring GetPlayerScriptID() { return playerScriptID_; }
-	void SetPlayerScriptID(std::wstring id) { playerScriptID_ = id; }
-	std::wstring GetPlayerScriptFileName() { return playerScriptFileName_; }
-	void SetPlayerScriptFileName(std::wstring name) { playerScriptFileName_ = name; }
-	std::wstring GetPlayerScriptReplayName() { return playerScriptReplayName_; }
-	void SetPlayerScriptReplayName(std::wstring name) { playerScriptReplayName_ = name; }
-	double GetPlayerLife() { return playerLife_; }
+	std::wstring GetPlayerScriptID() const { return playerScriptID_; }
+	void SetPlayerScriptID(const std::wstring& id) { playerScriptID_ = id; }
+	std::wstring GetPlayerScriptFileName() const { return playerScriptFileName_; }
+	void SetPlayerScriptFileName(const std::wstring& name) { playerScriptFileName_ = name; }
+	std::wstring GetPlayerScriptReplayName() const { return playerScriptReplayName_; }
+	void SetPlayerScriptReplayName(const std::wstring& name) { playerScriptReplayName_ = name; }
+	double GetPlayerLife() const { return playerLife_; }
 	void SetPlayerLife(double life) { playerLife_ = life; }
-	double GetPlayerBombCount() { return playerBombCount_; }
+	double GetPlayerBombCount() const { return playerBombCount_; }
 	void SetPlayerBombCount(double bomb) { playerBombCount_ = bomb; }
-	double GetPlayerPower() { return playerPower_; }
+	double GetPlayerPower() const { return playerPower_; }
 	void SetPlayerPower(double power) { playerPower_ = power; }
-	int GetPlayerRebirthFrame() { return playerRebirthFrame_; }
+	int GetPlayerRebirthFrame() const { return playerRebirthFrame_; }
 	void SetPlayerRebirthFrame(int frame) { playerRebirthFrame_ = frame; }
 
 	void ReadRecord(gstd::RecordBuffer& record);
@@ -163,7 +163,7 @@ public:
 	ReplayInformationManager();
 	virtual ~ReplayInformationManager();
 
-	void UpdateInformationList(std::wstring pathScript);
+	void UpdateInformationList(const std::wstring& pathScript);
 	std::vector<int> GetIndexList();
 	ref_count_ptr<ReplayInformation> GetInformation(int index);
 

--- a/source/TouhouDanmakufu/Common/StgCommon.cpp
+++ b/source/TouhouDanmakufu/Common/StgCommon.cpp
@@ -11,16 +11,14 @@ StgMoveObject::StgMoveObject(StgStageController* stageController)
 	framePattern_ = 0;
 	stageController_ = stageController;
 }
-StgMoveObject::~StgMoveObject()
-{
-}
+StgMoveObject::~StgMoveObject() = default;
 void StgMoveObject::_Move()
 {
-	if (pattern_ == NULL)
+	if (pattern_ == nullptr)
 		return;
 
-	if (mapPattern_.size() > 0) {
-		std::map<int, ref_count_ptr<StgMovePattern>::unsync>::iterator itr = mapPattern_.begin();
+	if (!mapPattern_.empty()) {
+		auto itr = mapPattern_.begin();
 		int frame = itr->first;
 		if (frame == framePattern_) {
 			ref_count_ptr<StgMovePattern>::unsync pattern = itr->second;
@@ -35,18 +33,18 @@ void StgMoveObject::_Move()
 void StgMoveObject::_AttachReservedPattern(ref_count_ptr<StgMovePattern>::unsync pattern)
 {
 	//速度継続など
-	if (pattern_ == NULL)
+	if (pattern_ == nullptr)
 		pattern_ = new StgMovePattern_Angle(this);
 
 	int newMoveType = pattern->GetType();
 	if (newMoveType == StgMovePattern::TYPE_ANGLE) {
-		StgMovePattern_Angle* angPattern = (StgMovePattern_Angle*)pattern.GetPointer();
+		auto* angPattern = (StgMovePattern_Angle*)pattern.GetPointer();
 		if (angPattern->GetSpeed() == StgMovePattern::NO_CHANGE)
 			angPattern->SetSpeed(pattern_->GetSpeed());
 		if (angPattern->GetDirectionAngle() == StgMovePattern::NO_CHANGE)
 			angPattern->SetDirectionAngle(pattern_->GetDirectionAngle());
 	} else if (newMoveType == StgMovePattern::TYPE_XY) {
-		StgMovePattern_XY* xyPattern = (StgMovePattern_XY*)pattern.GetPointer();
+		auto* xyPattern = (StgMovePattern_XY*)pattern.GetPointer();
 
 		double speed = pattern_->GetSpeed();
 		double angle = pattern_->GetDirectionAngle();
@@ -67,32 +65,32 @@ void StgMoveObject::_AttachReservedPattern(ref_count_ptr<StgMovePattern>::unsync
 }
 double StgMoveObject::GetSpeed()
 {
-	if (pattern_ == NULL)
+	if (pattern_ == nullptr)
 		return 0;
 	double res = pattern_->GetSpeed();
 	return res;
 }
 void StgMoveObject::SetSpeed(double speed)
 {
-	if (pattern_ == NULL || pattern_->GetType() != StgMovePattern::TYPE_ANGLE) {
+	if (pattern_ == nullptr || pattern_->GetType() != StgMovePattern::TYPE_ANGLE) {
 		pattern_ = new StgMovePattern_Angle(this);
 	}
-	StgMovePattern_Angle* pattern = (StgMovePattern_Angle*)pattern_.GetPointer();
+	auto* pattern = (StgMovePattern_Angle*)pattern_.GetPointer();
 	pattern->SetSpeed(speed);
 }
 double StgMoveObject::GetDirectionAngle()
 {
-	if (pattern_ == NULL)
+	if (pattern_ == nullptr)
 		return 0;
 	double res = pattern_->GetDirectionAngle();
 	return res;
 }
 void StgMoveObject::SetDirectionAngle(double angle)
 {
-	if (pattern_ == NULL || pattern_->GetType() != StgMovePattern::TYPE_ANGLE) {
+	if (pattern_ == nullptr || pattern_->GetType() != StgMovePattern::TYPE_ANGLE) {
 		pattern_ = new StgMovePattern_Angle(this);
 	}
-	StgMovePattern_Angle* pattern = (StgMovePattern_Angle*)pattern_.GetPointer();
+	auto* pattern = (StgMovePattern_Angle*)pattern_.GetPointer();
 	pattern->SetDirectionAngle(angle);
 }
 void StgMoveObject::AddPattern(int frameDelay, ref_count_ptr<StgMovePattern>::unsync pattern)
@@ -133,8 +131,8 @@ ref_count_ptr<StgMoveObject>::unsync StgMovePattern::_GetMoveObject(int id)
 {
 	StgStageController* controller = _GetStageController();
 	ref_count_ptr<DxScriptObjectBase>::unsync base = controller->GetMainRenderObject(id);
-	if (base == NULL || base->IsDeleted())
-		return NULL;
+	if (base == nullptr || base->IsDeleted())
+		return nullptr;
 
 	return ref_count_ptr<StgMoveObject>::unsync::DownCast(base);
 }
@@ -199,7 +197,7 @@ void StgMovePattern_Angle::_Activate()
 {
 	if (idRalativeID_ != DxScript::ID_INVALID) {
 		ref_count_ptr<StgMoveObject>::unsync obj = _GetMoveObject(idRalativeID_);
-		if (obj != NULL) {
+		if (obj != nullptr) {
 			double px = target_->GetPositionX();
 			double py = target_->GetPositionY();
 			double tx = obj->GetPositionX();
@@ -248,7 +246,7 @@ void StgMovePattern_XY::Move()
 	target_->SetPositionX(px);
 	target_->SetPositionY(py);
 
-	frameWork_++;
+	++frameWork_;
 }
 double StgMovePattern_XY::GetSpeed() const
 {
@@ -283,7 +281,7 @@ void StgMovePattern_Line::Move()
 
 		target_->SetPositionX(px);
 		target_->SetPositionY(py);
-		frameStop_--;
+		--frameStop_;
 		if (frameStop_ <= 0) {
 			typeLine_ = TYPE_NONE;
 			speed_ = 0;

--- a/source/TouhouDanmakufu/Common/StgCommon.cpp
+++ b/source/TouhouDanmakufu/Common/StgCommon.cpp
@@ -250,15 +250,13 @@ void StgMovePattern_XY::Move()
 
 	frameWork_++;
 }
-double StgMovePattern_XY::GetSpeed()
+double StgMovePattern_XY::GetSpeed() const
 {
-	double res = pow(speedX_ * speedX_ + speedY_ * speedY_, 0.5);
-	return res;
+	return pow(speedX_ * speedX_ + speedY_ * speedY_, 0.5);
 }
-double StgMovePattern_XY::GetDirectionAngle()
+double StgMovePattern_XY::GetDirectionAngle() const
 {
-	double res = Math::RadianToDegree(atan2(speedY_, speedX_));
-	return res;
+	return Math::RadianToDegree(atan2(speedY_, speedX_));
 }
 
 //StgMovePattern_Line

--- a/source/TouhouDanmakufu/Common/StgCommon.hpp
+++ b/source/TouhouDanmakufu/Common/StgCommon.hpp
@@ -24,9 +24,9 @@ public:
 	StgMoveObject(StgStageController* stageController);
 	virtual ~StgMoveObject();
 
-	double GetPositionX() { return posX_; }
+	double GetPositionX() const { return posX_; }
 	void SetPositionX(double pos) { posX_ = pos; }
-	double GetPositionY() { return posY_; }
+	double GetPositionY() const { return posY_; }
 	void SetPositionY(double pos) { posY_ = pos; }
 	double cssn(double s, double ang);
 
@@ -38,7 +38,7 @@ public:
 	void SetSpeedX(double speedX);
 	void SetSpeedY(double sppedY);
 
-	ref_count_ptr<StgMovePattern>::unsync GetPattern() { return pattern_; }
+	ref_count_ptr<StgMovePattern>::unsync GetPattern() const { return pattern_; }
 	void SetPattern(ref_count_ptr<StgMovePattern>::unsync pattern) { pattern_ = pattern; }
 	void AddPattern(int frameDelay, ref_count_ptr<StgMovePattern>::unsync pattern);
 
@@ -76,11 +76,11 @@ public:
 	virtual void Move() = 0;
 	double cssn(double c, double ang);
 
-	int GetType() { return typeMove_; }
+	int GetType() const { return typeMove_; }
 
-	virtual double GetSpeed() = 0;
-	virtual double GetDirectionAngle() = 0;
-	int GetShotDataID() { return idShotData_; }
+	virtual double GetSpeed() const = 0;
+	virtual double GetDirectionAngle() const = 0;
+	int GetShotDataID() const { return idShotData_; }
 	void SetShotDataID(int id) { idShotData_ = id; }
 
 protected:
@@ -100,8 +100,8 @@ public:
 	StgMovePattern_Angle(StgMoveObject* target);
 	virtual void Move();
 
-	virtual double GetSpeed() { return speed_; }
-	virtual double GetDirectionAngle() { return angDirection_; }
+	virtual double GetSpeed() const { return speed_; }
+	virtual double GetDirectionAngle() const { return angDirection_; }
 
 	void SetSpeed(double speed) { speed_ = speed; }
 	void SetDirectionAngle(double angle) { angDirection_ = angle; }
@@ -126,11 +126,11 @@ public:
 	StgMovePattern_XY(StgMoveObject* target);
 	virtual void Move();
 
-	virtual double GetSpeed();
-	virtual double GetDirectionAngle();
+	virtual double GetSpeed() const;
+	virtual double GetDirectionAngle() const;
 
-	double GetSpeedX() { return speedX_; }
-	double GetSpeedY() { return speedY_; }
+	double GetSpeedX() const { return speedX_; }
+	double GetSpeedY() const { return speedY_; }
 	void SetSpeedX(double value) { speedX_ = value; }
 	void SetSpeedY(double value) { speedY_ = value; }
 	void SetAccelerationX(double value) { accelerationX_ = value; }
@@ -159,8 +159,8 @@ protected:
 public:
 	StgMovePattern_Line(StgMoveObject* target);
 	virtual void Move();
-	virtual double GetSpeed() { return speed_; }
-	virtual double GetDirectionAngle() { return angDirection_; }
+	virtual double GetSpeed() const { return speed_; }
+	virtual double GetDirectionAngle() const { return angDirection_; }
 
 	void SetAtSpeed(double tx, double ty, double speed);
 	void SetAtFrame(double tx, double ty, double frame);

--- a/source/TouhouDanmakufu/Common/StgCommon.hpp
+++ b/source/TouhouDanmakufu/Common/StgCommon.hpp
@@ -72,9 +72,9 @@ public:
 
 public:
 	StgMovePattern(StgMoveObject* target);
-	virtual ~StgMovePattern() {}
+	virtual ~StgMovePattern() = default;
 	virtual void Move() = 0;
-	double cssn(double c, double ang);
+	double cssn(double s, double ang);
 
 	int GetType() const { return typeMove_; }
 
@@ -98,10 +98,10 @@ protected:
 class StgMovePattern_Angle : public StgMovePattern {
 public:
 	StgMovePattern_Angle(StgMoveObject* target);
-	virtual void Move();
+	void Move() override;
 
-	virtual double GetSpeed() const { return speed_; }
-	virtual double GetDirectionAngle() const { return angDirection_; }
+	double GetSpeed() const override { return speed_; }
+	double GetDirectionAngle() const override { return angDirection_; }
 
 	void SetSpeed(double speed) { speed_ = speed; }
 	void SetDirectionAngle(double angle) { angDirection_ = angle; }
@@ -118,16 +118,16 @@ protected:
 	double angularVelocity_;
 	int idRalativeID_;
 
-	virtual void _Activate();
+	void _Activate() override;
 };
 
 class StgMovePattern_XY : public StgMovePattern {
 public:
 	StgMovePattern_XY(StgMoveObject* target);
-	virtual void Move();
+	void Move() override;
 
-	virtual double GetSpeed() const;
-	virtual double GetDirectionAngle() const;
+	double GetSpeed() const override;
+	double GetDirectionAngle() const override;
 
 	double GetSpeedX() const { return speedX_; }
 	double GetSpeedY() const { return speedY_; }
@@ -158,9 +158,9 @@ protected:
 
 public:
 	StgMovePattern_Line(StgMoveObject* target);
-	virtual void Move();
-	virtual double GetSpeed() const { return speed_; }
-	virtual double GetDirectionAngle() const { return angDirection_; }
+	void Move() override;
+	double GetSpeed() const override { return speed_; }
+	double GetDirectionAngle() const override { return angDirection_; }
 
 	void SetAtSpeed(double tx, double ty, double speed);
 	void SetAtFrame(double tx, double ty, double frame);

--- a/source/TouhouDanmakufu/Common/StgControlScript.cpp
+++ b/source/TouhouDanmakufu/Common/StgControlScript.cpp
@@ -4,12 +4,8 @@
 /**********************************************************
 //StgControlScriptManager
 **********************************************************/
-StgControlScriptManager::StgControlScriptManager()
-{
-}
-StgControlScriptManager::~StgControlScriptManager()
-{
-}
+StgControlScriptManager::StgControlScriptManager() = default;
+StgControlScriptManager::~StgControlScriptManager() = default;
 
 /**********************************************************
 //StgControlScriptInformation
@@ -18,9 +14,7 @@ StgControlScriptInformation::StgControlScriptInformation()
 {
 	replayManager_ = new ReplayInformationManager();
 }
-StgControlScriptInformation::~StgControlScriptInformation()
-{
-}
+StgControlScriptInformation::~StgControlScriptInformation() = default;
 void StgControlScriptInformation::LoadFreePlayerList()
 {
 	std::wstring dir = EPathProperty::GetPlayerScriptRootDirectory();
@@ -154,7 +148,7 @@ const function stgControlFunction[] = {
 StgControlScript::StgControlScript(StgSystemController* systemController)
 {
 	systemController_ = systemController;
-	scriptManager_ = NULL;
+	scriptManager_ = nullptr;
 	_AddFunction(stgControlFunction, sizeof(stgControlFunction) / sizeof(function));
 
 	bLoad_ = false;
@@ -168,14 +162,14 @@ StgControlScript::StgControlScript(StgSystemController* systemController)
 //STG制御共通関数：共通データ
 gstd::value StgControlScript::Func_SaveCommonDataAreaA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
 
 	std::wstring area = argv[0].as_string();
 	std::string sArea = to_mbcs(area);
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 	ref_count_ptr<ScriptCommonData> commonData = commonDataManager->GetData(sArea);
-	if (commonData == NULL)
+	if (commonData == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	std::wstring pathMain = infoSystem->GetMainScriptInformation()->GetScriptPath();
@@ -193,7 +187,7 @@ gstd::value StgControlScript::Func_SaveCommonDataAreaA1(gstd::script_machine* ma
 }
 gstd::value StgControlScript::Func_LoadCommonDataAreaA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
 
 	std::wstring area = argv[0].as_string();
@@ -216,13 +210,13 @@ gstd::value StgControlScript::Func_LoadCommonDataAreaA1(gstd::script_machine* ma
 
 gstd::value StgControlScript::Func_SaveCommonDataAreaA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
 
 	std::string area = to_mbcs(argv[0].as_string());
 	ScriptCommonDataManager* commonDataManager = script->GetCommonDataManager();
 	ref_count_ptr<ScriptCommonData> commonData = commonDataManager->GetData(area);
-	if (commonData == NULL)
+	if (commonData == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	std::wstring pathSave = argv[1].as_string();
@@ -239,7 +233,7 @@ gstd::value StgControlScript::Func_SaveCommonDataAreaA2(gstd::script_machine* ma
 }
 gstd::value StgControlScript::Func_LoadCommonDataAreaA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
 
 	std::string area = to_mbcs(argv[0].as_string());
@@ -275,13 +269,13 @@ gstd::value StgControlScript::Func_AddVirtualKey(gstd::script_machine* machine, 
 }
 gstd::value StgControlScript::Func_AddReplayTargetVirtualKey(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
 	StgStageController* stageController = script->systemController_->GetStageController();
 
 	int id = (int)argv[0].as_real();
 	infoSystem->AddReplayTargetKey(id);
-	if (stageController != NULL) {
+	if (stageController != nullptr) {
 		ref_count_ptr<KeyReplayManager> keyReplayManager = stageController->GetKeyReplayManager();
 		keyReplayManager->AddTarget(id);
 	}
@@ -300,9 +294,9 @@ gstd::value StgControlScript::Func_SetSkipModeKey(gstd::script_machine* machine,
 //STG制御共通関数：システム関連
 gstd::value StgControlScript::Func_GetScore(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if (stageController == NULL)
+	if (stageController == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)0.0);
 
 	long double res = stageController->GetStageInformation()->GetScore();
@@ -310,20 +304,20 @@ gstd::value StgControlScript::Func_GetScore(gstd::script_machine* machine, int a
 }
 gstd::value StgControlScript::Func_AddScore(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if (stageController == NULL)
+	if (stageController == nullptr)
 		return value();
 
-	long double inc = (_int64)argv[0].as_real();
+	long double inc = (int64_t)argv[0].as_real();
 	stageController->GetStageInformation()->AddScore(inc);
 	return value();
 }
 gstd::value StgControlScript::Func_GetGraze(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if (stageController == NULL)
+	if (stageController == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)0.0);
 
 	long double res = stageController->GetStageInformation()->GetGraze();
@@ -331,20 +325,20 @@ gstd::value StgControlScript::Func_GetGraze(gstd::script_machine* machine, int a
 }
 gstd::value StgControlScript::Func_AddGraze(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if (stageController == NULL)
+	if (stageController == nullptr)
 		return value();
 
-	long double inc = (_int64)argv[0].as_real();
+	long double inc = (int64_t)argv[0].as_real();
 	stageController->GetStageInformation()->AddGraze(inc);
 	return value();
 }
 gstd::value StgControlScript::Func_GetPoint(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if (stageController == NULL)
+	if (stageController == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)0.0);
 
 	long double res = stageController->GetStageInformation()->GetPoint();
@@ -352,20 +346,20 @@ gstd::value StgControlScript::Func_GetPoint(gstd::script_machine* machine, int a
 }
 gstd::value StgControlScript::Func_AddPoint(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if (stageController == NULL)
+	if (stageController == nullptr)
 		return value();
 
-	long double inc = (_int64)argv[0].as_real();
+	long double inc = (int64_t)argv[0].as_real();
 	stageController->GetStageInformation()->AddPoint(inc);
 	return value();
 }
 gstd::value StgControlScript::Func_IsReplay(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if (stageController == NULL)
+	if (stageController == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	bool res = stageController->GetStageInformation()->IsReplay();
@@ -387,9 +381,9 @@ gstd::value StgControlScript::Func_GetCurrentFps(gstd::script_machine* machine, 
 }
 gstd::value StgControlScript::Func_GetStageTime(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if (stageController == NULL)
+	if (stageController == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)0);
 
 	ref_count_ptr<StgStageInformation> infoStage = stageController->GetStageInformation();
@@ -401,9 +395,9 @@ gstd::value StgControlScript::Func_GetStageTime(gstd::script_machine* machine, i
 }
 gstd::value StgControlScript::Func_GetStageTimeF(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if (stageController == NULL)
+	if (stageController == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)0);
 
 	ref_count_ptr<StgStageInformation> infoStage = stageController->GetStageInformation();
@@ -412,9 +406,9 @@ gstd::value StgControlScript::Func_GetStageTimeF(gstd::script_machine* machine, 
 }
 gstd::value StgControlScript::Func_GetPackageTime(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgPackageController* packageController = script->systemController_->GetPackageController();
-	if (packageController == NULL)
+	if (packageController == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)0);
 
 	ref_count_ptr<StgPackageInformation> infoPackage = packageController->GetPackageInformation();
@@ -427,11 +421,11 @@ gstd::value StgControlScript::Func_GetPackageTime(gstd::script_machine* machine,
 
 gstd::value StgControlScript::Func_GetStgFrameLeft(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
 
 	long double res = 0;
-	if (stageController != NULL) {
+	if (stageController != nullptr) {
 		RECT rect = stageController->GetStageInformation()->GetStgFrameRect();
 		res = rect.left;
 	}
@@ -439,11 +433,11 @@ gstd::value StgControlScript::Func_GetStgFrameLeft(gstd::script_machine* machine
 }
 gstd::value StgControlScript::Func_GetStgFrameTop(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
 
 	long double res = 0;
-	if (stageController != NULL) {
+	if (stageController != nullptr) {
 		RECT rect = stageController->GetStageInformation()->GetStgFrameRect();
 		res = rect.top;
 	}
@@ -451,11 +445,11 @@ gstd::value StgControlScript::Func_GetStgFrameTop(gstd::script_machine* machine,
 }
 gstd::value StgControlScript::Func_GetStgFrameWidth(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
 
 	long double res = 0;
-	if (stageController != NULL) {
+	if (stageController != nullptr) {
 		RECT rect = stageController->GetStageInformation()->GetStgFrameRect();
 		res = res = rect.right - rect.left;
 	}
@@ -463,11 +457,11 @@ gstd::value StgControlScript::Func_GetStgFrameWidth(gstd::script_machine* machin
 }
 gstd::value StgControlScript::Func_GetStgFrameHeight(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
 
 	long double res = 0;
-	if (stageController != NULL) {
+	if (stageController != nullptr) {
 		RECT rect = stageController->GetStageInformation()->GetStgFrameRect();
 		res = res = rect.bottom - rect.top;
 	}
@@ -475,11 +469,11 @@ gstd::value StgControlScript::Func_GetStgFrameHeight(gstd::script_machine* machi
 }
 gstd::value StgControlScript::Func_GetMainPackageScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgPackageController* packageController = script->systemController_->GetPackageController();
 
-	std::wstring path = L"";
-	if (packageController != NULL) {
+	std::wstring path;
+	if (packageController != nullptr) {
 		ref_count_ptr<ScriptInformation> infoScript = packageController->GetPackageInformation()->GetMainScriptInformation();
 		path = infoScript->GetScriptPath();
 	}
@@ -489,7 +483,7 @@ gstd::value StgControlScript::Func_GetMainPackageScriptPath(gstd::script_machine
 }
 gstd::value StgControlScript::Func_GetScriptPathList(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 
 	std::vector<std::wstring> listRes;
 	std::wstring dir = argv[0].as_string();
@@ -497,17 +491,15 @@ gstd::value StgControlScript::Func_GetScriptPathList(gstd::script_machine* machi
 
 	int typeScript = (int)argv[1].as_real();
 	std::vector<std::wstring> listFile = File::GetFilePathList(dir);
-	for (int iFile = 0; iFile < listFile.size(); iFile++) {
-		std::wstring path = listFile[iFile];
-
-		//明らかに関係なさそうな拡張子は除外
+	for (auto path : listFile) {
+			//明らかに関係なさそうな拡張子は除外
 		std::wstring ext = PathProperty::GetFileExtension(path);
 		if (ScriptInformation::IsExcludeExtension(ext))
 			continue;
 
 		path = PathProperty::GetUnique(path);
 		ref_count_ptr<ScriptInformation> infoScript = ScriptInformation::CreateScriptInformation(path, true);
-		if (infoScript == NULL)
+		if (infoScript == nullptr)
 			continue;
 		if (typeScript != TYPE_SCRIPT_ALL && typeScript != infoScript->GetType())
 			continue;
@@ -516,24 +508,23 @@ gstd::value StgControlScript::Func_GetScriptPathList(gstd::script_machine* machi
 		listRes.push_back(path);
 	}
 
-	gstd::value res = script->CreateStringArrayValue(listRes);
-	return res;
+	return script->CreateStringArrayValue(listRes);
 }
 gstd::value StgControlScript::Func_GetScriptInfoA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 
 	std::wstring path = argv[0].as_string();
 	int type = (int)argv[1].as_real();
 
-	ref_count_ptr<ScriptInformation> infoScript = NULL;
+	ref_count_ptr<ScriptInformation> infoScript = nullptr;
 	if (script->mapScriptInfo_.find(path) != script->mapScriptInfo_.end())
 		infoScript = script->mapScriptInfo_[path];
 	else {
 		infoScript = ScriptInformation::CreateScriptInformation(path, true);
 		script->mapScriptInfo_[path] = infoScript;
 	}
-	if (infoScript == NULL)
+	if (infoScript == nullptr)
 		throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path));
 
 	value res;
@@ -567,7 +558,7 @@ gstd::value StgControlScript::Func_GetScriptInfoA1(gstd::script_machine* machine
 //STG共通関数：描画関連
 gstd::value StgControlScript::Func_ClearInvalidRenderPriority(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgSystemController* systemController = script->systemController_;
 	ref_count_ptr<StgSystemInformation> infoSystem = systemController->GetSystemInformation();
 	infoSystem->SetInvaridRenderPriority(-1, -1);
@@ -577,7 +568,7 @@ gstd::value StgControlScript::Func_ClearInvalidRenderPriority(gstd::script_machi
 
 gstd::value StgControlScript::Func_SetInvalidRenderPriorityA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgSystemController* systemController = script->systemController_;
 	ref_count_ptr<StgSystemInformation> infoSystem = systemController->GetSystemInformation();
 
@@ -590,7 +581,7 @@ gstd::value StgControlScript::Func_SetInvalidRenderPriorityA1(gstd::script_machi
 
 gstd::value StgControlScript::Func_GetReservedRenderTargetName(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 
 	int index = (int)argv[0].as_real();
 	ETextureManager* textureManager = ETextureManager::GetInstance();
@@ -601,7 +592,7 @@ gstd::value StgControlScript::Func_GetReservedRenderTargetName(gstd::script_mach
 
 gstd::value StgControlScript::Func_RenderToTextureA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ETextureManager* textureManager = ETextureManager::GetInstance();
 	StgSystemController* systemController = script->systemController_;
 
@@ -612,9 +603,9 @@ gstd::value StgControlScript::Func_RenderToTextureA1(gstd::script_machine* machi
 
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	ref_count_ptr<Texture> texture = script->_GetTexture(name);
-	if (texture == NULL)
+	if (texture == nullptr)
 		textureManager->GetTexture(name);
-	if (texture == NULL && textureManager->IsDataExists(name)) {
+	if (texture == nullptr && textureManager->IsDataExists(name)) {
 		texture = new Texture();
 		texture->CreateRenderTarget(name);
 	}
@@ -625,7 +616,7 @@ gstd::value StgControlScript::Func_RenderToTextureA1(gstd::script_machine* machi
 	systemController->RenderScriptObject(priMin, priMax);
 
 	graphics->EndScene();
-	graphics->SetRenderTarget(NULL);
+	graphics->SetRenderTarget(nullptr);
 /*
 	{
 		static int count = 0;
@@ -642,23 +633,23 @@ gstd::value StgControlScript::Func_RenderToTextureA1(gstd::script_machine* machi
 
 gstd::value StgControlScript::Func_RenderToTextureB1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ETextureManager* textureManager = ETextureManager::GetInstance();
 
 	std::wstring name = argv[0].as_string();
 	int id = (int)argv[1].as_real();
 	bool bClear = argv[2].as_boolean();
 
-	DxScriptRenderObject* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	ref_count_ptr<Texture> texture = script->_GetTexture(name);
-	if (texture == NULL)
+	if (texture == nullptr)
 		textureManager->GetTexture(name);
 
-	if (texture == NULL && textureManager->IsDataExists(name)) {
+	if (texture == nullptr && textureManager->IsDataExists(name)) {
 		texture = new Texture();
 		texture->CreateRenderTarget(name);
 	}
@@ -669,14 +660,14 @@ gstd::value StgControlScript::Func_RenderToTextureB1(gstd::script_machine* machi
 	obj->Render();
 
 	graphics->EndScene();
-	graphics->SetRenderTarget(NULL);
+	graphics->SetRenderTarget(nullptr);
 
 	return value();
 }
 
 gstd::value StgControlScript::Func_SaveSnapShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ETextureManager* textureManager = ETextureManager::GetInstance();
 	StgSystemController* systemController = script->systemController_;
 
@@ -688,7 +679,7 @@ gstd::value StgControlScript::Func_SaveSnapShotA1(gstd::script_machine* machine,
 	graphics->BeginScene(true);
 	systemController->RenderScriptObject(0, 100);
 	graphics->EndScene();
-	graphics->SetRenderTarget(NULL);
+	graphics->SetRenderTarget(nullptr);
 
 	//フォルダ生成
 	std::wstring dir = PathProperty::GetFileDirectory(path);
@@ -706,7 +697,7 @@ gstd::value StgControlScript::Func_SaveSnapShotA1(gstd::script_machine* machine,
 
 gstd::value StgControlScript::Func_SaveSnapShotA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ETextureManager* textureManager = ETextureManager::GetInstance();
 	StgSystemController* systemController = script->systemController_;
 
@@ -723,7 +714,7 @@ gstd::value StgControlScript::Func_SaveSnapShotA2(gstd::script_machine* machine,
 	graphics->BeginScene(true);
 	systemController->RenderScriptObject(0, 100);
 	graphics->EndScene();
-	graphics->SetRenderTarget(NULL);
+	graphics->SetRenderTarget(nullptr);
 
 	//フォルダ生成
 	std::wstring dir = PathProperty::GetFileDirectory(path);
@@ -734,16 +725,16 @@ gstd::value StgControlScript::Func_SaveSnapShotA2(gstd::script_machine* machine,
 	IDirect3DSurface9* pSurface = texture->GetD3DSurface();
 	RECT rect = { rcLeft, rcTop, rcRight, rcBottom };
 	HRESULT hr = D3DXSaveSurfaceToFile(path.c_str(), D3DXIFF_BMP,
-		pSurface, NULL, &rect);
+		pSurface, nullptr, &rect);
 	return value();
 }
 
 //STG制御共通関数：自機関連
 gstd::value StgControlScript::Func_GetPlayerID(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if (stageController == NULL)
+	if (stageController == nullptr)
 		return value(machine->get_engine()->get_string_type(), std::wstring());
 
 	std::wstring id = stageController->GetStageInformation()->GetPlayerScriptInformation()->GetID();
@@ -751,9 +742,9 @@ gstd::value StgControlScript::Func_GetPlayerID(gstd::script_machine* machine, in
 }
 gstd::value StgControlScript::Func_GetPlayerReplayName(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	StgStageController* stageController = script->systemController_->GetStageController();
-	if (stageController == NULL)
+	if (stageController == nullptr)
 		return value(machine->get_engine()->get_string_type(), std::wstring());
 
 	std::wstring replayName = stageController->GetStageInformation()->GetPlayerScriptInformation()->GetReplayName();
@@ -763,7 +754,7 @@ gstd::value StgControlScript::Func_GetPlayerReplayName(gstd::script_machine* mac
 //STG制御共通関数：ユーザスクリプト
 gstd::value StgControlScript::Func_SetPauseScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> info = script->systemController_->GetSystemInformation();
 
 	std::wstring path = argv[0].as_string();
@@ -773,7 +764,7 @@ gstd::value StgControlScript::Func_SetPauseScriptPath(gstd::script_machine* mach
 }
 gstd::value StgControlScript::Func_SetEndSceneScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> info = script->systemController_->GetSystemInformation();
 
 	std::wstring path = argv[0].as_string();
@@ -783,7 +774,7 @@ gstd::value StgControlScript::Func_SetEndSceneScriptPath(gstd::script_machine* m
 }
 gstd::value StgControlScript::Func_SetReplaySaveSceneScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> info = script->systemController_->GetSystemInformation();
 
 	std::wstring path = argv[0].as_string();
@@ -795,7 +786,7 @@ gstd::value StgControlScript::Func_SetReplaySaveSceneScriptPath(gstd::script_mac
 //STG制御共通関数：自機スクリプト
 gstd::value StgControlScript::Func_GetLoadFreePlayerScriptList(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
 
 	infoControlScript->LoadFreePlayerList();
@@ -805,7 +796,7 @@ gstd::value StgControlScript::Func_GetLoadFreePlayerScriptList(gstd::script_mach
 }
 gstd::value StgControlScript::Func_GetFreePlayerScriptCount(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
 	std::vector<ref_count_ptr<ScriptInformation>> listFreePlayer = infoControlScript->GetFreePlayerList();
 
@@ -814,7 +805,7 @@ gstd::value StgControlScript::Func_GetFreePlayerScriptCount(gstd::script_machine
 }
 gstd::value StgControlScript::Func_GetFreePlayerScriptInfo(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
 	std::vector<ref_count_ptr<ScriptInformation>> listFreePlayer = infoControlScript->GetFreePlayerList();
 
@@ -851,7 +842,7 @@ gstd::value StgControlScript::Func_GetFreePlayerScriptInfo(gstd::script_machine*
 //STG制御共通関数：リプレイ関連
 gstd::value StgControlScript::Func_LoadReplayList(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
 
@@ -862,14 +853,14 @@ gstd::value StgControlScript::Func_LoadReplayList(gstd::script_machine* machine,
 
 gstd::value StgControlScript::Func_GetValidReplayIndices(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
 	ref_count_ptr<ReplayInformationManager> replayInfoManager = infoControlScript->GetReplayInformationManager();
 
 	std::vector<int> listValidIndices = replayInfoManager->GetIndexList();
 	std::vector<long double> list;
-	for (int iList = 0; iList < listValidIndices.size(); iList++)
-		list.push_back(listValidIndices[iList]);
+	for (int validIndice : listValidIndices)
+		list.push_back(validIndice);
 
 	gstd::value res = script->CreateRealArrayValue(list);
 	return res;
@@ -877,18 +868,18 @@ gstd::value StgControlScript::Func_GetValidReplayIndices(gstd::script_machine* m
 
 gstd::value StgControlScript::Func_IsValidReplayIndex(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
 	ref_count_ptr<ReplayInformationManager> replayInfoManager = infoControlScript->GetReplayInformationManager();
 
 	int index = (int)argv[0].as_real();
-	bool res = replayInfoManager->GetInformation(index) != NULL;
+	bool res = replayInfoManager->GetInformation(index) != nullptr;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
 
 gstd::value StgControlScript::Func_GetReplayInfo(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
 	ref_count_ptr<ReplayInformationManager> replayInfoManager = infoControlScript->GetReplayInformationManager();
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
@@ -902,7 +893,7 @@ gstd::value StgControlScript::Func_GetReplayInfo(gstd::script_machine* machine, 
 	else
 		replayInfo = replayInfoManager->GetInformation(index);
 
-	if (replayInfo == NULL)
+	if (replayInfo == nullptr)
 		script->RaiseError(ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_OUTOFRANGE_INDEX));
 
 	value res;
@@ -928,8 +919,7 @@ gstd::value StgControlScript::Func_GetReplayInfo(gstd::script_machine* machine, 
 	case REPLAY_STAGE_INDEX_LIST: {
 		std::vector<int> listStageI = replayInfo->GetStageIndexList();
 		std::vector<long double> listStageD;
-		for (int iStage = 0; iStage < listStageI.size(); iStage++) {
-			long double stage = listStageI[iStage];
+		for (long double stage : listStageI) {
 			listStageD.push_back(stage);
 		}
 		res = script->CreateRealArrayValue(listStageD);
@@ -938,8 +928,7 @@ gstd::value StgControlScript::Func_GetReplayInfo(gstd::script_machine* machine, 
 	case REPLAY_STAGE_START_SCORE_LIST: {
 		std::vector<int> listStage = replayInfo->GetStageIndexList();
 		std::vector<long double> listScoreD;
-		for (int iStage = 0; iStage < listStage.size(); iStage++) {
-			int stage = listStage[iStage];
+		for (int stage : listStage) {
 			ref_count_ptr<ReplayInformation::StageData> data = replayInfo->GetStageData(stage);
 
 			long double score = data->GetStartScore();
@@ -951,8 +940,7 @@ gstd::value StgControlScript::Func_GetReplayInfo(gstd::script_machine* machine, 
 	case REPLAY_STAGE_LAST_SCORE_LIST: {
 		std::vector<int> listStage = replayInfo->GetStageIndexList();
 		std::vector<long double> listScoreD;
-		for (int iStage = 0; iStage < listStage.size(); iStage++) {
-			int stage = listStage[iStage];
+		for (int stage : listStage) {
 			ref_count_ptr<ReplayInformation::StageData> data = replayInfo->GetStageData(stage);
 
 			long double score = data->GetLastScore();
@@ -970,12 +958,12 @@ gstd::value StgControlScript::Func_GetReplayInfo(gstd::script_machine* machine, 
 
 gstd::value StgControlScript::Func_SetReplayInfo(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
 	ref_count_ptr<ReplayInformationManager> replayInfoManager = infoControlScript->GetReplayInformationManager();
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
 	ref_count_ptr<ReplayInformation> replayInfo = infoSystem->GetActiveReplayInformation();
-	if (replayInfo == NULL)
+	if (replayInfo == nullptr)
 		script->RaiseError(L"save target replay not found");
 
 	int type = (int)argv[0].as_real();
@@ -990,7 +978,7 @@ gstd::value StgControlScript::Func_SetReplayInfo(gstd::script_machine* machine, 
 
 gstd::value StgControlScript::Func_GetReplayUserData(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
 	ref_count_ptr<ReplayInformationManager> replayInfoManager = infoControlScript->GetReplayInformationManager();
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
@@ -1004,7 +992,7 @@ gstd::value StgControlScript::Func_GetReplayUserData(gstd::script_machine* machi
 	else
 		replayInfo = replayInfoManager->GetInformation(index);
 
-	if (replayInfo == NULL)
+	if (replayInfo == nullptr)
 		script->RaiseError(ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_OUTOFRANGE_INDEX));
 
 	gstd::value res = replayInfo->GetUserData(key);
@@ -1013,12 +1001,12 @@ gstd::value StgControlScript::Func_GetReplayUserData(gstd::script_machine* machi
 
 gstd::value StgControlScript::Func_SetReplayUserData(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
 	ref_count_ptr<ReplayInformationManager> replayInfoManager = infoControlScript->GetReplayInformationManager();
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
 	ref_count_ptr<ReplayInformation> replayInfo = infoSystem->GetActiveReplayInformation();
-	if (replayInfo == NULL)
+	if (replayInfo == nullptr)
 		script->RaiseError(L"save target replay not found");
 
 	std::string key = to_mbcs(argv[0].as_string());
@@ -1029,7 +1017,7 @@ gstd::value StgControlScript::Func_SetReplayUserData(gstd::script_machine* machi
 
 gstd::value StgControlScript::Func_IsReplayUserDataExists(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgControlScriptInformation> infoControlScript = script->systemController_->GetControlScriptInformation();
 	ref_count_ptr<ReplayInformationManager> replayInfoManager = infoControlScript->GetReplayInformationManager();
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
@@ -1043,7 +1031,7 @@ gstd::value StgControlScript::Func_IsReplayUserDataExists(gstd::script_machine* 
 	else
 		replayInfo = replayInfoManager->GetInformation(index);
 
-	if (replayInfo == NULL)
+	if (replayInfo == nullptr)
 		script->RaiseError(ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_OUTOFRANGE_INDEX));
 
 	bool res = replayInfo->IsUserDataExists(key);
@@ -1052,12 +1040,12 @@ gstd::value StgControlScript::Func_IsReplayUserDataExists(gstd::script_machine* 
 
 gstd::value StgControlScript::Func_SaveReplay(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgControlScript* script = (StgControlScript*)machine->data;
+	auto* script = (StgControlScript*)machine->data;
 	ref_count_ptr<StgSystemInformation> infoSystem = script->systemController_->GetSystemInformation();
 	ref_count_ptr<ScriptInformation> infoMain = script->systemController_->GetSystemInformation()->GetMainScriptInformation();
 
 	ref_count_ptr<ReplayInformation> replayInfoActive = infoSystem->GetActiveReplayInformation();
-	if (replayInfoActive == NULL)
+	if (replayInfoActive == nullptr)
 		script->RaiseError(L"replay information not found");
 
 	int index = (int)argv[0].as_real();
@@ -1075,9 +1063,7 @@ gstd::value StgControlScript::Func_SaveReplay(gstd::script_machine* machine, int
 /**********************************************************
 //ScriptInfoPanel
 **********************************************************/
-ScriptInfoPanel::ScriptInfoPanel()
-{
-}
+ScriptInfoPanel::ScriptInfoPanel() = default;
 bool ScriptInfoPanel::_AddedLogger(HWND hTab)
 {
 	Create(hTab);
@@ -1113,10 +1099,9 @@ void ScriptInfoPanel::_TerminateScriptAll()
 {
 	ETaskManager* taskManager = ETaskManager::GetInstance();
 	std::list<ref_count_ptr<TaskBase>> listTask = taskManager->GetTaskList();
-	std::list<ref_count_ptr<TaskBase>>::iterator itr = listTask.begin();
-	for (; itr != listTask.end(); itr++) {
-		ref_count_ptr<StgSystemController> systemController = ref_count_ptr<StgSystemController>::DownCast(*itr);
-		if (systemController != NULL) {
+	for (auto& task : listTask) {
+		ref_count_ptr<StgSystemController> systemController = ref_count_ptr<StgSystemController>::DownCast(task);
+		if (systemController != nullptr) {
 			systemController->TerminateScriptAll();
 		}
 	}

--- a/source/TouhouDanmakufu/Common/StgControlScript.cpp
+++ b/source/TouhouDanmakufu/Common/StgControlScript.cpp
@@ -29,7 +29,7 @@ void StgControlScriptInformation::LoadFreePlayerList()
 	//ソート
 	std::sort(listFreePlayer_.begin(), listFreePlayer_.end(), ScriptInformation::PlayerListSort());
 }
-void StgControlScriptInformation::LoadReplayInformation(std::wstring pathMainScript)
+void StgControlScriptInformation::LoadReplayInformation(const std::wstring& pathMainScript)
 {
 	replayManager_->UpdateInformationList(pathMainScript);
 }
@@ -502,7 +502,7 @@ gstd::value StgControlScript::Func_GetScriptPathList(gstd::script_machine* machi
 
 		//明らかに関係なさそうな拡張子は除外
 		std::wstring ext = PathProperty::GetFileExtension(path);
-		if (ScriptInformation::IsExcludeExtention(ext))
+		if (ScriptInformation::IsExcludeExtension(ext))
 			continue;
 
 		path = PathProperty::GetUnique(path);

--- a/source/TouhouDanmakufu/Common/StgControlScript.hpp
+++ b/source/TouhouDanmakufu/Common/StgControlScript.hpp
@@ -10,7 +10,7 @@ class StgControlScript;
 class StgControlScriptManager : public ScriptManager {
 public:
 	StgControlScriptManager();
-	virtual ~StgControlScriptManager();
+	~StgControlScriptManager() override;
 };
 
 /**********************************************************
@@ -163,11 +163,11 @@ protected:
 class ScriptInfoPanel : public WindowLogger::Panel {
 public:
 	ScriptInfoPanel();
-	virtual void LocateParts();
+	void LocateParts() override;
 
 protected:
-	virtual bool _AddedLogger(HWND hTab);
-	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam); //オーバーライド用プロシージャ
+	bool _AddedLogger(HWND hTab) override;
+	LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override; //オーバーライド用プロシージャ
 	void _TerminateScriptAll();
 
 	WButton buttonTerminateScript_;

--- a/source/TouhouDanmakufu/Common/StgControlScript.hpp
+++ b/source/TouhouDanmakufu/Common/StgControlScript.hpp
@@ -21,9 +21,9 @@ public:
 	StgControlScriptInformation();
 	virtual ~StgControlScriptInformation();
 	void LoadFreePlayerList();
-	std::vector<ref_count_ptr<ScriptInformation>>& GetFreePlayerList() { return listFreePlayer_; }
+	std::vector<ref_count_ptr<ScriptInformation>> GetFreePlayerList() { return listFreePlayer_; }
 
-	void LoadReplayInformation(std::wstring pathMainScript);
+	void LoadReplayInformation(const std::wstring& pathMainScript);
 	ref_count_ptr<ReplayInformationManager> GetReplayInformationManager() { return replayManager_; }
 
 private:

--- a/source/TouhouDanmakufu/Common/StgEnemy.cpp
+++ b/source/TouhouDanmakufu/Common/StgEnemy.cpp
@@ -186,7 +186,7 @@ bool StgEnemyBossSceneObject::_NextStep()
 		ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemy[iEnemy];
 		obj->SetLife(listLife[iEnemy]);
 		if (oldActiveData != NULL) {
-			std::vector<ref_count_ptr<StgEnemyBossObject>::unsync> listOldEnemyObject = oldActiveData->GetEnemyObjectList();
+			const std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& listOldEnemyObject = oldActiveData->GetEnemyObjectList();
 			if (iEnemy < listOldEnemyObject.size()) {
 				ref_count_ptr<StgEnemyBossObject>::unsync objOld = listOldEnemyObject[iEnemy];
 				obj->SetPositionX(objOld->GetPositionX());
@@ -210,7 +210,7 @@ void StgEnemyBossSceneObject::Work()
 	if (activeData_->IsReadyNext()) {
 		//次ステップ遷移可能
 		bool bEnemyExists = false;
-		std::vector<ref_count_ptr<StgEnemyBossObject>::unsync> listEnemy = activeData_->GetEnemyObjectList();
+		const std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& listEnemy = activeData_->GetEnemyObjectList();
 		for (int iEnemy = 0; iEnemy < listEnemy.size(); iEnemy++) {
 			ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemy[iEnemy];
 			bEnemyExists |= (!obj->IsDeleted());
@@ -248,7 +248,7 @@ void StgEnemyBossSceneObject::Work()
 
 		if (bZeroTimer || bEndLastSpell) {
 			//タイマー0なら敵のライフを0にする
-			std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& listEnemy = activeData_->GetEnemyObjectList();
+			const std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& listEnemy = activeData_->GetEnemyObjectList();
 			for (int iEnemy = 0; iEnemy < listEnemy.size(); iEnemy++) {
 				ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemy[iEnemy];
 				obj->SetLife(0);
@@ -263,7 +263,7 @@ void StgEnemyBossSceneObject::Work()
 
 		//次シーンへの遷移フラグ設定
 		bool bReadyNext = true;
-		std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& listEnemy = activeData_->GetEnemyObjectList();
+		const std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& listEnemy = activeData_->GetEnemyObjectList();
 		for (int iEnemy = 0; iEnemy < listEnemy.size(); iEnemy++) {
 			ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemy[iEnemy];
 			if (obj->GetLife() > 0)
@@ -399,19 +399,19 @@ void StgEnemyBossSceneObject::LoadAllScriptInThread()
 	}
 	bLoad_ = true;
 }
-int StgEnemyBossSceneObject::GetRemainStepCount()
+int StgEnemyBossSceneObject::GetRemainStepCount() const
 {
 	int res = listData_.size() - dataStep_ - 1;
 	res = max(res, 0);
 	return res;
 }
-int StgEnemyBossSceneObject::GetActiveStepLifeCount()
+int StgEnemyBossSceneObject::GetActiveStepLifeCount() const
 {
 	if (dataStep_ >= listData_.size())
 		return 0;
 	return listData_[dataStep_].size();
 }
-double StgEnemyBossSceneObject::GetActiveStepTotalMaxLife()
+double StgEnemyBossSceneObject::GetActiveStepTotalMaxLife() const
 {
 	if (dataStep_ >= listData_.size())
 		return 0;
@@ -425,7 +425,7 @@ double StgEnemyBossSceneObject::GetActiveStepTotalMaxLife()
 	}
 	return res;
 }
-double StgEnemyBossSceneObject::GetActiveStepTotalLife()
+double StgEnemyBossSceneObject::GetActiveStepTotalLife() const
 {
 	if (dataStep_ >= listData_.size())
 		return 0;
@@ -436,7 +436,7 @@ double StgEnemyBossSceneObject::GetActiveStepTotalLife()
 	}
 	return res;
 }
-double StgEnemyBossSceneObject::GetActiveStepLife(int index)
+double StgEnemyBossSceneObject::GetActiveStepLife(int index) const
 {
 	if (dataStep_ >= listData_.size())
 		return 0;
@@ -446,7 +446,7 @@ double StgEnemyBossSceneObject::GetActiveStepLife(int index)
 	double res = 0;
 	ref_count_ptr<StgEnemyBossSceneData>::unsync data = listData_[dataStep_][index];
 	if (index == dataIndex_) {
-		std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& listEnemyObject = data->GetEnemyObjectList();
+		const std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& listEnemyObject = data->GetEnemyObjectList();
 		for (int iEnemy = 0; iEnemy < listEnemyObject.size(); iEnemy++) {
 			ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemyObject[iEnemy];
 			res += obj->GetLife();
@@ -458,7 +458,7 @@ double StgEnemyBossSceneObject::GetActiveStepLife(int index)
 	}
 	return res;
 }
-std::vector<double> StgEnemyBossSceneObject::GetActiveStepLifeRateList()
+std::vector<double> StgEnemyBossSceneObject::GetActiveStepLifeRateList() const
 {
 	std::vector<double> res;
 	int count = GetActiveStepLifeCount();
@@ -516,7 +516,7 @@ int StgEnemyBossSceneData::GetEnemyBossIdInCreate()
 
 	return obj->GetObjectID();
 }
-_int64 StgEnemyBossSceneData::GetCurrentSpellScore()
+_int64 StgEnemyBossSceneData::GetCurrentSpellScore() const
 {
 	_int64 res = scoreSpell_;
 	if (!bDurable_) {

--- a/source/TouhouDanmakufu/Common/StgEnemy.hpp
+++ b/source/TouhouDanmakufu/Common/StgEnemy.hpp
@@ -17,7 +17,7 @@ public:
 	void RegistIntersectionTarget();
 
 	void AddEnemy(ref_count_ptr<StgEnemyObject>::unsync obj) { listObj_.push_back(obj); }
-	int GetEnemyCount() { return listObj_.size(); }
+	int GetEnemyCount() const { return listObj_.size(); }
 
 	void SetBossSceneObject(ref_count_ptr<StgEnemyBossSceneObject>::unsync obj);
 	ref_count_ptr<StgEnemyBossSceneObject>::unsync GetBossSceneObject();
@@ -55,7 +55,7 @@ public:
 	}
 
 	ref_count_ptr<StgEnemyObject>::unsync GetOwnObject();
-	double GetLife() { return life_; }
+	double GetLife() const { return life_; }
 	void SetLife(double life) { life_ = life; }
 	void AddLife(double inc)
 	{
@@ -67,9 +67,9 @@ public:
 		rateDamageShot_ = rateShot;
 		rateDamageSpell_ = rateSpell;
 	}
-	double GetShotDamageRate() { return rateDamageShot_; }
-	double GetSpellDamageRate() { return rateDamageSpell_; }
-	int GetIntersectedPlayerShotCount() { return intersectedPlayerShotCount_; }
+	double GetShotDamageRate() const { return rateDamageShot_; }
+	double GetSpellDamageRate() const { return rateDamageSpell_; }
+	int GetIntersectedPlayerShotCount() const { return intersectedPlayerShotCount_; }
 
 protected:
 	virtual void _Move();
@@ -107,17 +107,17 @@ public:
 	virtual void SetRenderState() {} //何もしない
 
 	void AddData(int step, ref_count_ptr<StgEnemyBossSceneData>::unsync data);
-	ref_count_ptr<StgEnemyBossSceneData>::unsync GetActiveData() { return activeData_; }
+	ref_count_ptr<StgEnemyBossSceneData>::unsync GetActiveData() const { return activeData_; }
 	void LoadAllScriptInThread();
 
-	int GetRemainStepCount();
-	int GetActiveStepLifeCount();
-	double GetActiveStepTotalMaxLife();
-	double GetActiveStepTotalLife();
-	double GetActiveStepLife(int index);
-	std::vector<double> GetActiveStepLifeRateList();
-	int GetDataStep() { return dataStep_; }
-	int GetDataIndex() { return dataIndex_; }
+	int GetRemainStepCount() const;
+	int GetActiveStepLifeCount() const;
+	double GetActiveStepTotalMaxLife() const;
+	double GetActiveStepTotalLife() const;
+	double GetActiveStepLife(int index) const;
+	std::vector<double> GetActiveStepLifeRateList() const;
+	int GetDataStep() const { return dataStep_; }
+	int GetDataIndex() const { return dataIndex_; }
 
 	void AddPlayerShootDownCount();
 	void AddPlayerSpellCount();
@@ -138,40 +138,40 @@ class StgEnemyBossSceneData {
 public:
 	StgEnemyBossSceneData();
 	virtual ~StgEnemyBossSceneData() {}
-	std::wstring GetPath() { return path_; }
-	void SetPath(std::wstring path) { path_ = path; }
-	_int64 GetScriptID() { return isScript_; }
+	std::wstring GetPath() const { return path_; }
+	void SetPath(const std::wstring& path) { path_ = path; }
+	_int64 GetScriptID() const { return isScript_; }
 	void SetScriptID(_int64 id) { isScript_ = id; }
 	std::vector<double>& GetLifeList() { return listLife_; }
-	void SetLifeList(std::vector<double>& list) { listLife_ = list; }
+	void SetLifeList(const std::vector<double>& list) { listLife_ = list; }
 	std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& GetEnemyObjectList() { return listEnemyObject_; }
-	void SetEnemyObjectList(std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& list) { listEnemyObject_ = list; }
+	void SetEnemyObjectList(const std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& list) { listEnemyObject_ = list; }
 	int GetEnemyBossIdInCreate();
-	bool IsReadyNext() { return bReadyNext_; }
+	bool IsReadyNext() const { return bReadyNext_; }
 	void SetReadyNext() { bReadyNext_ = true; }
 
-	_int64 GetCurrentSpellScore();
-	_int64 GetSpellScore() { return scoreSpell_; }
+	_int64 GetCurrentSpellScore() const;
+	_int64 GetSpellScore() const { return scoreSpell_; }
 	void SetSpellScore(_int64 score) { scoreSpell_ = score; }
-	int GetSpellTimer() { return timerSpell_; }
+	int GetSpellTimer() const { return timerSpell_; }
 	void SetSpellTimer(int timer) { timerSpell_ = timer; }
-	int GetOriginalSpellTimer() { return timerSpellOrg_; }
+	int GetOriginalSpellTimer() const { return timerSpellOrg_; }
 	void SetOriginalSpellTimer(int timer)
 	{
 		timerSpellOrg_ = timer;
 		timerSpell_ = timer;
 	}
-	bool IsSpellCard() { return bSpell_; }
+	bool IsSpellCard() const { return bSpell_; }
 	void SetSpellCard(bool b) { bSpell_ = b; }
-	bool IsLastSpell() { return bLastSpell_; }
+	bool IsLastSpell() const { return bLastSpell_; }
 	void SetLastSpell(bool b) { bLastSpell_ = b; }
-	bool IsDurable() { return bDurable_; }
+	bool IsDurable() const { return bDurable_; }
 	void SetDurable(bool b) { bDurable_ = b; }
 
 	void AddPlayerShootDownCount() { countPlayerShootDown_++; }
-	int GetPlayerShootDownCount() { return countPlayerShootDown_; }
+	int GetPlayerShootDownCount() const { return countPlayerShootDown_; }
 	void AddPlayerSpellCount() { countPlayerSpell_++; }
-	int GetPlayerSpellCount() { return countPlayerSpell_; }
+	int GetPlayerSpellCount() const { return countPlayerSpell_; }
 
 private:
 	std::wstring path_;

--- a/source/TouhouDanmakufu/Common/StgEnemy.hpp
+++ b/source/TouhouDanmakufu/Common/StgEnemy.hpp
@@ -35,20 +35,20 @@ private:
 class StgEnemyObject : public DxScriptSpriteObject2D, public StgMoveObject, public StgIntersectionObject {
 public:
 	StgEnemyObject(StgStageController* stageController);
-	virtual ~StgEnemyObject();
+	~StgEnemyObject() override;
 
-	virtual void Work();
+	void Work() override;
 	virtual void Activate();
-	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) override;
 	virtual void ClearEnemyObject() { ClearIntersectionRelativeTarget(); }
 	virtual void RegistIntersectionTarget();
 
-	virtual void SetX(double x)
+	void SetX(double x) override
 	{
 		posX_ = x;
 		DxScriptRenderObject::SetX(x);
 	}
-	virtual void SetY(double y)
+	void SetY(double y) override
 	{
 		posY_ = y;
 		DxScriptRenderObject::SetY(y);
@@ -72,7 +72,7 @@ public:
 	int GetIntersectedPlayerShotCount() const { return intersectedPlayerShotCount_; }
 
 protected:
-	virtual void _Move();
+	void _Move() override;
 	virtual void _AddRelativeIntersection();
 
 	StgStageController* stageController_;
@@ -101,10 +101,10 @@ class StgEnemyBossSceneData;
 class StgEnemyBossSceneObject : public DxScriptObjectBase {
 public:
 	StgEnemyBossSceneObject(StgStageController* stageController);
-	virtual void Work();
+	void Work() override;
 	virtual void Activate();
-	virtual void Render() {} //何もしない
-	virtual void SetRenderState() {} //何もしない
+	void Render() override {} //何もしない
+	void SetRenderState() override {} //何もしない
 
 	void AddData(int step, ref_count_ptr<StgEnemyBossSceneData>::unsync data);
 	ref_count_ptr<StgEnemyBossSceneData>::unsync GetActiveData() const { return activeData_; }
@@ -137,11 +137,11 @@ private:
 class StgEnemyBossSceneData {
 public:
 	StgEnemyBossSceneData();
-	virtual ~StgEnemyBossSceneData() {}
+	virtual ~StgEnemyBossSceneData() = default;
 	std::wstring GetPath() const { return path_; }
 	void SetPath(const std::wstring& path) { path_ = path; }
-	_int64 GetScriptID() const { return isScript_; }
-	void SetScriptID(_int64 id) { isScript_ = id; }
+	int64_t GetScriptID() const { return isScript_; }
+	void SetScriptID(int64_t id) { isScript_ = id; }
 	std::vector<double>& GetLifeList() { return listLife_; }
 	void SetLifeList(const std::vector<double>& list) { listLife_ = list; }
 	std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& GetEnemyObjectList() { return listEnemyObject_; }
@@ -150,9 +150,9 @@ public:
 	bool IsReadyNext() const { return bReadyNext_; }
 	void SetReadyNext() { bReadyNext_ = true; }
 
-	_int64 GetCurrentSpellScore() const;
-	_int64 GetSpellScore() const { return scoreSpell_; }
-	void SetSpellScore(_int64 score) { scoreSpell_ = score; }
+	int64_t GetCurrentSpellScore() const;
+	int64_t GetSpellScore() const { return scoreSpell_; }
+	void SetSpellScore(int64_t score) { scoreSpell_ = score; }
 	int GetSpellTimer() const { return timerSpell_; }
 	void SetSpellTimer(int timer) { timerSpell_ = timer; }
 	int GetOriginalSpellTimer() const { return timerSpellOrg_; }
@@ -175,7 +175,7 @@ public:
 
 private:
 	std::wstring path_;
-	_int64 isScript_;
+	int64_t isScript_;
 	std::vector<double> listLife_;
 	std::vector<ref_count_ptr<StgEnemyBossObject>::unsync> listEnemyObject_;
 	int countCreate_; //ボス生成数。listEnemyObject_を超えて生成しようとしたらエラー。
@@ -184,7 +184,7 @@ private:
 	bool bSpell_; //スペルカード
 	bool bLastSpell_; //ラストスペル
 	bool bDurable_; //耐久スペル
-	_int64 scoreSpell_;
+	int64_t scoreSpell_;
 	int timerSpellOrg_; //初期タイマー フレーム単位 -1で無効
 	int timerSpell_; //タイマー フレーム単位 -1で無効
 	int countPlayerShootDown_; //自機撃破数

--- a/source/TouhouDanmakufu/Common/StgIntersection.cpp
+++ b/source/TouhouDanmakufu/Common/StgIntersection.cpp
@@ -14,27 +14,24 @@ StgIntersectionManager::StgIntersectionManager()
 
 	_CreatePool(2);
 	listSpace_.resize(3);
-	for (int iSpace = 0; iSpace < listSpace_.size(); iSpace++) {
-		StgIntersectionSpace* space = new StgIntersectionSpace();
-		space->Initialize(4, -100, -100, screenWidth + 100, screenHeight + 100);
-		listSpace_[iSpace] = space;
+	for (auto& space : listSpace_) {
+		auto* newSpace = new StgIntersectionSpace();
+		newSpace->Initialize(4, -100, -100, screenWidth + 100, screenHeight + 100);
+		space = newSpace;
 	}
 }
-StgIntersectionManager::~StgIntersectionManager()
-{
-}
+StgIntersectionManager::~StgIntersectionManager() = default;
+
 void StgIntersectionManager::Work()
 {
 	listEnemyTargetPoint_ = listEnemyTargetPointNext_;
 	listEnemyTargetPointNext_.clear();
 
 	int totalCheck = 0;
-	std::vector<ref_count_ptr<StgIntersectionSpace>>::iterator itr = listSpace_.begin();
-	for (; itr != listSpace_.end(); itr++) {
-		StgIntersectionSpace* space = (*itr).GetPointer();
+	for (auto& space : listSpace_) {
 		ref_count_ptr<StgIntersectionCheckList>::unsync listCheck = space->CreateIntersectionCheckList();
 		int countCheck = listCheck->GetCheckCount();
-		for (int iCheck = 0; iCheck < countCheck; iCheck++) {
+		for (int iCheck = 0; iCheck < countCheck; ++iCheck) {
 			//Getは1回しか使用できません
 			ref_count_ptr<StgIntersectionTarget>::unsync targetA = listCheck->GetTargetA(iCheck);
 			ref_count_ptr<StgIntersectionTarget>::unsync targetB = listCheck->GetTargetB(iCheck);
@@ -46,20 +43,20 @@ void StgIntersectionManager::Work()
 			//Grazeの関係で、先に自機の当たり判定をする必要がある。
 			ref_count_weak_ptr<StgIntersectionObject>::unsync objA = targetA->GetObject();
 			ref_count_weak_ptr<StgIntersectionObject>::unsync objB = targetB->GetObject();
-			if (objA != NULL) {
+			if (objA != nullptr) {
 				objA->Intersect(targetA, targetB);
 				objA->SetIntersected();
 
-				if (objB != NULL) {
+				if (objB != nullptr) {
 					int idObject = objB->GetDxScriptObjectID();
 					objA->AddIntersectedId(idObject);
 				}
 			}
 
-			if (objB != NULL) {
+			if (objB != nullptr) {
 				objB->Intersect(targetB, targetA);
 				objB->SetIntersected();
-				if (objA != NULL) {
+				if (objA != nullptr) {
 					int idObject = objA->GetDxScriptObjectID();
 					objB->AddIntersectedId(idObject);
 				}
@@ -103,11 +100,11 @@ void StgIntersectionManager::AddTarget(ref_count_ptr<StgIntersectionTarget>::uns
 		bool bEraseShot = false;
 		if (type == StgIntersectionTarget::TYPE_PLAYER_SHOT) {
 			StgShotObject* shot = (StgShotObject*)target->GetObject().GetPointer();
-			if (shot != NULL)
+			if (shot != nullptr)
 				bEraseShot = shot->IsEraseShot();
 		} else if (type == StgIntersectionTarget::TYPE_PLAYER_SPELL) {
 			StgPlayerSpellObject* spell = (StgPlayerSpellObject*)target->GetObject().GetPointer();
-			if (spell != NULL)
+			if (spell != nullptr)
 				bEraseShot = spell->IsEraseShot();
 		}
 		if (bEraseShot)
@@ -119,9 +116,9 @@ void StgIntersectionManager::AddTarget(ref_count_ptr<StgIntersectionTarget>::uns
 		listSpace_[SPACE_PLAYERSOHT_ENEMY]->RegistTargetB(target);
 
 		ref_count_ptr<StgIntersectionTarget_Circle>::unsync circle = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(target);
-		if (circle != NULL) {
+		if (circle != nullptr) {
 			ref_count_weak_ptr<StgEnemyObject>::unsync objEnemy = ref_count_weak_ptr<StgEnemyObject>::unsync::DownCast(target->GetObject());
-			if (objEnemy != NULL) {
+			if (objEnemy != nullptr) {
 				int idObject = objEnemy->GetObjectID();
 				POINT pos = { (int)circle->GetCircle().GetX(), (int)circle->GetCircle().GetY() };
 				StgIntersectionTargetPoint tp;
@@ -137,7 +134,6 @@ void StgIntersectionManager::AddTarget(ref_count_ptr<StgIntersectionTarget>::uns
 		listSpace_[SPACE_PLAYER_ENEMY]->RegistTargetB(target);
 		listSpace_[SPACE_PLAYERSHOT_ENEMYSHOT]->RegistTargetB(target);
 		break;
-
 	}
 }
 void StgIntersectionManager::AddEnemyTargetToShot(ref_count_ptr<StgIntersectionTarget>::unsync target)
@@ -151,9 +147,9 @@ void StgIntersectionManager::AddEnemyTargetToShot(ref_count_ptr<StgIntersectionT
 		listSpace_[SPACE_PLAYERSOHT_ENEMY]->RegistTargetB(target);
 
 		ref_count_ptr<StgIntersectionTarget_Circle>::unsync circle = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(target);
-		if (circle != NULL) {
+		if (circle != nullptr) {
 			ref_count_weak_ptr<StgEnemyObject>::unsync objEnemy = ref_count_weak_ptr<StgEnemyObject>::unsync::DownCast(target->GetObject());
-			if (objEnemy != NULL) {
+			if (objEnemy != nullptr) {
 				int idObject = objEnemy->GetObjectID();
 				POINT pos = { (int)circle->GetCircle().GetX(), (int)circle->GetCircle().GetY() };
 				StgIntersectionTargetPoint tp;
@@ -191,8 +187,8 @@ bool StgIntersectionManager::IsIntersected(ref_count_ptr<StgIntersectionTarget>:
 		ref_count_ptr<StgIntersectionTarget_Circle>::unsync c2 = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(target2);
 		res = DxMath::IsIntersected(c1->GetCircle(), c2->GetCircle());
 	} else if ((shape1 == StgIntersectionTarget::SHAPE_CIRCLE && shape2 == StgIntersectionTarget::SHAPE_LINE) || (shape1 == StgIntersectionTarget::SHAPE_LINE && shape2 == StgIntersectionTarget::SHAPE_CIRCLE)) {
-		ref_count_ptr<StgIntersectionTarget_Circle>::unsync c = NULL;
-		ref_count_ptr<StgIntersectionTarget_Line>::unsync l = NULL;
+		ref_count_ptr<StgIntersectionTarget_Circle>::unsync c = nullptr;
+		ref_count_ptr<StgIntersectionTarget_Line>::unsync l = nullptr;
 		if (shape1 == StgIntersectionTarget::SHAPE_CIRCLE && shape2 == StgIntersectionTarget::SHAPE_LINE) {
 			c = ref_count_ptr<StgIntersectionTarget_Circle>::unsync::DownCast(target1);
 			l = ref_count_ptr<StgIntersectionTarget_Line>::unsync::DownCast(target2);
@@ -275,12 +271,12 @@ bool StgIntersectionManager::IsIntersected(const DxWidthLine& line1, const DxWid
 void StgIntersectionManager::_ResetPoolObject(gstd::ref_count_ptr<StgIntersectionTarget>::unsync& obj)
 {
 	//	ELogger::WriteTop(StringUtility::Format("_ResetPoolObject:start:%s)", obj->GetInfoAsString().c_str()));
-	obj->obj_ = NULL;
+	obj->obj_ = nullptr;
 	//	ELogger::WriteTop("_ResetPoolObject:end");
 }
 gstd::ref_count_ptr<StgIntersectionTarget>::unsync StgIntersectionManager::_CreatePoolObject(int type)
 {
-	gstd::ref_count_ptr<StgIntersectionTarget>::unsync res = NULL;
+	gstd::ref_count_ptr<StgIntersectionTarget>::unsync res = nullptr;
 	switch (type) {
 	case StgIntersectionTarget::SHAPE_CIRCLE:
 		res = new StgIntersectionTarget_Circle();
@@ -294,15 +290,13 @@ gstd::ref_count_ptr<StgIntersectionTarget>::unsync StgIntersectionManager::_Crea
 void StgIntersectionManager::CheckDeletedObject(std::string funcName)
 {
 	int countType = listUsedPool_.size();
-	for (int iType = 0; iType < countType; iType++) {
+	for (int iType = 0; iType < countType; ++iType) {
 		std::list<gstd::ref_count_ptr<StgIntersectionTarget, false>>* listUsed = &listUsedPool_[iType];
 		std::vector<gstd::ref_count_ptr<StgIntersectionTarget, false>>* listCache = &listCachePool_[iType];
 
-		std::list<gstd::ref_count_ptr<StgIntersectionTarget, false>>::iterator itr = listUsed->begin();
-		for (; itr != listUsed->end(); itr++) {
-			gstd::ref_count_ptr<StgIntersectionTarget, false> target = (*itr);
+		for (auto& target : *listUsed) {
 			ref_count_weak_ptr<DxScriptObjectBase>::unsync dxObj = ref_count_weak_ptr<DxScriptObjectBase>::unsync::DownCast(target->GetObject());
-			if (dxObj != NULL && dxObj->IsDeleted()) {
+			if (dxObj != nullptr && dxObj->IsDeleted()) {
 				ELogger::WriteTop(StringUtility::Format(L"%s(deleted):%s", funcName.c_str(), target->GetInfoAsString().c_str()));
 			}
 		}
@@ -330,9 +324,7 @@ StgIntersectionSpace::StgIntersectionSpace()
 
 	listCheck_ = new StgIntersectionCheckList();
 }
-StgIntersectionSpace::~StgIntersectionSpace()
-{
-}
+StgIntersectionSpace::~StgIntersectionSpace() = default;
 bool StgIntersectionSpace::Initialize(int level, int left, int top, int right, int bottom)
 {
 	// 設定最高レベル以上の空間は作れない
@@ -341,8 +333,8 @@ bool StgIntersectionSpace::Initialize(int level, int left, int top, int right, i
 
 	countCell_ = (listCountLevel_[level + 1] - 1) / 3;
 	listCell_.resize(countCell_);
-	for (int iCell = 0; iCell < listCell_.size(); iCell++) {
-		listCell_[iCell].resize(2);
+	for (auto& cell : listCell_) {
+		cell.resize(2);
 	}
 
 	spaceLeft_ = left;
@@ -380,9 +372,9 @@ bool StgIntersectionSpace::RegistTarget(int type, ref_count_ptr<StgIntersectionT
 
 void StgIntersectionSpace::ClearTarget()
 {
-	for (int iCell = 0; iCell < listCell_.size(); iCell++) {
-		for (int iType = 0; iType < listCell_[iCell].size(); iType++) {
-			listCell_[iCell][iType].clear();
+	for (auto& cell : listCell_) {
+		for (auto& cellType : cell) {
+			cellType.clear();
 		}
 	}
 }
@@ -401,37 +393,28 @@ void StgIntersectionSpace::_WriteIntersectionCheckList(int indexSpace, ref_count
 {
 	std::vector<std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>>& listCell = listCell_[indexSpace];
 	int typeCount = listCell.size();
-	for (int iType1 = 0; iType1 < typeCount; iType1++) {
+	for (int iType1 = 0; iType1 < typeCount; ++iType1) {
 		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& list1 = listCell[iType1];
-		int iType2 = 0;
-		for (iType2 = iType1 + 1; iType2 < typeCount; iType2++) {
+		for (int iType2 = iType1 + 1; iType2 < typeCount; ++iType2) {
 			std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& list2 = listCell[iType2];
 
 			// ① 空間内のオブジェクト同士の衝突リスト作成
-			std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>::iterator itr1 = list1.begin();
-			for (; itr1 != list1.end(); itr1++) {
-				std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>::iterator itr2 = list2.begin();
-				for (; itr2 != list2.end(); itr2++) {
-					ref_count_ptr<StgIntersectionTarget>::unsync target1 = (*itr1);
-					ref_count_ptr<StgIntersectionTarget>::unsync target2 = (*itr2);
+			for (auto& target1 : list1) {
+				for (auto& target2 : list2) {
 					listCheck->Add(target1, target2);
 				}
 			}
 		}
 
 		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& stack = listStack[iType1];
-		for (iType2 = 0; iType2 < typeCount; iType2++) {
+		for (int iType2 = 0; iType2 < typeCount; ++iType2) {
 			if (iType1 == iType2)
 				continue;
 			std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& list2 = listCell[iType2];
 
 			// ② 衝突スタックとの衝突リスト作成
-			std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>::iterator itrStack = stack.begin();
-			for (; itrStack != stack.end(); itrStack++) {
-				std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>::iterator itr2 = list2.begin();
-				for (; itr2 != list2.end(); itr2++) {
-					ref_count_ptr<StgIntersectionTarget>::unsync target2 = (*itr2);
-					ref_count_ptr<StgIntersectionTarget>::unsync targetStack = (*itrStack);
+			for (auto& targetStack : stack) {
+				for (auto& target2 : list2) {
 					if (iType1 < iType2)
 						listCheck->Add(targetStack, target2);
 					else
@@ -442,19 +425,16 @@ void StgIntersectionSpace::_WriteIntersectionCheckList(int indexSpace, ref_count
 	}
 
 	//空間内のオブジェクトをスタックに追加
-	int iType = 0;
-	for (iType = 0; iType < typeCount; iType++) {
+	for (int iType = 0; iType < typeCount; ++iType) {
 		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& list = listCell[iType];
 		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& stack = listStack[iType];
-		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>::iterator itr = list.begin();
-		for (; itr != list.end(); itr++) {
-			ref_count_ptr<StgIntersectionTarget>::unsync target = (*itr);
+		for (auto& target : list) {
 			stack.push_back(target);
 		}
 	}
 
 	// ③ 子空間に移動
-	for (int iChild = 0; iChild < 4; iChild++) {
+	for (int iChild = 0; iChild < 4; ++iChild) {
 		int indexChild = indexSpace * 4 + 1 + iChild;
 		if (indexChild < countCell_) {
 			_WriteIntersectionCheckList(indexChild, listCheck, listStack);
@@ -462,11 +442,10 @@ void StgIntersectionSpace::_WriteIntersectionCheckList(int indexSpace, ref_count
 	}
 
 	//スタックから解除
-	for (iType = 0; iType < typeCount; iType++) {
+	for (int iType = 0; iType < typeCount; ++iType) {
 		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& list = listCell[iType];
 		std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>& stack = listStack[iType];
-		int count = list.size();
-		for (int iCount = 0; iCount < count; iCount++) {
+		for (int iCount = 0; iCount < list.size(); ++iCount) {
 			stack.pop_back();
 		}
 	}
@@ -521,9 +500,9 @@ unsigned int StgIntersectionSpace::_GetPointElem(float pos_x, float pos_y)
 //StgIntersectionObject
 void StgIntersectionObject::ClearIntersectionRelativeTarget()
 {
-	for (int iTarget = 0; iTarget < listRelativeTarget_.size(); iTarget++) {
-		ref_count_weak_ptr<StgIntersectionTarget>::unsync target = listRelativeTarget_[iTarget];
-		target->SetObject(NULL);
+	for (auto& iTarget : listRelativeTarget_) {
+		ref_count_weak_ptr<StgIntersectionTarget>::unsync target = iTarget;
+		target->SetObject(nullptr);
 	}
 	listRelativeTarget_.clear();
 }
@@ -532,10 +511,10 @@ void StgIntersectionObject::AddIntersectionRelativeTarget(ref_count_ptr<StgInter
 	listRelativeTarget_.push_back(target);
 	int shape = target->GetShape();
 	if (shape == StgIntersectionTarget::SHAPE_CIRCLE) {
-		StgIntersectionTarget_Circle* tTarget = (StgIntersectionTarget_Circle*)target.GetPointer();
+		auto* tTarget = (StgIntersectionTarget_Circle*)target.GetPointer();
 		listOrgCircle_.push_back(tTarget->GetCircle());
 	} else if (shape == StgIntersectionTarget::SHAPE_LINE) {
-		StgIntersectionTarget_Line* tTarget = (StgIntersectionTarget_Line*)target.GetPointer();
+		auto* tTarget = (StgIntersectionTarget_Line*)target.GetPointer();
 		listOrgLine_.push_back(tTarget->GetLine());
 	}
 }
@@ -543,11 +522,10 @@ void StgIntersectionObject::UpdateIntersectionRelativeTarget(int posX, int posY,
 {
 	int iCircle = 0;
 	int iLine = 0;
-	for (int iTarget = 0; iTarget < listRelativeTarget_.size(); iTarget++) {
-		ref_count_ptr<StgIntersectionTarget>::unsync target = listRelativeTarget_[iTarget];
+	for (auto& target : listRelativeTarget_) {
 		int shape = target->GetShape();
 		if (shape == StgIntersectionTarget::SHAPE_CIRCLE) {
-			StgIntersectionTarget_Circle* tTarget = (StgIntersectionTarget_Circle*)target.GetPointer();
+			auto* tTarget = (StgIntersectionTarget_Circle*)target.GetPointer();
 			DxCircle org = listOrgCircle_[iCircle];
 			int px = org.GetX() + posX;
 			int py = org.GetY() + posY;
@@ -556,25 +534,24 @@ void StgIntersectionObject::UpdateIntersectionRelativeTarget(int posX, int posY,
 			circle.SetX(px);
 			circle.SetY(py);
 			tTarget->SetCircle(circle);
-			iCircle++;
+			++iCircle;
 		} else if (shape == StgIntersectionTarget::SHAPE_LINE) {
-			StgIntersectionTarget_Line* tTarget = (StgIntersectionTarget_Line*)target.GetPointer();
-			iLine++;
+			auto* tTarget = (StgIntersectionTarget_Line*)target.GetPointer();
+			++iLine;
 		}
 	}
 }
 void StgIntersectionObject::RegistIntersectionRelativeTarget(StgIntersectionManager* manager)
 {
-	for (int iTarget = 0; iTarget < listRelativeTarget_.size(); iTarget++) {
-		ref_count_ptr<StgIntersectionTarget>::unsync target = listRelativeTarget_[iTarget];
+	for (auto& target : listRelativeTarget_) {
 		manager->AddTarget(target);
 	}
 }
 int StgIntersectionObject::GetDxScriptObjectID()
 {
 	int res = DxScript::ID_INVALID;
-	StgEnemyObject* objEnemy = dynamic_cast<StgEnemyObject*>(this);
-	if (objEnemy != NULL) {
+	auto* objEnemy = dynamic_cast<StgEnemyObject*>(this);
+	if (objEnemy != nullptr) {
 		res = objEnemy->GetObjectID();
 	}
 
@@ -586,7 +563,7 @@ int StgIntersectionObject::GetDxScriptObjectID()
 **********************************************************/
 void StgIntersectionTarget::ClearObjectIntersectedIdList()
 {
-	if (obj_ != NULL) {
+	if (obj_ != nullptr) {
 		obj_->ClearIntersectedIdList();
 	}
 }
@@ -627,11 +604,11 @@ std::wstring StgIntersectionTarget::GetInfoAsString()
 	res += StringUtility::Format(L"address[%08x] ", (int)this);
 
 	res += L"obj[";
-	if (obj_ == NULL) {
+	if (obj_ == nullptr) {
 		res += L"NULL";
 	} else {
 		ref_count_weak_ptr<DxScriptObjectBase>::unsync dxObj = ref_count_weak_ptr<DxScriptObjectBase>::unsync::DownCast(obj_);
-		if (dxObj == NULL)
+		if (dxObj == nullptr)
 			res += L"UNKNOWN";
 		else {
 			int address = (int)dxObj.GetPointer();

--- a/source/TouhouDanmakufu/Common/StgIntersection.cpp
+++ b/source/TouhouDanmakufu/Common/StgIntersection.cpp
@@ -209,7 +209,7 @@ bool StgIntersectionManager::IsIntersected(ref_count_ptr<StgIntersectionTarget>:
 	}
 	return res;
 }
-bool StgIntersectionManager::IsIntersected(DxCircle& circle, DxWidthLine& line)
+bool StgIntersectionManager::IsIntersected(const DxCircle& circle, const DxWidthLine& line)
 {
 	//先端もしくは終端が円内にあるかを調べる
 	{
@@ -268,7 +268,7 @@ bool StgIntersectionManager::IsIntersected(DxCircle& circle, DxWidthLine& line)
 	bool res = e < r;
 	return res;
 }
-bool StgIntersectionManager::IsIntersected(DxWidthLine& line1, DxWidthLine& line2)
+bool StgIntersectionManager::IsIntersected(const DxWidthLine& line1, const DxWidthLine& line2)
 {
 	return false;
 }

--- a/source/TouhouDanmakufu/Common/StgIntersection.hpp
+++ b/source/TouhouDanmakufu/Common/StgIntersection.hpp
@@ -23,7 +23,7 @@ class StgIntersectionManager : public ObjectPool<StgIntersectionTarget, false> {
 
 public:
 	StgIntersectionManager();
-	virtual ~StgIntersectionManager();
+	~StgIntersectionManager() override;
 	void Work();
 
 	void AddTarget(ref_count_ptr<StgIntersectionTarget>::unsync target);
@@ -38,8 +38,8 @@ public:
 	static bool IsIntersected(const DxWidthLine& line1, const DxWidthLine& line2);
 
 private:
-	virtual void _ResetPoolObject(gstd::ref_count_ptr<StgIntersectionTarget>::unsync& obj);
-	virtual gstd::ref_count_ptr<StgIntersectionTarget>::unsync _CreatePoolObject(int type);
+	void _ResetPoolObject(gstd::ref_count_ptr<StgIntersectionTarget>::unsync& obj) override;
+	gstd::ref_count_ptr<StgIntersectionTarget>::unsync _CreatePoolObject(int type) override;
 
 	std::vector<ref_count_ptr<StgIntersectionSpace>> listSpace_;
 	std::vector<StgIntersectionTargetPoint> listEnemyTargetPoint_;
@@ -93,7 +93,7 @@ protected:
 class StgIntersectionCheckList {
 public:
 	StgIntersectionCheckList() { count_ = 0; }
-	virtual ~StgIntersectionCheckList() {}
+	virtual ~StgIntersectionCheckList() = default;
 
 	void Clear() { count_ = 0; }
 	int GetCheckCount() const { return count_; }
@@ -106,18 +106,18 @@ public:
 			listTargetA_[count_] = targetA;
 			listTargetB_[count_] = targetB;
 		}
-		count_++;
+		++count_;
 	}
 	ref_count_ptr<StgIntersectionTarget>::unsync GetTargetA(int index)
 	{
 		ref_count_ptr<StgIntersectionTarget>::unsync res = listTargetA_[index];
-		listTargetA_[index] = NULL;
+		listTargetA_[index] = nullptr;
 		return res;
 	}
 	ref_count_ptr<StgIntersectionTarget>::unsync GetTargetB(int index)
 	{
 		ref_count_ptr<StgIntersectionTarget>::unsync res = listTargetB_[index];
-		listTargetB_[index] = NULL;
+		listTargetB_[index] = nullptr;
 		return res;
 	}
 
@@ -134,7 +134,7 @@ public:
 		bIntersected_ = false;
 		intersectedCount_ = 0;
 	}
-	virtual ~StgIntersectionObject() {}
+	virtual ~StgIntersectionObject() = default;
 	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) = 0;
 	void ClearIntersected()
 	{
@@ -145,12 +145,12 @@ public:
 	void SetIntersected()
 	{
 		bIntersected_ = true;
-		intersectedCount_++;
+		++intersectedCount_;
 	}
 	int GetIntersectedCount() const { return intersectedCount_; }
 	void ClearIntersectedIdList()
 	{
-		if (listIntersectedID_.size() > 0)
+		if (!listIntersectedID_.empty())
 			listIntersectedID_.clear();
 	}
 	void AddIntersectedId(int id) { listIntersectedID_.push_back(id); }
@@ -196,7 +196,7 @@ public:
 
 public:
 	StgIntersectionTarget() { mortonNo_ = -1; }
-	virtual ~StgIntersectionTarget() {}
+	~StgIntersectionTarget() override = default;
 	virtual RECT GetIntersectionSapceRect() = 0;
 
 	int GetTargetType() const { return typeTarget_; }
@@ -209,7 +209,7 @@ public:
 	void SetMortonNumber(int no) { mortonNo_ = no; }
 	void ClearObjectIntersectedIdList();
 
-	virtual std::wstring GetInfoAsString();
+	std::wstring GetInfoAsString() override;
 
 protected:
 	int mortonNo_;
@@ -223,8 +223,8 @@ class StgIntersectionTarget_Circle : public StgIntersectionTarget {
 
 public:
 	StgIntersectionTarget_Circle() { shape_ = SHAPE_CIRCLE; }
-	virtual ~StgIntersectionTarget_Circle() {}
-	virtual RECT GetIntersectionSapceRect()
+	~StgIntersectionTarget_Circle() override = default;
+	RECT GetIntersectionSapceRect() override
 	{
 		DirectGraphics* graphics = DirectGraphics::GetBase();
 		int screenWidth = graphics->GetScreenWidth();
@@ -260,8 +260,8 @@ protected:
 	StgIntersectionTarget_Line() { shape_ = SHAPE_LINE; }
 
 public:
-	virtual ~StgIntersectionTarget_Line() {}
-	virtual RECT GetIntersectionSapceRect()
+	~StgIntersectionTarget_Line() override = default;
+	RECT GetIntersectionSapceRect() override
 	{
 		double x1 = line_.GetX1();
 		double y1 = line_.GetY1();

--- a/source/TouhouDanmakufu/Common/StgIntersection.hpp
+++ b/source/TouhouDanmakufu/Common/StgIntersection.hpp
@@ -34,8 +34,8 @@ public:
 	void CheckDeletedObject(std::string funcName);
 
 	static bool IsIntersected(ref_count_ptr<StgIntersectionTarget>::unsync& target1, ref_count_ptr<StgIntersectionTarget>::unsync& target2);
-	static bool IsIntersected(DxCircle& circle, DxWidthLine& line);
-	static bool IsIntersected(DxWidthLine& line1, DxWidthLine& line2);
+	static bool IsIntersected(const DxCircle& circle, const DxWidthLine& line);
+	static bool IsIntersected(const DxWidthLine& line1, const DxWidthLine& line2);
 
 private:
 	virtual void _ResetPoolObject(gstd::ref_count_ptr<StgIntersectionTarget>::unsync& obj);
@@ -96,7 +96,7 @@ public:
 	virtual ~StgIntersectionCheckList() {}
 
 	void Clear() { count_ = 0; }
-	int GetCheckCount() { return count_; }
+	int GetCheckCount() const { return count_; }
 	void Add(ref_count_ptr<StgIntersectionTarget>::unsync& targetA, ref_count_ptr<StgIntersectionTarget>::unsync& targetB)
 	{
 		if (listTargetA_.size() <= count_) {
@@ -141,13 +141,13 @@ public:
 		bIntersected_ = false;
 		intersectedCount_ = 0;
 	}
-	bool IsIntersected() { return bIntersected_; }
+	bool IsIntersected() const { return bIntersected_; }
 	void SetIntersected()
 	{
 		bIntersected_ = true;
 		intersectedCount_++;
 	}
-	int GetIntersectedCount() { return intersectedCount_; }
+	int GetIntersectedCount() const { return intersectedCount_; }
 	void ClearIntersectedIdList()
 	{
 		if (listIntersectedID_.size() > 0)
@@ -158,11 +158,11 @@ public:
 
 	void ClearIntersectionRelativeTarget();
 	void AddIntersectionRelativeTarget(ref_count_ptr<StgIntersectionTarget>::unsync target);
-	ref_count_ptr<StgIntersectionTarget>::unsync GetIntersectionRelativeTarget(int index) { return listRelativeTarget_[index]; }
+	ref_count_ptr<StgIntersectionTarget>::unsync GetIntersectionRelativeTarget(int index) const { return listRelativeTarget_[index]; }
 
 	void UpdateIntersectionRelativeTarget(int posX, int posY, double angle);
 	void RegistIntersectionRelativeTarget(StgIntersectionManager* manager);
-	int GetIntersectionRelativeTargetCount() { return listRelativeTarget_.size(); }
+	int GetIntersectionRelativeTargetCount() const { return listRelativeTarget_.size(); }
 	int GetDxScriptObjectID();
 
 	virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList() { return std::vector<ref_count_ptr<StgIntersectionTarget>::unsync>(); }
@@ -199,13 +199,13 @@ public:
 	virtual ~StgIntersectionTarget() {}
 	virtual RECT GetIntersectionSapceRect() = 0;
 
-	int GetTargetType() { return typeTarget_; }
+	int GetTargetType() const { return typeTarget_; }
 	void SetTargetType(int type) { typeTarget_ = type; }
-	int GetShape() { return shape_; }
-	ref_count_weak_ptr<StgIntersectionObject>::unsync GetObject() { return obj_; }
+	int GetShape() const { return shape_; }
+	ref_count_weak_ptr<StgIntersectionObject>::unsync GetObject() const { return obj_; }
 	void SetObject(ref_count_weak_ptr<StgIntersectionObject>::unsync obj) { obj_ = obj; }
 
-	int GetMortonNumber() { return mortonNo_; }
+	int GetMortonNumber() const { return mortonNo_; }
 	void SetMortonNumber(int no) { mortonNo_ = no; }
 	void ClearObjectIntersectedIdList();
 
@@ -247,7 +247,7 @@ public:
 	}
 
 	DxCircle& GetCircle() { return circle_; }
-	void SetCircle(DxCircle& circle) { circle_ = circle; }
+	void SetCircle(const DxCircle& circle) { circle_ = circle; }
 
 private:
 	DxCircle circle_;
@@ -314,9 +314,9 @@ private:
 **********************************************************/
 class StgIntersectionTargetPoint {
 public:
-	POINT& GetPoint() { return pos_; }
-	void SetPoint(POINT& pos) { pos_ = pos; }
-	int GetObjectID() { return idObject_; }
+	POINT GetPoint() { return pos_; }
+	void SetPoint(POINT pos) { pos_ = pos; }
+	int GetObjectID() const { return idObject_; }
 	void SetObjectID(int id) { idObject_ = id; }
 
 private:

--- a/source/TouhouDanmakufu/Common/StgItem.cpp
+++ b/source/TouhouDanmakufu/Common/StgItem.cpp
@@ -28,9 +28,7 @@ StgItemManager::StgItemManager(StgStageController* stageController)
 	bDefaultBonusItemEnable_ = true;
 	bAllItemToPlayer_ = false;
 }
-StgItemManager::~StgItemManager()
-{
-}
+StgItemManager::~StgItemManager() = default;
 void StgItemManager::Work()
 {
 	ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController_->GetPlayerObject();
@@ -39,8 +37,7 @@ void StgItemManager::Work()
 	double pr = objPlayer->GetItemIntersectionRadius();
 	int pAutoItemCollectY = objPlayer->GetAutoItemCollectY();
 
-	std::list<ref_count_ptr<StgItemObject>::unsync>::iterator itr = listObj_.begin();
-	for (; itr != listObj_.end();) {
+	for (auto itr = listObj_.begin(); itr != listObj_.end();) {
 		ref_count_ptr<StgItemObject>::unsync obj = (*itr);
 		if (obj->IsDeleted()) {
 			// obj->Clear();
@@ -51,7 +48,7 @@ void StgItemManager::Work()
 			if (objPlayer->GetState() == StgPlayerObject::STATE_NORMAL) {
 				double radius = pow(pow(px - ix, 2) + pow(py - iy, 2), 0.5);
 				if (radius <= pr) {
-					obj->Intersect(NULL, NULL);
+					obj->Intersect(nullptr, nullptr);
 				}
 
 				if (bCancelToPlayer_) {
@@ -66,7 +63,7 @@ void StgItemManager::Work()
 							bMoveToPlayer = true;
 					}
 
-					if (listItemTypeToPlayer_.size() > 0) {
+					if (!listItemTypeToPlayer_.empty()) {
 						//自機にアイテムを集める
 						int typeItem = obj->GetItemType();
 						bool bFind = listItemTypeToPlayer_.find(typeItem) != listItemTypeToPlayer_.end();
@@ -74,10 +71,8 @@ void StgItemManager::Work()
 							bMoveToPlayer = true;
 					}
 
-					if (listCircleToPlayer_.size() > 0) {
-						std::list<DxCircle>::iterator itr = listCircleToPlayer_.begin();
-						for (; itr != listCircleToPlayer_.end(); itr++) {
-							DxCircle circle = *itr;
+					if (!listCircleToPlayer_.empty()) {
+						for (auto& circle : listCircleToPlayer_) {
 							double cr = pow(pow(ix - circle.GetX(), 2) + pow(iy - circle.GetY(), 2), 0.5);
 							if (cr <= circle.GetR()) {
 								bMoveToPlayer = true;
@@ -97,7 +92,7 @@ void StgItemManager::Work()
 				obj->SetMoveToPlayer(false);
 			}
 
-			itr++;
+			++itr;
 		}
 	}
 	listItemTypeToPlayer_.clear();
@@ -123,22 +118,20 @@ void StgItemManager::Render(int targetPriority)
 	DxCamera2D* camera = graphics->GetCamera2D().GetPointer();
 	D3DXMATRIX matCamera = camera->GetMatrix();
 
-	std::list<ref_count_ptr<StgItemObject>::unsync>::iterator itr = listObj_.begin();
-	for (; itr != listObj_.end(); itr++) {
-		ref_count_ptr<StgItemObject>::unsync obj = (*itr);
-		if (obj->IsDeleted())
+	for (auto& object : listObj_) {
+		if (object->IsDeleted())
 			continue;
-		if (obj->GetRenderPriorityI() != targetPriority)
+		if (object->GetRenderPriorityI() != targetPriority)
 			continue;
 
-		obj->RenderOnItemManager(matCamera);
+		object->RenderOnItemManager(matCamera);
 	}
 
 	int countBlendType = StgItemDataList::RENDER_TYPE_COUNT;
 	int blendMode[] = { DirectGraphics::MODE_BLEND_ADD_ARGB, DirectGraphics::MODE_BLEND_ADD_RGB, DirectGraphics::MODE_BLEND_ALPHA };
 	int typeRender[] = { StgShotDataList::RENDER_ADD_ARGB, StgShotDataList::RENDER_ADD_RGB, StgShotDataList::RENDER_ALPHA };
 	ref_count_ptr<SpriteList2D>::unsync listSprite[] = { listSpriteDigit_, listSpriteItem_ };
-	for (int iBlend = 0; iBlend < countBlendType; iBlend++) {
+	for (int iBlend = 0; iBlend < countBlendType; ++iBlend) {
 		graphics->SetBlendMode(blendMode[iBlend]);
 		if (blendMode[iBlend] == DirectGraphics::MODE_BLEND_ADD_ARGB) {
 			listSpriteDigit_->Render();
@@ -150,7 +143,7 @@ void StgItemManager::Render(int targetPriority)
 
 		std::vector<ref_count_ptr<StgItemRenderer>::unsync>* listRenderer = listItemData_->GetRendererList(typeRender[iBlend]);
 		int iRender = 0;
-		for (iRender = 0; iRender < listRenderer->size(); iRender++)
+		for (iRender = 0; iRender < listRenderer->size(); ++iRender)
 			(listRenderer->at(iRender))->Render();
 	}
 
@@ -163,13 +156,11 @@ std::vector<bool> StgItemManager::GetValidRenderPriorityList()
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
 	res.resize(objectManager->GetRenderBucketCapacity());
 
-	std::list<ref_count_ptr<StgItemObject>::unsync>::iterator itr = listObj_.begin();
-	for (; itr != listObj_.end(); itr++) {
-		ref_count_ptr<StgItemObject>::unsync obj = (*itr);
-		if (obj->IsDeleted())
+	for (auto& object : listObj_) {
+		if (object->IsDeleted())
 			continue;
 
-		int pri = obj->GetRenderPriorityI();
+		int pri = object->GetRenderPriorityI();
 		res[pri] = true;
 	}
 
@@ -231,33 +222,30 @@ StgItemDataList::StgItemDataList()
 {
 	listRenderer_.resize(RENDER_TYPE_COUNT);
 }
-StgItemDataList::~StgItemDataList()
-{
-}
+StgItemDataList::~StgItemDataList() = default;
 bool StgItemDataList::AddItemDataList(const std::wstring& path, bool bReload)
 {
 	if (!bReload && listReadPath_.find(path) != listReadPath_.end())
 		return true;
 
 	ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-	if (reader == NULL)
-		throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path).c_str());
+	if (reader == nullptr)
+		throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path));
 	if (!reader->Open())
-		throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path).c_str());
+		throw gstd::wexception(ErrorUtility::GetFileNotFoundErrorMessage(path));
 	std::string source = reader->ReadAllString();
 
-	bool res = false;
 	Scanner scanner(source);
 	try {
 		std::vector<ref_count_ptr<StgItemData>::unsync> listData;
-		std::wstring pathImage = L"";
+		std::wstring pathImage;
 		RECT rcDelay = { -1, -1, -1, -1 };
 		while (scanner.HasNext()) {
 			Token& tok = scanner.Next();
-			if (tok.GetType() == Token::TK_EOF) //Eofの識別子が来たらファイルの調査終了
-			{
+			if (tok.GetType() == Token::TK_EOF) { //Eofの識別子が来たらファイルの調査終了
 				break;
-			} else if (tok.GetType() == Token::TK_ID) {
+			}
+			if (tok.GetType() == Token::TK_ID) {
 				std::wstring element = tok.GetElement();
 				if (element == L"ItemData") {
 					_ScanItem(listData, scanner);
@@ -272,7 +260,7 @@ bool StgItemDataList::AddItemDataList(const std::wstring& path, bool bReload)
 		}
 
 		//テクスチャ読み込み
-		if (pathImage.size() == 0)
+		if (pathImage.empty())
 			throw gstd::wexception(L"画像ファイルが設定されていません。");
 		std::wstring dir = PathProperty::GetFileDirectory(path);
 		pathImage = StringUtility::Replace(pathImage, L"./", dir);
@@ -293,18 +281,18 @@ bool StgItemDataList::AddItemDataList(const std::wstring& path, bool bReload)
 		if (textureIndex < 0) {
 			textureIndex = listTexture_.size();
 			listTexture_.push_back(texture);
-			for (int iRender = 0; iRender < listRenderer_.size(); iRender++) {
+			for (auto& iRender : listRenderer_) {
 				ref_count_ptr<StgItemRenderer>::unsync render = new StgItemRenderer();
 				render->SetTexture(texture);
-				listRenderer_[iRender].push_back(render);
+				iRender.push_back(render);
 			}
 		}
 
 		if (listData_.size() < listData.size())
 			listData_.resize(listData.size());
-		for (int iData = 0; iData < listData.size(); iData++) {
+		for (int iData = 0; iData < listData.size(); ++iData) {
 			ref_count_ptr<StgItemData>::unsync data = listData[iData];
-			if (data == NULL)
+			if (data == nullptr)
 				continue;
 			data->indexTexture_ = textureIndex;
 			listData_[iData] = data;
@@ -312,18 +300,16 @@ bool StgItemDataList::AddItemDataList(const std::wstring& path, bool bReload)
 
 		listReadPath_.insert(path);
 		Logger::WriteTop(StringUtility::Format(L"アイテムデータを読み込みました:%s", path.c_str()));
-		res = true;
+		return true;
 	} catch (gstd::wexception& e) {
 		std::wstring log = StringUtility::Format(L"アイテムデータ読み込み失敗:%d行目(%s)", scanner.GetCurrentLine(), e.what());
 		Logger::WriteTop(log);
-		res = NULL;
+		return false;
 	} catch (...) {
 		std::wstring log = StringUtility::Format(L"アイテムデータ読み込み失敗:%d行目", scanner.GetCurrentLine());
 		Logger::WriteTop(log);
-		res = NULL;
+		return false;
 	}
-
-	return res;
 }
 void StgItemDataList::_ScanItem(std::vector<ref_count_ptr<StgItemData>::unsync>& listData, Scanner& scanner)
 {
@@ -340,7 +326,7 @@ void StgItemDataList::_ScanItem(std::vector<ref_count_ptr<StgItemData>::unsync>&
 		tok = scanner.Next();
 		if (tok.GetType() == Token::TK_CLOSEC) {
 			break;
-		} else if (tok.GetType() == Token::TK_ID) {
+		} if (tok.GetType() == Token::TK_ID) {
 			std::wstring element = tok.GetElement();
 
 			if (element == L"id") {
@@ -403,7 +389,8 @@ void StgItemDataList::_ScanAnimation(ref_count_ptr<StgItemData>::unsync itemData
 		tok = scanner.Next();
 		if (tok.GetType() == Token::TK_CLOSEC) {
 			break;
-		} else if (tok.GetType() == Token::TK_ID) {
+		}
+		if (tok.GetType() == Token::TK_ID) {
 			std::wstring element = tok.GetElement();
 
 			if (element == L"animation_data") {
@@ -441,7 +428,7 @@ std::vector<std::wstring> StgItemDataList::_GetArgumentList(Scanner& scanner)
 			int type = tok.GetType();
 			if (type == Token::TK_CLOSEP)
 				break;
-			else if (type != Token::TK_COMMA) {
+			if (type != Token::TK_COMMA) {
 				std::wstring str = tok.GetElement();
 				res.push_back(str);
 			}
@@ -462,28 +449,23 @@ StgItemData::StgItemData(StgItemDataList* listItemData)
 	alpha_ = 255;
 	totalAnimeFrame_ = 0;
 }
-StgItemData::~StgItemData()
-{
-}
+StgItemData::~StgItemData() = default;
 RECT StgItemData::GetRect(int frame)
 {
 	if (totalAnimeFrame_ == 0)
 		return rcSrc_;
 
-	RECT res;
 	frame = frame % totalAnimeFrame_;
 	int total = 0;
-	std::vector<AnimationData>::iterator itr = listAnime_.begin();
-	for (; itr != listAnime_.end(); itr++) {
-		// AnimationData* anime = itr;
-		total += itr->frame_;
+	for (auto& anime : listAnime_) {
+		total += anime.frame_;
 		if (total >= frame) {
-			res = itr->rcSrc_;
+			return anime.rcSrc_;
 			break;
 		}
 	}
 
-	return res;
+	return RECT();
 }
 ref_count_ptr<Texture> StgItemData::GetTexture()
 {
@@ -492,7 +474,7 @@ ref_count_ptr<Texture> StgItemData::GetTexture()
 }
 StgItemRenderer* StgItemData::GetRenderer()
 {
-	StgItemRenderer* res = NULL;
+	StgItemRenderer* res = nullptr;
 	if (typeRender_ == DirectGraphics::MODE_BLEND_ALPHA)
 		res = listItemData_->GetRenderer(indexTexture_, StgItemDataList::RENDER_ALPHA).GetPointer();
 	else if (typeRender_ == DirectGraphics::MODE_BLEND_ADD_RGB)
@@ -516,19 +498,17 @@ StgItemRenderer::StgItemRenderer()
 }
 int StgItemRenderer::GetVertexCount() const
 {
-	int res = countRenderVertex_;
-	res = min(countRenderVertex_, vertex_.GetSize() / strideVertexStreamZero_);
-	return res;
+	return min(countRenderVertex_, vertex_.GetSize() / strideVertexStreamZero_);
 }
 void StgItemRenderer::Render()
 {
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	IDirect3DDevice9* device = graphics->GetDevice();
 	ref_count_ptr<Texture>& texture = texture_[0];
-	if (texture != NULL)
+	if (texture != nullptr)
 		device->SetTexture(0, texture->GetD3DTexture());
 	else
-		device->SetTexture(0, NULL);
+		device->SetTexture(0, nullptr);
 	device->SetFVF(VERTEX_TLX::fvf);
 
 	device->DrawPrimitiveUP(typePrimitive_, _GetPrimitiveCount(), vertex_.GetPointer(), strideVertexStreamZero_);
@@ -539,7 +519,7 @@ void StgItemRenderer::Render()
 void StgItemRenderer::AddVertex(const VERTEX_TLX& vertex)
 {
 	SetVertex(countRenderVertex_, vertex);
-	countRenderVertex_++;
+	++countRenderVertex_;
 }
 void StgItemRenderer::AddSquareVertex(const VERTEX_TLX* listVertex)
 {
@@ -679,18 +659,16 @@ void StgItemObject::RenderOnItemManager(D3DXMATRIX mat)
 		renderer->SetPosition(0, 0, 0);
 
 		int fontSize = 14;
-		_int64 score = score_;
+		int64_t score = score_;
 		std::vector<int> listNum;
-		while (true) {
+		do {
 			int tnum = score % 10;
 			score /= 10;
 			listNum.push_back(tnum);
-			if (score == 0)
-				break;
-		}
-		for (int iNum = listNum.size() - 1; iNum >= 0; iNum--) {
-			RECT_D rcSrc = { (double)(listNum[iNum] * 36), 0.,
-				(double)((listNum[iNum] + 1) * 36 - 1), 31. };
+		} while (score != 0);
+		for (int iNum = listNum.size() - 1; iNum >= 0; --iNum) {
+			RECT_D rcSrc = { (double)(listNum[iNum] * 36), 0.0,
+				(double)((listNum[iNum] + 1) * 36 - 1), 31.0 };
 			RECT_D rcDest = { (double)(posX_ + (listNum.size() - 1 - iNum) * fontSize / 2), (double)posY_,
 				(double)(posX_ + (listNum.size() - iNum) * fontSize / 2), (double)(posY_ + fontSize) };
 			renderer->SetSourceRect(rcSrc);
@@ -731,8 +709,8 @@ void StgItemObject::_NotifyEventToPlayerScript(const std::vector<long double>& l
 	ref_count_ptr<StgPlayerObject>::unsync player = stageController_->GetPlayerObject();
 	StgStagePlayerScript* scriptPlayer = player->GetPlayerScript();
 	std::vector<gstd::value> listScriptValue;
-	for (int iVal = 0; iVal < listValue.size(); iVal++) {
-		listScriptValue.push_back(scriptPlayer->CreateRealValue(listValue[iVal]));
+	for (long double val : listValue) {
+		listScriptValue.push_back(scriptPlayer->CreateRealValue(val));
 	}
 
 	scriptPlayer->RequestEvent(StgStageItemScript::EV_GET_ITEM, listScriptValue);
@@ -741,13 +719,13 @@ void StgItemObject::_NotifyEventToItemScript(const std::vector<long double>& lis
 {
 	//アイテムスクリプトへ通知
 	StgStageScriptManager* stageScriptManager = stageController_->GetScriptManagerP();
-	_int64 idItemScript = stageScriptManager->GetItemScriptID();
+	int64_t idItemScript = stageScriptManager->GetItemScriptID();
 	if (idItemScript != StgControlScriptManager::ID_INVALID) {
 		ref_count_ptr<ManagedScript> scriptItem = stageScriptManager->GetScript(idItemScript);
-		if (scriptItem != NULL) {
+		if (scriptItem != nullptr) {
 			std::vector<gstd::value> listScriptValue;
-			for (int iVal = 0; iVal < listValue.size(); iVal++) {
-				listScriptValue.push_back(scriptItem->CreateRealValue(listValue[iVal]));
+			for (long double val : listValue) {
+				listScriptValue.push_back(scriptItem->CreateRealValue(val));
 			}
 			scriptItem->RequestEvent(StgStageItemScript::EV_GET_ITEM, listScriptValue);
 		}
@@ -765,22 +743,22 @@ void StgItemObject::SetColor(int r, int g, int b)
 }
 void StgItemObject::SetToPosition(POINT pos)
 {
-	StgMovePattern_Item* move = (StgMovePattern_Item*)pattern_.GetPointer();
+	auto* move = (StgMovePattern_Item*)pattern_.GetPointer();
 	move->SetToPosition(pos);
 }
 int StgItemObject::GetMoveType()
 {
 	int res = StgMovePattern_Item::MOVE_NONE;
 
-	StgMovePattern_Item* move = dynamic_cast<StgMovePattern_Item*>(pattern_.GetPointer());
-	if (move != NULL)
+	auto* move = dynamic_cast<StgMovePattern_Item*>(pattern_.GetPointer());
+	if (move != nullptr)
 		res = move->GetItemMoveType();
 	return res;
 }
 void StgItemObject::SetMoveType(int type)
 {
-	StgMovePattern_Item* move = dynamic_cast<StgMovePattern_Item*>(pattern_.GetPointer());
-	if (move != NULL)
+	auto* move = dynamic_cast<StgMovePattern_Item*>(pattern_.GetPointer());
+	if (move != nullptr)
 		move->SetItemMoveType(type);
 }
 
@@ -789,7 +767,7 @@ StgItemObject_1UP::StgItemObject_1UP(StgStageController* stageController)
 	: StgItemObject(stageController)
 {
 	typeItem_ = ITEM_1UP;
-	StgMovePattern_Item* move = (StgMovePattern_Item*)pattern_.GetPointer();
+	auto* move = (StgMovePattern_Item*)pattern_.GetPointer();
 	move->SetItemMoveType(StgMovePattern_Item::MOVE_TOPOSITION_A);
 }
 void StgItemObject_1UP::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget)
@@ -809,7 +787,7 @@ StgItemObject_Bomb::StgItemObject_Bomb(StgStageController* stageController)
 	: StgItemObject(stageController)
 {
 	typeItem_ = ITEM_SPELL;
-	StgMovePattern_Item* move = (StgMovePattern_Item*)pattern_.GetPointer();
+	auto* move = (StgMovePattern_Item*)pattern_.GetPointer();
 	move->SetItemMoveType(StgMovePattern_Item::MOVE_TOPOSITION_A);
 }
 void StgItemObject_Bomb::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget)
@@ -829,7 +807,7 @@ StgItemObject_Power::StgItemObject_Power(StgStageController* stageController)
 	: StgItemObject(stageController)
 {
 	typeItem_ = ITEM_POWER;
-	StgMovePattern_Item* move = (StgMovePattern_Item*)pattern_.GetPointer();
+	auto* move = (StgMovePattern_Item*)pattern_.GetPointer();
 	move->SetItemMoveType(StgMovePattern_Item::MOVE_TOPOSITION_A);
 	score_ = 10;
 }
@@ -854,7 +832,7 @@ StgItemObject_Point::StgItemObject_Point(StgStageController* stageController)
 	: StgItemObject(stageController)
 {
 	typeItem_ = ITEM_POINT;
-	StgMovePattern_Item* move = (StgMovePattern_Item*)pattern_.GetPointer();
+	auto* move = (StgMovePattern_Item*)pattern_.GetPointer();
 	move->SetItemMoveType(StgMovePattern_Item::MOVE_TOPOSITION_A);
 }
 void StgItemObject_Point::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget)
@@ -878,7 +856,7 @@ StgItemObject_Bonus::StgItemObject_Bonus(StgStageController* stageController)
 	: StgItemObject(stageController)
 {
 	typeItem_ = ITEM_BONUS;
-	StgMovePattern_Item* move = (StgMovePattern_Item*)pattern_.GetPointer();
+	auto* move = (StgMovePattern_Item*)pattern_.GetPointer();
 	move->SetItemMoveType(StgMovePattern_Item::MOVE_TOPLAYER);
 
 	int graze = stageController->GetStageInformation()->GetGraze();
@@ -911,7 +889,7 @@ StgItemObject_Score::StgItemObject_Score(StgStageController* stageController)
 	: StgItemObject(stageController)
 {
 	typeItem_ = ITEM_SCORE;
-	StgMovePattern_Item* move = (StgMovePattern_Item*)pattern_.GetPointer();
+	auto* move = (StgMovePattern_Item*)pattern_.GetPointer();
 	move->SetItemMoveType(StgMovePattern_Item::MOVE_SCORE);
 
 	bPermitMoveToPlayer_ = false;
@@ -928,7 +906,7 @@ void StgItemObject_Score::Work()
 		stageController_->GetMainObjectManager()->DeleteObject(GetObjectID());
 		return;
 	}
-	frameDelete_++;
+	++frameDelete_;
 }
 void StgItemObject_Score::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget)
 {
@@ -941,7 +919,7 @@ StgItemObject_User::StgItemObject_User(StgStageController* stageController)
 	typeItem_ = ITEM_USER;
 	idImage_ = -1;
 	frameWork_ = 0;
-	StgMovePattern_Item* move = (StgMovePattern_Item*)pattern_.GetPointer();
+	auto* move = (StgMovePattern_Item*)pattern_.GetPointer();
 	move->SetItemMoveType(StgMovePattern_Item::MOVE_DOWN);
 
 	bChangeItemScore_ = true;
@@ -950,17 +928,17 @@ void StgItemObject_User::SetImageID(int id)
 {
 	idImage_ = id;
 	StgItemData* data = _GetItemData();
-	if (data != NULL) {
+	if (data != nullptr) {
 		typeItem_ = data->GetItemType();
 	}
 }
 StgItemData* StgItemObject_User::_GetItemData()
 {
-	StgItemData* res = NULL;
+	StgItemData* res = nullptr;
 	StgItemManager* itemManager = stageController_->GetItemManager();
 	StgItemDataList* dataList = itemManager->GetItemDataList();
 
-	if (dataList != NULL) {
+	if (dataList != nullptr) {
 		res = dataList->GetData(idImage_).GetPointer();
 	}
 
@@ -968,7 +946,7 @@ StgItemData* StgItemObject_User::_GetItemData()
 }
 void StgItemObject_User::_SetVertexPosition(VERTEX_TLX& vertex, float x, float y, float z, float w)
 {
-	float bias = -0.5f;
+	float bias = -0.5F;
 	vertex.position.x = x + bias;
 	vertex.position.y = y + bias;
 	vertex.position.z = z;
@@ -977,7 +955,7 @@ void StgItemObject_User::_SetVertexPosition(VERTEX_TLX& vertex, float x, float y
 void StgItemObject_User::_SetVertexUV(VERTEX_TLX& vertex, float u, float v)
 {
 	StgItemData* itemData = _GetItemData();
-	if (itemData == NULL)
+	if (itemData == nullptr)
 		return;
 
 	ref_count_ptr<Texture> texture = itemData->GetTexture();
@@ -1001,12 +979,12 @@ void StgItemObject_User::RenderOnItemManager(D3DXMATRIX mat)
 		return;
 
 	StgItemData* itemData = _GetItemData();
-	if (itemData == NULL)
+	if (itemData == nullptr)
 		return;
 
 	int objBlendType = GetBlendType();
 	StgItemRenderer* renderer = itemData->GetRenderer();
-	if (renderer == NULL)
+	if (renderer == nullptr)
 		return;
 
 	D3DXMATRIX matScale;
@@ -1106,7 +1084,7 @@ StgMovePattern_Item::StgMovePattern_Item(StgMoveObject* target)
 }
 void StgMovePattern_Item::Move()
 {
-	StgItemObject* itemObject = (StgItemObject*)target_;
+	auto* itemObject = (StgItemObject*)target_;
 	StgStageController* stageController = itemObject->GetStageController();
 
 	double px = target_->GetPositionX();
@@ -1132,9 +1110,9 @@ void StgMovePattern_Item::Move()
 			typeMove_ = MOVE_DOWN;
 		}
 	} else if (typeMove_ == MOVE_DOWN) {
-		speed_ += 3.0f / 60.0f;
-		if (speed_ > 2.5f)
-			speed_ = 2.5f;
+		speed_ += 3.0F / 60.0F;
+		if (speed_ > 2.5F)
+			speed_ = 2.5F;
 		angDirection_ = 90;
 	} else if (typeMove_ == MOVE_SCORE) {
 		speed_ = 1;
@@ -1150,5 +1128,5 @@ void StgMovePattern_Item::Move()
 		target_->SetPositionY(py);
 	}
 
-	frame_++;
+	++frame_;
 }

--- a/source/TouhouDanmakufu/Common/StgItem.cpp
+++ b/source/TouhouDanmakufu/Common/StgItem.cpp
@@ -176,7 +176,7 @@ std::vector<bool> StgItemManager::GetValidRenderPriorityList()
 	return res;
 }
 
-bool StgItemManager::LoadItemData(std::wstring path, bool bReload)
+bool StgItemManager::LoadItemData(const std::wstring& path, bool bReload)
 {
 	return listItemData_->AddItemDataList(path, bReload);
 }
@@ -215,7 +215,7 @@ void StgItemManager::CollectItemsByType(int type)
 {
 	listItemTypeToPlayer_.insert(type);
 }
-void StgItemManager::CollectItemsInCircle(DxCircle circle)
+void StgItemManager::CollectItemsInCircle(const DxCircle& circle)
 {
 	listCircleToPlayer_.push_back(circle);
 }
@@ -234,7 +234,7 @@ StgItemDataList::StgItemDataList()
 StgItemDataList::~StgItemDataList()
 {
 }
-bool StgItemDataList::AddItemDataList(std::wstring path, bool bReload)
+bool StgItemDataList::AddItemDataList(const std::wstring& path, bool bReload)
 {
 	if (!bReload && listReadPath_.find(path) != listReadPath_.end())
 		return true;
@@ -514,7 +514,7 @@ StgItemRenderer::StgItemRenderer()
 	countRenderVertex_ = 0;
 	SetVertexCount(256 * 256);
 }
-int StgItemRenderer::GetVertexCount()
+int StgItemRenderer::GetVertexCount() const
 {
 	int res = countRenderVertex_;
 	res = min(countRenderVertex_, vertex_.GetSize() / strideVertexStreamZero_);
@@ -536,12 +536,12 @@ void StgItemRenderer::Render()
 	//描画対象をクリアする
 	countRenderVertex_ = 0;
 }
-void StgItemRenderer::AddVertex(VERTEX_TLX& vertex)
+void StgItemRenderer::AddVertex(const VERTEX_TLX& vertex)
 {
 	SetVertex(countRenderVertex_, vertex);
 	countRenderVertex_++;
 }
-void StgItemRenderer::AddSquareVertex(VERTEX_TLX* listVertex)
+void StgItemRenderer::AddSquareVertex(const VERTEX_TLX* listVertex)
 {
 	AddVertex(listVertex[0]);
 	AddVertex(listVertex[2]);
@@ -725,7 +725,7 @@ void StgItemObject::_CreateScoreItem()
 	objectManager->AddObject(obj);
 	itemManager->AddItem(obj);
 }
-void StgItemObject::_NotifyEventToPlayerScript(std::vector<long double>& listValue)
+void StgItemObject::_NotifyEventToPlayerScript(const std::vector<long double>& listValue)
 {
 	//自機スクリプトへ通知
 	ref_count_ptr<StgPlayerObject>::unsync player = stageController_->GetPlayerObject();
@@ -737,7 +737,7 @@ void StgItemObject::_NotifyEventToPlayerScript(std::vector<long double>& listVal
 
 	scriptPlayer->RequestEvent(StgStageItemScript::EV_GET_ITEM, listScriptValue);
 }
-void StgItemObject::_NotifyEventToItemScript(std::vector<long double>& listValue)
+void StgItemObject::_NotifyEventToItemScript(const std::vector<long double>& listValue)
 {
 	//アイテムスクリプトへ通知
 	StgStageScriptManager* stageScriptManager = stageController_->GetScriptManagerP();

--- a/source/TouhouDanmakufu/Common/StgItem.hpp
+++ b/source/TouhouDanmakufu/Common/StgItem.hpp
@@ -19,23 +19,23 @@ public:
 	void Render(int targetPriority);
 
 	void AddItem(ref_count_ptr<StgItemObject>::unsync obj) { listObj_.push_back(obj); }
-	int GetItemCount() { return listObj_.size(); }
+	int GetItemCount() const { return listObj_.size(); }
 
 	SpriteList2D* GetItemRenderer() { return listSpriteItem_.GetPointer(); }
 	SpriteList2D* GetDigitRenderer() { return listSpriteDigit_.GetPointer(); }
 	std::vector<bool> GetValidRenderPriorityList();
 
 	StgItemDataList* GetItemDataList() { return listItemData_.GetPointer(); }
-	bool LoadItemData(std::wstring path, bool bReload = false);
+	bool LoadItemData(const std::wstring& path, bool bReload = false);
 
 	ref_count_ptr<StgItemObject>::unsync CreateItem(int type);
 
 	void CollectItemsAll();
 	void CollectItemsByType(int type);
-	void CollectItemsInCircle(DxCircle circle);
+	void CollectItemsInCircle(const DxCircle& circle);
 	void CancelCollectItems();
 
-	bool IsDefaultBonusItemEnable() { return bDefaultBonusItemEnable_; }
+	bool IsDefaultBonusItemEnable() const { return bDefaultBonusItemEnable_; }
 	void SetDefaultBonusItemEnable(bool bEnable) { bDefaultBonusItemEnable_ = bEnable; }
 
 private:
@@ -68,14 +68,14 @@ public:
 	StgItemDataList();
 	virtual ~StgItemDataList();
 
-	int GetTextureCount() { return listTexture_.size(); }
+	int GetTextureCount() const { return listTexture_.size(); }
 	ref_count_ptr<Texture> GetTexture(int index) { return listTexture_[index]; }
-	ref_count_ptr<StgItemRenderer>::unsync GetRenderer(int index, int typeRender) { return listRenderer_[typeRender][index]; }
+	ref_count_ptr<StgItemRenderer>::unsync GetRenderer(int index, int typeRender) const { return listRenderer_[typeRender][index]; }
 	std::vector<ref_count_ptr<StgItemRenderer>::unsync>* GetRendererList(int typeRender) { return &listRenderer_[typeRender]; }
 
-	ref_count_ptr<StgItemData>::unsync GetData(int id) { return (id >= 0 && id < listData_.size()) ? listData_[id] : NULL; }
+	ref_count_ptr<StgItemData>::unsync GetData(int id) const { return (id >= 0 && id < listData_.size()) ? listData_[id] : NULL; }
 
-	bool AddItemDataList(std::wstring path, bool bReload);
+	bool AddItemDataList(const std::wstring& path, bool bReload);
 
 private:
 	void _ScanItem(std::vector<ref_count_ptr<StgItemData>::unsync>& listData, Scanner& scanner);
@@ -102,12 +102,12 @@ public:
 	StgItemData(StgItemDataList* listItemData);
 	virtual ~StgItemData();
 
-	int GetTextureIndex() { return indexTexture_; }
-	int GetItemType() { return typeItem_; }
-	int GetRenderType() { return typeRender_; }
+	int GetTextureIndex() const { return indexTexture_; }
+	int GetItemType() const { return typeItem_; }
+	int GetRenderType() const { return typeRender_; }
 	RECT GetRect(int frame);
-	RECT GetOut() { return rcOut_; }
-	int GetAlpha() { return alpha_; }
+	RECT GetOut() const { return rcOut_; }
+	int GetAlpha() const { return alpha_; }
 
 	ref_count_ptr<Texture> GetTexture();
 	StgItemRenderer* GetRenderer();
@@ -133,10 +133,10 @@ private:
 class StgItemRenderer : public RenderObjectTLX {
 public:
 	StgItemRenderer();
-	virtual int GetVertexCount();
+	virtual int GetVertexCount() const;
 	virtual void Render();
-	void AddVertex(VERTEX_TLX& vertex);
-	void AddSquareVertex(VERTEX_TLX* listVertex);
+	void AddVertex(const VERTEX_TLX& vertex);
+	void AddSquareVertex(const VERTEX_TLX* listVertex);
 
 private:
 	int countRenderVertex_;
@@ -187,26 +187,26 @@ public:
 	virtual void SetAlpha(int alpha);
 	void SetToPosition(POINT pos);
 
-	_int64 GetScore() { return score_; }
+	_int64 GetScore() const { return score_; }
 	void SetScore(_int64 score) { score_ = score; }
-	bool IsMoveToPlayer() { return bMoveToPlayer_; }
+	bool IsMoveToPlayer() const { return bMoveToPlayer_; }
 	void SetMoveToPlayer(bool b) { bMoveToPlayer_ = b; }
-	bool IsPermitMoveToPlayer() { return bPermitMoveToPlayer_; }
+	bool IsPermitMoveToPlayer() const { return bPermitMoveToPlayer_; }
 	void SetPermitMoveToPlayer(bool bPermit) { bPermitMoveToPlayer_ = bPermit; }
 	void SetChangeItemScore(bool b) { bChangeItemScore_ = b; }
 
 	int GetMoveType();
 	void SetMoveType(int type);
 
-	int GetItemType() { return typeItem_; }
+	int GetItemType() const { return typeItem_; }
 	void SetItemType(int type) { typeItem_ = type; }
 	StgStageController* GetStageController() { return stageController_; }
 
 protected:
 	void _DeleteInAutoClip();
 	void _CreateScoreItem();
-	void _NotifyEventToPlayerScript(std::vector<long double>& listValue);
-	void _NotifyEventToItemScript(std::vector<long double>& listValue);
+	void _NotifyEventToPlayerScript(const std::vector<long double>& listValue);
+	void _NotifyEventToItemScript(const std::vector<long double>& listValue);
 
 	StgStageController* stageController_;
 	int typeItem_;
@@ -295,11 +295,11 @@ public:
 	StgMovePattern_Item(StgMoveObject* target);
 	virtual void Move();
 	int GetType() { return TYPE_OTHER; }
-	virtual double GetSpeed() { return 0; }
-	virtual double GetDirectionAngle() { return 0; }
+	virtual double GetSpeed() const { return 0; }
+	virtual double GetDirectionAngle() const { return 0; }
 	void SetToPosition(POINT pos) { posTo_ = pos; }
 
-	int GetItemMoveType() { return typeMove_; }
+	int GetItemMoveType() const { return typeMove_; }
 	void SetItemMoveType(int type) { typeMove_ = type; }
 
 protected:

--- a/source/TouhouDanmakufu/Common/StgItem.hpp
+++ b/source/TouhouDanmakufu/Common/StgItem.hpp
@@ -73,7 +73,7 @@ public:
 	ref_count_ptr<StgItemRenderer>::unsync GetRenderer(int index, int typeRender) const { return listRenderer_[typeRender][index]; }
 	std::vector<ref_count_ptr<StgItemRenderer>::unsync>* GetRendererList(int typeRender) { return &listRenderer_[typeRender]; }
 
-	ref_count_ptr<StgItemData>::unsync GetData(int id) const { return (id >= 0 && id < listData_.size()) ? listData_[id] : NULL; }
+	ref_count_ptr<StgItemData>::unsync GetData(int id) const { return (id >= 0 && id < listData_.size()) ? listData_[id] : nullptr; }
 
 	bool AddItemDataList(const std::wstring& path, bool bReload);
 
@@ -133,8 +133,8 @@ private:
 class StgItemRenderer : public RenderObjectTLX {
 public:
 	StgItemRenderer();
-	virtual int GetVertexCount() const;
-	virtual void Render();
+	int GetVertexCount() const override;
+	void Render() override;
 	void AddVertex(const VERTEX_TLX& vertex);
 	void AddSquareVertex(const VERTEX_TLX* listVertex);
 
@@ -165,30 +165,30 @@ public:
 
 public:
 	StgItemObject(StgStageController* stageController);
-	virtual void Work();
-	virtual void Render() {} //一括で描画するためオブジェクト管理での描画はしない
+	void Work() override;
+	void Render() override {} //一括で描画するためオブジェクト管理での描画はしない
 	virtual void RenderOnItemManager(D3DXMATRIX mat);
-	virtual void SetRenderState() {}
+	void SetRenderState() override {}
 	virtual void Activate() {}
 
-	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) = 0;
+	void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) override = 0;
 
-	virtual void SetX(double x)
+	void SetX(double x) override
 	{
 		posX_ = x;
 		DxScriptRenderObject::SetX(x);
 	}
-	virtual void SetY(double y)
+	void SetY(double y) override
 	{
 		posY_ = y;
 		DxScriptRenderObject::SetY(y);
 	}
-	virtual void SetColor(int r, int g, int b);
-	virtual void SetAlpha(int alpha);
+	void SetColor(int r, int g, int b) override;
+	void SetAlpha(int alpha) override;
 	void SetToPosition(POINT pos);
 
-	_int64 GetScore() const { return score_; }
-	void SetScore(_int64 score) { score_ = score; }
+	int64_t GetScore() const { return score_; }
+	void SetScore(int64_t score) { score_ = score; }
 	bool IsMoveToPlayer() const { return bMoveToPlayer_; }
 	void SetMoveToPlayer(bool b) { bMoveToPlayer_ = b; }
 	bool IsPermitMoveToPlayer() const { return bPermitMoveToPlayer_; }
@@ -212,7 +212,7 @@ protected:
 	int typeItem_;
 	D3DCOLOR color_;
 
-	_int64 score_;
+	int64_t score_;
 	bool bMoveToPlayer_; //自機移動フラグ
 	bool bPermitMoveToPlayer_; //自機自動回収許可
 	bool bChangeItemScore_;
@@ -221,39 +221,39 @@ protected:
 class StgItemObject_1UP : public StgItemObject {
 public:
 	StgItemObject_1UP(StgStageController* stageController);
-	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) override;
 };
 
 class StgItemObject_Bomb : public StgItemObject {
 public:
 	StgItemObject_Bomb(StgStageController* stageController);
-	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) override;
 };
 
 class StgItemObject_Power : public StgItemObject {
 public:
 	StgItemObject_Power(StgStageController* stageController);
-	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) override;
 };
 
 class StgItemObject_Point : public StgItemObject {
 public:
 	StgItemObject_Point(StgStageController* stageController);
-	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) override;
 };
 
 class StgItemObject_Bonus : public StgItemObject {
 public:
 	StgItemObject_Bonus(StgStageController* stageController);
-	virtual void Work();
-	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	void Work() override;
+	void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) override;
 };
 
 class StgItemObject_Score : public StgItemObject {
 public:
 	StgItemObject_Score(StgStageController* stageController);
-	virtual void Work();
-	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	void Work() override;
+	void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) override;
 
 private:
 	int frameDelete_;
@@ -262,15 +262,15 @@ private:
 class StgItemObject_User : public StgItemObject {
 public:
 	StgItemObject_User(StgStageController* stageController);
-	virtual void Work();
-	virtual void RenderOnItemManager(D3DXMATRIX mat);
-	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	void Work() override;
+	void RenderOnItemManager(D3DXMATRIX mat) override;
+	void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) override;
 
 	void SetImageID(int id);
 
 private:
 	StgItemData* _GetItemData();
-	void _SetVertexPosition(VERTEX_TLX& vertex, float x, float y, float z = 1.0f, float w = 1.0f);
+	void _SetVertexPosition(VERTEX_TLX& vertex, float x, float y, float z = 1.0F, float w = 1.0F);
 	void _SetVertexUV(VERTEX_TLX& vertex, float u, float v);
 	void _SetVertexColorARGB(VERTEX_TLX& vertex, D3DCOLOR color);
 
@@ -293,10 +293,10 @@ public:
 
 public:
 	StgMovePattern_Item(StgMoveObject* target);
-	virtual void Move();
+	void Move() override;
 	int GetType() { return TYPE_OTHER; }
-	virtual double GetSpeed() const { return 0; }
-	virtual double GetDirectionAngle() const { return 0; }
+	double GetSpeed() const override { return 0; }
+	double GetDirectionAngle() const override { return 0; }
 	void SetToPosition(POINT pos) { posTo_ = pos; }
 
 	int GetItemMoveType() const { return typeMove_; }

--- a/source/TouhouDanmakufu/Common/StgPackageController.cpp
+++ b/source/TouhouDanmakufu/Common/StgPackageController.cpp
@@ -8,9 +8,7 @@ StgPackageController::StgPackageController(StgSystemController* systemController
 {
 	systemController_ = systemController;
 }
-StgPackageController::~StgPackageController()
-{
-}
+StgPackageController::~StgPackageController() = default;
 void StgPackageController::Initialize()
 {
 	infoPackage_ = new StgPackageInformation();
@@ -23,7 +21,7 @@ void StgPackageController::Initialize()
 	//メインスクリプト
 	std::wstring pathMainScript = infoScript->GetScriptPath();
 	ELogger::WriteTop(StringUtility::Format(L"パッケージスクリプト[%s]", pathMainScript.c_str()));
-	_int64 idScript = scriptManager_->LoadScript(pathMainScript, StgPackageScript::TYPE_PACKAGE_MAIN);
+	int64_t idScript = scriptManager_->LoadScript(pathMainScript, StgPackageScript::TYPE_PACKAGE_MAIN);
 	scriptManager_->StartScript(idScript);
 
 	infoPackage_->SetPackageStartTime(timeGetTime());
@@ -32,7 +30,7 @@ void StgPackageController::Work()
 {
 	scriptManager_->Work();
 	//スクリプトが閉じられた場合は再度実行(描画の継ぎ目を目立たなくする)
-	if (scriptManager_->IsHasCloseScliptWork())
+	if (scriptManager_->IsHasCloseScriptWork())
 		scriptManager_->Work();
 }
 void StgPackageController::Render()
@@ -51,7 +49,7 @@ void StgPackageController::RenderToTransitionTexture()
 	scriptManager_->Render();
 
 	graphics->EndScene();
-	graphics->SetRenderTarget(NULL);
+	graphics->SetRenderTarget(nullptr);
 }
 
 /**********************************************************
@@ -62,12 +60,10 @@ StgPackageInformation::StgPackageInformation()
 	bEndPackage_ = false;
 	timeStart_ = 0;
 }
-StgPackageInformation::~StgPackageInformation()
-{
-}
+StgPackageInformation::~StgPackageInformation() = default;
 void StgPackageInformation::InitializeStageData()
 {
-	infoReplay_ = NULL;
+	infoReplay_ = nullptr;
 	listStageData_.clear();
 
 	nextStageStartData_ = new StgStageStartData();

--- a/source/TouhouDanmakufu/Common/StgPackageController.hpp
+++ b/source/TouhouDanmakufu/Common/StgPackageController.hpp
@@ -38,7 +38,7 @@ public:
 	StgPackageInformation();
 	virtual ~StgPackageInformation();
 
-	bool IsEnd() { return bEndPackage_; }
+	bool IsEnd() const { return bEndPackage_; }
 	void SetEnd() { bEndPackage_ = true; }
 
 	void InitializeStageData();
@@ -53,7 +53,7 @@ public:
 	ref_count_ptr<ScriptInformation> GetMainScriptInformation() { return infoMainScript_; }
 	void SetMainScriptInformation(ref_count_ptr<ScriptInformation> info) { infoMainScript_ = info; }
 
-	int GetPackageStartTime() { return timeStart_; }
+	int GetPackageStartTime() const { return timeStart_; }
 	void SetPackageStartTime(int time) { timeStart_ = time; }
 
 private:

--- a/source/TouhouDanmakufu/Common/StgPackageScript.cpp
+++ b/source/TouhouDanmakufu/Common/StgPackageScript.cpp
@@ -10,9 +10,7 @@ StgPackageScriptManager::StgPackageScriptManager(StgSystemController* controller
 	systemController_ = controller;
 	objectManager_ = new DxScriptObjectManager();
 }
-StgPackageScriptManager::~StgPackageScriptManager()
-{
-}
+StgPackageScriptManager::~StgPackageScriptManager() = default;
 void StgPackageScriptManager::Work()
 {
 	if (!IsError()) {
@@ -35,7 +33,7 @@ ref_count_ptr<ManagedScript> StgPackageScriptManager::Create(int type)
 		break;
 	}
 
-	if (res != NULL) {
+	if (res != nullptr) {
 		res->SetObjectManager(objectManager_);
 		res->SetScriptManager(this);
 	}
@@ -83,14 +81,14 @@ void StgPackageScript::_CheckNextStageExists()
 {
 	ref_count_ptr<StgPackageInformation> infoPackage = packageController_->GetPackageInformation();
 	ref_count_ptr<StgStageStartData> nextStageData = infoPackage->GetNextStageData();
-	if (nextStageData == NULL)
+	if (nextStageData == nullptr)
 		RaiseError(L"not initialized stage data");
 }
 
 //パッケージ共通関数：パッケージ操作
 gstd::value StgPackageScript::Func_ClosePackage(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgPackageScript* script = (StgPackageScript*)machine->data;
+	auto* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 
 	ref_count_ptr<StgPackageInformation> infoPackage = packageController->GetPackageInformation();
@@ -102,12 +100,12 @@ gstd::value StgPackageScript::Func_ClosePackage(gstd::script_machine* machine, i
 //パッケージ共通関数：ステージ操作
 gstd::value StgPackageScript::Func_InitializeStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgPackageScript* script = (StgPackageScript*)machine->data;
+	auto* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 
 	StgSystemController* systemController = packageController->GetSystemController();
 	ref_count_ptr<StgSystemInformation> infoSystem = systemController->GetSystemInformation();
-	infoSystem->SetActiveReplayInformation(NULL);
+	infoSystem->SetActiveReplayInformation(nullptr);
 
 	ref_count_ptr<StgPackageInformation> infoPackage = packageController->GetPackageInformation();
 	infoPackage->InitializeStageData();
@@ -116,17 +114,17 @@ gstd::value StgPackageScript::Func_InitializeStageScene(gstd::script_machine* ma
 }
 gstd::value StgPackageScript::Func_FinalizeStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgPackageScript* script = (StgPackageScript*)machine->data;
+	auto* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 	StgSystemController* systemController = packageController->GetSystemController();
 	ref_count_ptr<StgSystemInformation> infoSystem = systemController->GetSystemInformation();
 
 	ref_count_ptr<StgPackageInformation> infoPackage = packageController->GetPackageInformation();
-	if (infoPackage->GetNextStageData() != NULL && infoPackage->GetNextStageData()->GetPrevStageInformation() == NULL)
+	if (infoPackage->GetNextStageData() != nullptr && infoPackage->GetNextStageData()->GetPrevStageInformation() == nullptr)
 		script->RaiseError(L"not finished stage");
 
 	std::vector<ref_count_ptr<StgStageStartData>> listStage = infoPackage->GetStageDataList();
-	if (listStage.size() > 0) {
+	if (!listStage.empty()) {
 		ref_count_ptr<StgStageStartData> stageData = listStage[listStage.size() - 1];
 		ref_count_ptr<StgStageInformation> infoStage = stageData->GetStageInformation();
 		bool bReplay = infoStage->IsReplay();
@@ -141,7 +139,7 @@ gstd::value StgPackageScript::Func_FinalizeStageScene(gstd::script_machine* mach
 }
 gstd::value StgPackageScript::Func_StartStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgPackageScript* script = (StgPackageScript*)machine->data;
+	auto* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 	script->_CheckNextStageExists();
 
@@ -155,9 +153,9 @@ gstd::value StgPackageScript::Func_StartStageScene(gstd::script_machine* machine
 	ref_count_ptr<ReplayInformation> infoReplay = infoPackage->GetReplayInformation();
 	std::wstring replayPlayerID;
 	std::wstring replayPlayerScriptFileName;
-	if (infoReplay != NULL) {
+	if (infoReplay != nullptr) {
 		ref_count_ptr<ReplayInformation::StageData> replayStageData = infoReplay->GetStageData(stageIndex);
-		if (replayStageData == NULL)
+		if (replayStageData == nullptr)
 			script->RaiseError(L"invalid replay stage index");
 		nextStageData->SetStageReplayData(replayStageData);
 
@@ -166,26 +164,25 @@ gstd::value StgPackageScript::Func_StartStageScene(gstd::script_machine* machine
 		replayPlayerScriptFileName = replayStageData->GetPlayerScriptFileName();
 	} else {
 		ref_count_ptr<ScriptInformation> infoPlayer = infoStage->GetPlayerScriptInformation();
-		if (infoPlayer != NULL) {
+		if (infoPlayer != nullptr) {
 			replayPlayerID = infoPlayer->GetID();
 			replayPlayerScriptFileName = PathProperty::GetFileName(infoPlayer->GetScriptPath());
 		}
 	}
 
 	//自機を検索
-	infoStage->SetPlayerScriptInformation(NULL);
+	infoStage->SetPlayerScriptInformation(nullptr);
 	ref_count_ptr<ScriptInformation> infoMain = infoSystem->GetMainScriptInformation();
 	std::vector<ref_count_ptr<ScriptInformation>> listPlayer;
 	std::vector<std::wstring> listPlayerPath = infoMain->GetPlayerList();
-	if (listPlayerPath.size() == 0) {
+	if (listPlayerPath.empty()) {
 		std::wstring dir = EPathProperty::GetPlayerScriptRootDirectory();
 		listPlayer = ScriptInformation::FindPlayerScriptInformationList(dir);
 	} else {
 		listPlayer = infoMain->CreatePlayerScriptInformationList();
 	}
 
-	for (int iPlayer = 0; iPlayer < listPlayer.size(); iPlayer++) {
-		ref_count_ptr<ScriptInformation> tInfo = listPlayer[iPlayer];
+	for (auto& tInfo : listPlayer) {
 		if (tInfo->GetID() != replayPlayerID)
 			continue;
 		std::wstring tPlayerScriptFileName = PathProperty::GetFileName(tInfo->GetScriptPath());
@@ -196,7 +193,7 @@ gstd::value StgPackageScript::Func_StartStageScene(gstd::script_machine* machine
 		break;
 	}
 
-	if (infoStage->GetPlayerScriptInformation() == NULL)
+	if (infoStage->GetPlayerScriptInformation() == nullptr)
 		script->RaiseError(L"player not found");
 
 	//packageController->RenderToTransitionTexture();
@@ -207,7 +204,7 @@ gstd::value StgPackageScript::Func_StartStageScene(gstd::script_machine* machine
 }
 gstd::value StgPackageScript::Func_SetStageIndex(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgPackageScript* script = (StgPackageScript*)machine->data;
+	auto* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 	script->_CheckNextStageExists();
 
@@ -217,8 +214,7 @@ gstd::value StgPackageScript::Func_SetStageIndex(gstd::script_machine* machine, 
 
 	int stageIndex = (int)argv[0].as_real();
 	std::vector<ref_count_ptr<StgStageStartData>> listStage = infoPackage->GetStageDataList();
-	for (int iStage = 0; iStage < listStage.size(); iStage++) {
-		ref_count_ptr<StgStageStartData> stageData = listStage[iStage];
+	for (auto& stageData : listStage) {
 		if (stageIndex == stageData->GetStageInformation()->GetStageIndex())
 			script->RaiseError(L"stage index already used");
 	}
@@ -229,7 +225,7 @@ gstd::value StgPackageScript::Func_SetStageIndex(gstd::script_machine* machine, 
 }
 gstd::value StgPackageScript::Func_SetStageMainScript(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgPackageScript* script = (StgPackageScript*)machine->data;
+	auto* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 	script->_CheckNextStageExists();
 
@@ -239,18 +235,18 @@ gstd::value StgPackageScript::Func_SetStageMainScript(gstd::script_machine* mach
 
 	std::wstring path = argv[0].as_string();
 	ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-	if (reader == NULL || !reader->Open()) {
+	if (reader == nullptr || !reader->Open()) {
 		std::wstring error = ErrorUtility::GetFileNotFoundErrorMessage(path);
 		script->RaiseError(error);
 	}
 
-	std::string source = "";
+	std::string source;
 	int size = reader->GetFileSize();
 	source.resize(size);
 	reader->Read(&source[0], size);
 
 	ref_count_ptr<ScriptInformation> infoScript = ScriptInformation::CreateScriptInformation(path, L"", source, false);
-	if (infoScript == NULL)
+	if (infoScript == nullptr)
 		script->RaiseError(ErrorUtility::GetFileNotFoundErrorMessage(path));
 
 	infoStage->SetMainScriptInformation(infoScript);
@@ -259,7 +255,7 @@ gstd::value StgPackageScript::Func_SetStageMainScript(gstd::script_machine* mach
 }
 gstd::value StgPackageScript::Func_SetStagePlayerScript(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgPackageScript* script = (StgPackageScript*)machine->data;
+	auto* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 	script->_CheckNextStageExists();
 
@@ -269,12 +265,12 @@ gstd::value StgPackageScript::Func_SetStagePlayerScript(gstd::script_machine* ma
 
 	std::wstring path = argv[0].as_string();
 	ref_count_ptr<FileReader> reader = FileManager::GetBase()->GetFileReader(path);
-	if (reader == NULL || !reader->Open()) {
+	if (reader == nullptr || !reader->Open()) {
 		std::wstring error = ErrorUtility::GetFileNotFoundErrorMessage(path);
 		script->RaiseError(error);
 	}
 
-	std::string source = "";
+	std::string source;
 	int size = reader->GetFileSize();
 	source.resize(size);
 	reader->Read(&source[0], size);
@@ -286,7 +282,7 @@ gstd::value StgPackageScript::Func_SetStagePlayerScript(gstd::script_machine* ma
 }
 gstd::value StgPackageScript::Func_SetStageReplayFile(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgPackageScript* script = (StgPackageScript*)machine->data;
+	auto* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 	script->_CheckNextStageExists();
 
@@ -294,7 +290,7 @@ gstd::value StgPackageScript::Func_SetStageReplayFile(gstd::script_machine* mach
 
 	std::wstring pathReplay = argv[0].as_string();
 	ref_count_ptr<ReplayInformation> infoRepray = ReplayInformation::CreateFromFile(pathReplay);
-	if (infoRepray == NULL) {
+	if (infoRepray == nullptr) {
 		std::wstring path = ErrorUtility::GetFileNotFoundErrorMessage(pathReplay);
 		script->RaiseError(path);
 	}
@@ -303,7 +299,7 @@ gstd::value StgPackageScript::Func_SetStageReplayFile(gstd::script_machine* mach
 }
 gstd::value StgPackageScript::Func_GetStageSceneState(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgPackageScript* script = (StgPackageScript*)machine->data;
+	auto* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 	StgSystemController* systemController = packageController->GetSystemController();
 	ref_count_ptr<StgSystemInformation> infoSystem = systemController->GetSystemInformation();
@@ -317,14 +313,14 @@ gstd::value StgPackageScript::Func_GetStageSceneState(gstd::script_machine* mach
 }
 gstd::value StgPackageScript::Func_GetStageSceneResult(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgPackageScript* script = (StgPackageScript*)machine->data;
+	auto* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 	script->_CheckNextStageExists();
 
 	int res = StgStageInformation::RESULT_UNKNOWN;
 	ref_count_ptr<StgPackageInformation> infoPackage = packageController->GetPackageInformation();
 	std::vector<ref_count_ptr<StgStageStartData>> listStage = infoPackage->GetStageDataList();
-	if (listStage.size() > 0) {
+	if (!listStage.empty()) {
 		ref_count_ptr<StgStageStartData> stageData = listStage[listStage.size() - 1];
 		ref_count_ptr<StgStageInformation> infoStage = stageData->GetStageInformation();
 		res = infoStage->GetResult();
@@ -334,11 +330,11 @@ gstd::value StgPackageScript::Func_GetStageSceneResult(gstd::script_machine* mac
 }
 gstd::value StgPackageScript::Func_PauseStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgPackageScript* script = (StgPackageScript*)machine->data;
+	auto* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 	StgSystemController* systemController = packageController->GetSystemController();
 	StgStageController* stageController = systemController->GetStageController();
-	if (stageController == NULL)
+	if (stageController == nullptr)
 		return gstd::value();
 
 	bool bPause = argv[0].as_boolean();
@@ -356,11 +352,11 @@ gstd::value StgPackageScript::Func_PauseStageScene(gstd::script_machine* machine
 }
 gstd::value StgPackageScript::Func_TerminateStageScene(gstd::script_machine* machine, int argc, gstd::value const* argv)
 {
-	StgPackageScript* script = (StgPackageScript*)machine->data;
+	auto* script = (StgPackageScript*)machine->data;
 	StgPackageController* packageController = script->packageController_;
 	StgSystemController* systemController = packageController->GetSystemController();
 	StgStageController* stageController = systemController->GetStageController();
-	if (stageController == NULL)
+	if (stageController == nullptr)
 		return gstd::value();
 
 	ref_count_ptr<StgStageInformation> infoStage = stageController->GetStageInformation();

--- a/source/TouhouDanmakufu/Common/StgPackageScript.hpp
+++ b/source/TouhouDanmakufu/Common/StgPackageScript.hpp
@@ -12,10 +12,10 @@ class StgPackageScript;
 class StgPackageScriptManager : public StgControlScriptManager {
 public:
 	StgPackageScriptManager(StgSystemController* controller);
-	virtual ~StgPackageScriptManager();
-	virtual void Work();
-	virtual void Render();
-	virtual ref_count_ptr<ManagedScript> Create(int type);
+	~StgPackageScriptManager() override;
+	void Work() override;
+	void Render() override;
+	ref_count_ptr<ManagedScript> Create(int type) override;
 
 	ref_count_ptr<DxScriptObjectManager> GetObjectManager() { return objectManager_; }
 

--- a/source/TouhouDanmakufu/Common/StgPlayer.cpp
+++ b/source/TouhouDanmakufu/Common/StgPlayer.cpp
@@ -298,7 +298,7 @@ ref_count_ptr<StgPlayerObject>::unsync StgPlayerObject::GetOwnObject()
 {
 	return ref_count_ptr<StgPlayerObject>::unsync::DownCast(stageController_->GetMainRenderObject(idObject_));
 }
-bool StgPlayerObject::IsPermitShot()
+bool StgPlayerObject::IsPermitShot() const
 {
 	//以下のとき不可
 	//・会話中

--- a/source/TouhouDanmakufu/Common/StgPlayer.cpp
+++ b/source/TouhouDanmakufu/Common/StgPlayer.cpp
@@ -40,9 +40,7 @@ StgPlayerObject::StgPlayerObject(StgStageController* stageController)
 
 	_InitializeRebirth();
 }
-StgPlayerObject::~StgPlayerObject()
-{
-}
+StgPlayerObject::~StgPlayerObject() = default;
 void StgPlayerObject::_InitializeRebirth()
 {
 	RECT rcStgFrame = stageController_->GetStageInformation()->GetStgFrameRect();
@@ -72,13 +70,13 @@ void StgPlayerObject::Work()
 			listScriptValue.push_back(valueHitObjectID);
 			script_->RequestEvent(StgStagePlayerScript::EV_HIT, listScriptValue);
 		} else {
-			if (listGrazedShot_.size() > 0) {
+			if (!listGrazedShot_.empty()) {
 				std::vector<value> listValPos;
 				std::vector<long double> listShotID;
 				int grazedShotCount = listGrazedShot_.size();
 				for (int iObj = 0; iObj < grazedShotCount; iObj++) {
 					ref_count_weak_ptr<StgShotObject>::unsync objShot = ref_count_weak_ptr<StgShotObject>::unsync::DownCast(listGrazedShot_[iObj]);
-					if (objShot != NULL) {
+					if (objShot != nullptr) {
 						int id = objShot->GetObjectID();
 						listShotID.push_back(id);
 
@@ -97,7 +95,7 @@ void StgPlayerObject::Work()
 
 				ref_count_ptr<StgStageScriptManager> stageScriptManager = stageController_->GetScriptManagerR();
 				ref_count_ptr<ManagedScript> itemScript = stageScriptManager->GetItemScript();
-				if (itemScript != NULL) {
+				if (itemScript != nullptr) {
 					itemScript->RequestEvent(StgStagePlayerScript::EV_GRAZE, listScriptValue);
 				}
 			}
@@ -120,7 +118,7 @@ void StgPlayerObject::Work()
 				//自機ダウン
 				bool bEnemyLastSpell = false;
 				ref_count_ptr<StgEnemyBossSceneObject>::unsync objBossScene = enemyManager->GetBossSceneObject();
-				if (objBossScene != NULL) {
+				if (objBossScene != nullptr) {
 					objBossScene->AddPlayerShootDownCount();
 					if (objBossScene->GetActiveData()->IsLastSpell())
 						bEnemyLastSpell = true;
@@ -225,7 +223,7 @@ bool StgPlayerObject::_IsValidSpell()
 {
 	bool res = true;
 	res &= (state_ == STATE_NORMAL || (state_ == STATE_HIT && frameState_ > 0));
-	res &= (objSpell_ == NULL || objSpell_->IsDeleted());
+	res &= (objSpell_ == nullptr || objSpell_->IsDeleted());
 	return res;
 }
 void StgPlayerObject::CallSpell()
@@ -244,7 +242,7 @@ void StgPlayerObject::CallSpell()
 		throw gstd::wexception(L"@Event(EV_REQUEST_SPELL)内でboolean型の値が返されていません。");
 	bool bUse = vUse.as_boolean();
 	if (!bUse) {
-		objSpell_ = NULL;
+		objSpell_ = nullptr;
 		objectManager->DeleteObject(idSpell);
 		return;
 	}
@@ -256,7 +254,7 @@ void StgPlayerObject::CallSpell()
 
 	StgEnemyManager* enemyManager = stageController_->GetEnemyManager();
 	ref_count_ptr<StgEnemyBossSceneObject>::unsync objBossScene = enemyManager->GetBossSceneObject();
-	if (objBossScene != NULL) {
+	if (objBossScene != nullptr) {
 		objBossScene->AddPlayerSpellCount();
 	}
 
@@ -266,20 +264,20 @@ void StgPlayerObject::CallSpell()
 
 void StgPlayerObject::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget)
 {
-	StgIntersectionTarget_Player* own = (StgIntersectionTarget_Player*)ownTarget.GetPointer();
+	auto* own = (StgIntersectionTarget_Player*)ownTarget.GetPointer();
 	int otherType = otherTarget->GetTargetType();
 	switch (otherType) {
 	case StgIntersectionTarget::TYPE_ENEMY_SHOT: {
 		//敵弾
 		if (own->IsGraze()) {
 			StgShotObject* objShot = (StgShotObject*)otherTarget->GetObject().GetPointer();
-			if (objShot != NULL && objShot->IsValidGraze()) {
+			if (objShot != nullptr && objShot->IsValidGraze()) {
 				listGrazedShot_.push_back(otherTarget->GetObject());
 				stageController_->GetStageInformation()->AddGraze(1);
 			}
 		} else {
 			ref_count_weak_ptr<StgShotObject>::unsync objShot = ref_count_weak_ptr<StgShotObject>::unsync::DownCast(otherTarget->GetObject());
-			if (objShot != NULL)
+			if (objShot != nullptr)
 				hitObjectID_ = objShot->GetObjectID();
 		}
 	} break;
@@ -288,7 +286,7 @@ void StgPlayerObject::Intersect(ref_count_ptr<StgIntersectionTarget>::unsync own
 		//敵
 		if (!own->IsGraze()) {
 			ref_count_weak_ptr<StgEnemyObject>::unsync objEnemy = ref_count_weak_ptr<StgEnemyObject>::unsync::DownCast(otherTarget->GetObject());
-			if (objEnemy != NULL)
+			if (objEnemy != nullptr)
 				hitObjectID_ = objEnemy->GetObjectID();
 		}
 	} break;
@@ -312,9 +310,9 @@ bool StgPlayerObject::IsPermitSpell()
 	StgEnemyManager* enemyManager = stageController_->GetEnemyManager();
 	bool bEnemyLastSpell = false;
 	ref_count_ptr<StgEnemyBossSceneObject>::unsync objBossScene = enemyManager->GetBossSceneObject();
-	if (objBossScene != NULL) {
+	if (objBossScene != nullptr) {
 		ref_count_ptr<StgEnemyBossSceneData>::unsync data = objBossScene->GetActiveData();
-		if (data != NULL && data->IsLastSpell())
+		if (data != nullptr && data->IsLastSpell())
 			bEnemyLastSpell = true;
 	}
 

--- a/source/TouhouDanmakufu/Common/StgPlayer.hpp
+++ b/source/TouhouDanmakufu/Common/StgPlayer.hpp
@@ -19,14 +19,14 @@ public:
 	StgPlayerInformation() {}
 	virtual ~StgPlayerInformation() {}
 
-	double GetLife() { return life_; }
+	double GetLife() const { return life_; }
 	void SetLife(double life) { life_ = life; }
-	double GetSpell() { return countBomb_; }
+	double GetSpell() const { return countBomb_; }
 	void SetSpell(double spell) { countBomb_ = spell; }
-	double GetPower() { return power_; }
+	double GetPower() const { return power_; }
 	void SetPower(double power) { power_ = power; }
 
-	int GetRebirthFrame() { return frameRebirth_; }
+	int GetRebirthFrame() const { return frameRebirth_; }
 	void SetRebirthFrame(int frame) { frameRebirth_ = frame; }
 
 private:
@@ -73,24 +73,24 @@ public:
 
 	StgStagePlayerScript* GetPlayerScript() { return script_; }
 	ref_count_ptr<StgPlayerObject>::unsync GetOwnObject();
-	double GetX() { return posX_; }
-	double GetY() { return posY_; }
-	double GetFastSpeed() { return speedFast_; }
+	double GetX() const { return posX_; }
+	double GetY() const { return posY_; }
+	double GetFastSpeed() const { return speedFast_; }
 	void SetFastSpeed(double speed) { speedFast_ = speed; }
-	double GetSlowSpeed() { return speedSlow_; }
+	double GetSlowSpeed() const { return speedSlow_; }
 	void SetSlowSpeed(double speed) { speedSlow_ = speed; }
 
-	RECT GetClip() { return rcClip_; }
+	RECT GetClip() const { return rcClip_; }
 	void SetClip(RECT rect) { rcClip_ = rect; }
 
-	int GetState() { return state_; }
-	int GetDownStateFrame() { return frameStateDown_; }
+	int GetState() const { return state_; }
+	int GetDownStateFrame() const { return frameStateDown_; }
 	void SetDownStateFrame(int frame) { frameStateDown_ = frame; }
 	int GetRebirthFrame() { return infoPlayer_->GetRebirthFrame(); }
 	void SetRebirthFrameMax(int frame) { frameRebirthMax_ = frame; }
 	void SetRebirthFrame(int frame) { infoPlayer_->SetRebirthFrame(frame); }
 	void SetRebirthLossFrame(int frame) { frameRebirthDiff_ = frame; }
-	double GetItemIntersectionRadius() { return itemCircle_; }
+	double GetItemIntersectionRadius() const { return itemCircle_; }
 	void SetItemIntersectionRadius(double r) { itemCircle_ = r; }
 	double GetLife() { return infoPlayer_->GetLife(); }
 	void SetLife(double life) { infoPlayer_->SetLife(life); }
@@ -98,12 +98,12 @@ public:
 	void SetSpell(double spell) { infoPlayer_->SetSpell(spell); }
 	double GetPower() { return infoPlayer_->GetPower(); }
 	void SetPower(double power) { infoPlayer_->SetPower(power); }
-	int GetInvincibilityFrame() { return frameInvincibility_; }
+	int GetInvincibilityFrame() const { return frameInvincibility_; }
 	void SetInvincibilityFrame(int frame) { frameInvincibility_ = frame; }
-	int GetAutoItemCollectY() { return yAutoItemCollect_; }
+	int GetAutoItemCollectY() const { return yAutoItemCollect_; }
 	void SetAutoItemCollectY(int y) { yAutoItemCollect_ = y; }
 
-	bool IsPermitShot();
+	bool IsPermitShot() const;
 	void SetForbidShot(bool bForbid) { bForbidShot_ = bForbid; }
 	bool IsPermitSpell();
 	void SetForbidSpell(bool bForbid) { bForbidSpell_ = bForbid; }
@@ -147,7 +147,7 @@ public:
 		typeTarget_ = TYPE_PLAYER;
 		bGraze_ = bGraze;
 	}
-	bool IsGraze() { return bGraze_; }
+	bool IsGraze() const { return bGraze_; }
 
 private:
 	bool bGraze_;
@@ -172,11 +172,11 @@ public:
 	virtual void Work();
 	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
 
-	double GetDamage() { return damage_; }
+	double GetDamage() const { return damage_; }
 	void SetDamage(double damage) { damage_ = damage; }
-	bool IsEraseShot() { return bEraseShot_; }
+	bool IsEraseShot() const { return bEraseShot_; }
 	void SetEraseShot(bool b) { bEraseShot_ = b; }
-	double GetLife() { return life_; }
+	double GetLife() const { return life_; }
 	void SetLife(double life) { life_ = life; }
 
 protected:

--- a/source/TouhouDanmakufu/Common/StgPlayer.hpp
+++ b/source/TouhouDanmakufu/Common/StgPlayer.hpp
@@ -16,8 +16,8 @@ class StgPlayerInformation {
 	friend StgPlayerObject;
 
 public:
-	StgPlayerInformation() {}
-	virtual ~StgPlayerInformation() {}
+	StgPlayerInformation() = default;
+	virtual ~StgPlayerInformation() = default;
 
 	double GetLife() const { return life_; }
 	void SetLife(double life) { life_ = life; }
@@ -47,21 +47,21 @@ public:
 
 public:
 	StgPlayerObject(StgStageController* stageController);
-	virtual ~StgPlayerObject();
+	~StgPlayerObject() override;
 	void Clear() { ClearIntersectionRelativeTarget(); }
 	void SetScript(StgStagePlayerScript* script) { script_ = script; }
 
-	virtual void Work();
+	void Work() override;
 	void Move();
-	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) override;
 	void CallSpell();
 
-	virtual void SetX(double x)
+	void SetX(double x) override
 	{
 		posX_ = x;
 		DxScriptRenderObject::SetX(x);
 	}
-	virtual void SetY(double y)
+	void SetY(double y) override
 	{
 		posY_ = y;
 		DxScriptRenderObject::SetY(y);
@@ -111,7 +111,7 @@ public:
 
 protected:
 	void _InitializeRebirth();
-	void _Move();
+	void _Move() override;
 	void _AddIntersection();
 	bool _IsValidSpell();
 
@@ -159,8 +159,8 @@ private:
 class StgPlayerSpellManageObject : public DxScriptObjectBase {
 public:
 	StgPlayerSpellManageObject() { bVisible_ = false; }
-	virtual void Render() {}
-	virtual void SetRenderState() {}
+	void Render() override {}
+	void SetRenderState() override {}
 };
 
 /**********************************************************
@@ -169,8 +169,8 @@ public:
 class StgPlayerSpellObject : public DxScriptPrimitiveObject2D, public StgIntersectionObject {
 public:
 	StgPlayerSpellObject(StgStageController* stageController);
-	virtual void Work();
-	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	void Work() override;
+	void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) override;
 
 	double GetDamage() const { return damage_; }
 	void SetDamage(double damage) { damage_ = damage; }

--- a/source/TouhouDanmakufu/Common/StgShot.cpp
+++ b/source/TouhouDanmakufu/Common/StgShot.cpp
@@ -245,7 +245,7 @@ void StgShotManager::SetDeleteEventEnableByType(int type, bool bEnable)
 		listDeleteEventEnable_.reset(bit);
 	}
 }
-bool StgShotManager::IsDeleteEventEnable(int bit)
+bool StgShotManager::IsDeleteEventEnable(int bit) const
 {
 	bool res = listDeleteEventEnable_[bit];
 	return res;
@@ -632,7 +632,7 @@ StgShotRenderer::StgShotRenderer()
 	countRenderVertex_ = 0;
 	SetVertexCount(256 * 256);
 }
-int StgShotRenderer::GetVertexCount()
+int StgShotRenderer::GetVertexCount() const
 {
 	int res = countRenderVertex_;
 	res = min(countRenderVertex_, vertex_.GetSize() / strideVertexStreamZero_);
@@ -1169,11 +1169,10 @@ std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> StgNormalShotObject::G
 	return res;
 }
 
-void StgNormalShotObject::RenderOnShotManager(D3DXMATRIX& matO)
+void StgNormalShotObject::RenderOnShotManager(D3DXMATRIX mat)
 {
 	if (!IsVisible())
 		return;
-	D3DXMATRIX mat = matO;
 
 	StgShotData* shotData = _GetShotData();
 	if (shotData == NULL)
@@ -1591,11 +1590,10 @@ std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> StgLooseLaserObject::G
 	return res;
 }
 
-void StgLooseLaserObject::RenderOnShotManager(D3DXMATRIX& matO)
+void StgLooseLaserObject::RenderOnShotManager(D3DXMATRIX mat)
 {
 	if (!IsVisible())
 		return;
-	D3DXMATRIX mat = matO;
 
 	StgShotData* shotData = _GetShotData();
 	if (shotData == NULL)
@@ -1876,11 +1874,10 @@ void StgStraightLaserObject::_AddReservedShot(ref_count_ptr<StgShotObject>::unsy
 	obj->Activate();
 	objectManager->ActivateObject(obj->GetObjectID(), true);
 }
-void StgStraightLaserObject::RenderOnShotManager(D3DXMATRIX& matO)
+void StgStraightLaserObject::RenderOnShotManager(D3DXMATRIX mat)
 {
 	if (!IsVisible())
 		return;
-	D3DXMATRIX mat = matO;
 	StgShotData* shotData = _GetShotData();
 	if (shotData == NULL)
 		return;
@@ -2195,7 +2192,7 @@ double StgShotObject::cssn(double s, double ang)
 }
 
 //Extremely special thanks to Natashi for making this not awful
-void StgCurveLaserObject::RenderOnShotManager(D3DXMATRIX& mat)
+void StgCurveLaserObject::RenderOnShotManager(D3DXMATRIX mat)
 { //original: (D3DXMATRIX mat)
 	if (!IsVisible())
 		return;

--- a/source/TouhouDanmakufu/Common/StgShot.hpp
+++ b/source/TouhouDanmakufu/Common/StgShot.hpp
@@ -41,14 +41,14 @@ public:
 	StgShotDataList* GetPlayerShotDataList() { return listPlayerShotData_.GetPointer(); }
 	StgShotDataList* GetEnemyShotDataList() { return listEnemyShotData_.GetPointer(); }
 
-	bool LoadPlayerShotData(std::wstring path, bool bReload = false);
-	bool LoadEnemyShotData(std::wstring path, bool bReload = false);
+	bool LoadPlayerShotData(const std::wstring& path, bool bReload = false);
+	bool LoadEnemyShotData(const std::wstring& path, bool bReload = false);
 
 	RECT GetShotAutoDeleteClipRect();
 
 	void DeleteInCircle(int typeDelete, int typeTo, int typeOnwer, int cx, int cy, double radius);
 	std::vector<int> GetShotIdInCircle(int typeOnwer, int cx, int cy, int radius);
-	int GetShotCount(int typeOnwer);
+	int GetShotCount(int typeOwner);
 	int GetShotCountAll() const { return listObj_.size(); }
 	std::vector<bool> GetValidRenderPriorityList();
 
@@ -88,9 +88,9 @@ public:
 	ref_count_ptr<StgShotRenderer>::unsync GetRenderer(int index, int typeRender) const { return listRenderer_[typeRender][index]; }
 	std::vector<ref_count_ptr<StgShotRenderer>::unsync>* GetRendererList(int typeRender) { return &listRenderer_[typeRender]; }
 
-	ref_count_ptr<StgShotData>::unsync GetData(int id) const { return (id >= 0 && id < listData_.size()) ? listData_[id] : NULL; }
+	ref_count_ptr<StgShotData>::unsync GetData(int id) const { return (id >= 0 && id < listData_.size()) ? listData_[id] : nullptr; }
 
-	bool AddShotDataList(std::wstring path, bool bReload);
+	bool AddShotDataList(const std::wstring& path, bool bReload);
 
 private:
 	void _ScanShot(std::vector<ref_count_ptr<StgShotData>::unsync>& listData, Scanner& scanner);
@@ -159,8 +159,8 @@ private:
 class StgShotRenderer : public RenderObjectTLX {
 public:
 	StgShotRenderer();
-	virtual int GetVertexCount() const;
-	virtual void Render();
+	int GetVertexCount() const override;
+	void Render() override;
 	void AddVertex(VERTEX_TLX& vertex);
 	void AddSquareVertex(VERTEX_TLX* listVertex);
 
@@ -189,30 +189,30 @@ public:
 
 public:
 	StgShotObject(StgStageController* stageController);
-	virtual ~StgShotObject();
+	~StgShotObject() override;
 
-	virtual void Work();
-	virtual void Render() {} //一括で描画するためオブジェクト管理での描画はしない
+	void Work() override;
+	void Render() override {} //一括で描画するためオブジェクト管理での描画はしない
 	virtual void Activate() {}
 	virtual void RenderOnShotManager(D3DXMATRIX mat) {}
 	double cssn(double s, double ang);
-	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) override;
 	virtual void ClearShotObject() { ClearIntersectionRelativeTarget(); }
 	virtual void RegistIntersectionTarget() = 0;
 
-	virtual void SetX(double x)
+	void SetX(double x) override
 	{
 		posX_ = x;
 		DxScriptRenderObject::SetX(x);
 	}
-	virtual void SetY(double y)
+	void SetY(double y) override
 	{
 		posY_ = y;
 		DxScriptRenderObject::SetY(y);
 	}
-	virtual void SetColor(int r, int g, int b);
-	virtual void SetAlpha(int alpha);
-	virtual void SetRenderState() {}
+	void SetColor(int r, int g, int b) override;
+	void SetAlpha(int alpha) override;
+	void SetRenderState() override {}
 
 	ref_count_ptr<StgShotObject>::unsync GetOwnObject();
 	int GetShotDataID() const { return idShotData_; }
@@ -274,14 +274,14 @@ protected:
 	bool bChangeItemEnable_;
 
 	StgShotData* _GetShotData();
-	void _SetVertexPosition(VERTEX_TLX& vertex, float x, float y, float z = 1.0f, float w = 1.0f);
+	void _SetVertexPosition(VERTEX_TLX& vertex, float x, float y, float z = 1.0F, float w = 1.0F);
 	void _SetVertexUV(VERTEX_TLX& vertex, float u, float v);
 	void _SetVertexColorARGB(VERTEX_TLX& vertex, D3DCOLOR color);
 	virtual void _DeleteInLife();
 	virtual void _DeleteInAutoClip();
 	virtual void _DeleteInFadeDelete();
 	virtual void _DeleteInAutoDeleteFrame();
-	virtual void _Move();
+	void _Move() override;
 	void _AddReservedShotWork();
 	virtual void _AddReservedShot(ref_count_ptr<StgShotObject>::unsync obj, ReserveShotListData* data);
 	virtual void _ConvertToItemAndSendEvent() {}
@@ -298,7 +298,7 @@ public:
 		radius_ = 0;
 		angle_ = 0;
 	}
-	virtual ~ReserveShotListData() {}
+	virtual ~ReserveShotListData() = default;
 	int GetShotID() const { return idShot_; }
 	double GetRadius() const { return radius_; }
 	double GetAngle() const { return angle_; }
@@ -315,15 +315,15 @@ public:
 		std::list<ReserveShotListData> list_;
 
 	public:
-		ListElement() {}
-		virtual ~ListElement() {}
+		ListElement() = default;
+		virtual ~ListElement() = default;
 		void Add(ReserveShotListData& data) { list_.push_back(data); }
 		std::list<ReserveShotListData>* GetDataList() { return &list_; }
 	};
 
 public:
 	ReserveShotList() { frame_ = 0; }
-	virtual ~ReserveShotList() {}
+	virtual ~ReserveShotList() = default;
 	ref_count_ptr<ListElement>::unsync GetNextFrameData();
 	void AddData(int frame, int idShot, int radius, int angle);
 	void Clear(StgStageController* stageController);
@@ -339,19 +339,19 @@ private:
 class StgNormalShotObject : public StgShotObject {
 public:
 	StgNormalShotObject(StgStageController* stageController);
-	virtual ~StgNormalShotObject();
-	virtual void Work();
-	virtual void RenderOnShotManager(D3DXMATRIX mat);
-	virtual void ClearShotObject();
-	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	~StgNormalShotObject() override;
+	void Work() override;
+	void RenderOnShotManager(D3DXMATRIX mat) override;
+	void ClearShotObject() override;
+	void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) override;
 
-	virtual void RegistIntersectionTarget();
-	virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList();
-	virtual void SetShotDataID(int id);
+	void RegistIntersectionTarget() override;
+	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList() override;
+	void SetShotDataID(int id) override;
 
 protected:
 	void _AddIntersectionRelativeTarget();
-	virtual void _ConvertToItemAndSendEvent();
+	void _ConvertToItemAndSendEvent() override;
 	double angularVelocity_;
 };
 
@@ -361,8 +361,8 @@ protected:
 class StgLaserObject : public StgShotObject {
 public:
 	StgLaserObject(StgStageController* stageController);
-	virtual void ClearShotObject();
-	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
+	void ClearShotObject() override;
+	void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget) override;
 
 	int GetLength() const { return length_; }
 	void SetLength(int length);
@@ -395,26 +395,26 @@ protected:
 class StgLooseLaserObject : public StgLaserObject {
 public:
 	StgLooseLaserObject(StgStageController* stageController);
-	virtual void Work();
-	virtual void RenderOnShotManager(D3DXMATRIX mat);
+	void Work() override;
+	void RenderOnShotManager(D3DXMATRIX mat) override;
 
-	virtual void RegistIntersectionTarget();
-	virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList();
-	virtual void SetX(double x)
+	void RegistIntersectionTarget() override;
+	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList() override;
+	void SetX(double x) override
 	{
 		StgShotObject::SetX(x);
 		posXE_ = x;
 	}
-	virtual void SetY(double y)
+	void SetY(double y) override
 	{
 		StgShotObject::SetY(y);
 		posYE_ = y;
 	}
 
 protected:
-	virtual void _DeleteInAutoClip();
-	virtual void _Move();
-	virtual void _ConvertToItemAndSendEvent();
+	void _DeleteInAutoClip() override;
+	void _Move() override;
+	void _ConvertToItemAndSendEvent() override;
 
 	double posXE_; //後方x
 	double posYE_; //後方y
@@ -426,14 +426,14 @@ protected:
 class StgStraightLaserObject : public StgLaserObject {
 public:
 	StgStraightLaserObject(StgStageController* stageController);
-	virtual void Work();
-	virtual void RenderOnShotManager(D3DXMATRIX mat);
-	virtual void RegistIntersectionTarget();
-	virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList();
+	void Work() override;
+	void RenderOnShotManager(D3DXMATRIX mat) override;
+	void RegistIntersectionTarget() override;
+	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList() override;
 
 	double GetLaserAngle() const { return angLaser_; }
 	void SetLaserAngle(double angle) { angLaser_ = angle; }
-	void SetFadeDelete()
+	void SetFadeDelete() override
 	{
 		if (frameFadeDelete_ < 0)
 			frameFadeDelete_ = FRAME_FADEDELETE_LASER;
@@ -441,10 +441,10 @@ public:
 	void SetSourceEnable(bool bEnable) { bUseSouce_ = bEnable; }
 
 protected:
-	virtual void _DeleteInAutoClip();
-	virtual void _DeleteInAutoDeleteFrame();
-	virtual void _AddReservedShot(ref_count_ptr<StgShotObject>::unsync obj, ReserveShotListData* data);
-	virtual void _ConvertToItemAndSendEvent();
+	void _DeleteInAutoClip() override;
+	void _DeleteInAutoDeleteFrame() override;
+	void _AddReservedShot(ref_count_ptr<StgShotObject>::unsync obj, ReserveShotListData* data) override;
+	void _ConvertToItemAndSendEvent() override;
 
 	double angLaser_;
 	bool bUseSouce_;
@@ -463,19 +463,19 @@ protected:
 
 public:
 	StgCurveLaserObject(StgStageController* stageController);
-	virtual void Work();
-	virtual void RenderOnShotManager(D3DXMATRIX mat);
-	virtual void RegistIntersectionTarget();
-	virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList();
+	void Work() override;
+	void RenderOnShotManager(D3DXMATRIX mat) override;
+	void RegistIntersectionTarget() override;
+	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList() override;
 	void SetTipDecrement(double dec) { tipDecrement_ = dec; }
 
 protected:
 	std::list<Position> listPosition_;
 	double tipDecrement_;
 
-	virtual void _DeleteInAutoClip();
-	virtual void _Move();
-	virtual void _ConvertToItemAndSendEvent();
+	void _DeleteInAutoClip() override;
+	void _Move() override;
+	void _ConvertToItemAndSendEvent() override;
 };
 
 #endif

--- a/source/TouhouDanmakufu/Common/StgShot.hpp
+++ b/source/TouhouDanmakufu/Common/StgShot.hpp
@@ -49,11 +49,11 @@ public:
 	void DeleteInCircle(int typeDelete, int typeTo, int typeOnwer, int cx, int cy, double radius);
 	std::vector<int> GetShotIdInCircle(int typeOnwer, int cx, int cy, int radius);
 	int GetShotCount(int typeOnwer);
-	int GetShotCountAll() { return listObj_.size(); }
+	int GetShotCountAll() const { return listObj_.size(); }
 	std::vector<bool> GetValidRenderPriorityList();
 
 	void SetDeleteEventEnableByType(int type, bool bEnable);
-	bool IsDeleteEventEnable(int bit);
+	bool IsDeleteEventEnable(int bit) const;
 
 protected:
 	StgStageController* stageController_;
@@ -83,12 +83,12 @@ public:
 	StgShotDataList();
 	virtual ~StgShotDataList();
 
-	int GetTextureCount() { return listTexture_.size(); }
+	int GetTextureCount() const { return listTexture_.size(); }
 	ref_count_ptr<Texture> GetTexture(int index) { return listTexture_[index]; }
-	ref_count_ptr<StgShotRenderer>::unsync GetRenderer(int index, int typeRender) { return listRenderer_[typeRender][index]; }
+	ref_count_ptr<StgShotRenderer>::unsync GetRenderer(int index, int typeRender) const { return listRenderer_[typeRender][index]; }
 	std::vector<ref_count_ptr<StgShotRenderer>::unsync>* GetRendererList(int typeRender) { return &listRenderer_[typeRender]; }
 
-	ref_count_ptr<StgShotData>::unsync GetData(int id) { return (id >= 0 && id < listData_.size()) ? listData_[id] : NULL; }
+	ref_count_ptr<StgShotData>::unsync GetData(int id) const { return (id >= 0 && id < listData_.size()) ? listData_[id] : NULL; }
 
 	bool AddShotDataList(std::wstring path, bool bReload);
 
@@ -116,17 +116,17 @@ public:
 	StgShotData(StgShotDataList* listShotData);
 	virtual ~StgShotData();
 
-	int GetTextureIndex() { return indexTexture_; }
-	int GetRenderType() { return typeRender_; }
-	int GetDelayRenderType() { return typeDelayRender_; }
+	int GetTextureIndex() const { return indexTexture_; }
+	int GetRenderType() const { return typeRender_; }
+	int GetDelayRenderType() const { return typeDelayRender_; }
 	RECT GetRect(int frame);
-	RECT GetDelayRect() { return rcDelay_; }
-	int GetAlpha() { return alpha_; }
-	D3DCOLOR GetDelayColor() { return colorDelay_; }
+	RECT GetDelayRect() const { return rcDelay_; }
+	int GetAlpha() const { return alpha_; }
+	D3DCOLOR GetDelayColor() const { return colorDelay_; }
 	std::vector<DxCircle>* GetIntersectionCircleList() { return &listCol_; }
-	double GetAngularVelocityMin() { return angularVelocityMin_; }
-	double GetAngularVelocityMax() { return angularVelocityMax_; }
-	bool IsFixedAngle() { return bFixedAngle_; }
+	double GetAngularVelocityMin() const { return angularVelocityMin_; }
+	double GetAngularVelocityMax() const { return angularVelocityMax_; }
+	bool IsFixedAngle() const { return bFixedAngle_; }
 
 	ref_count_ptr<Texture> GetTexture();
 	StgShotRenderer* GetRenderer();
@@ -159,7 +159,7 @@ private:
 class StgShotRenderer : public RenderObjectTLX {
 public:
 	StgShotRenderer();
-	virtual int GetVertexCount();
+	virtual int GetVertexCount() const;
 	virtual void Render();
 	void AddVertex(VERTEX_TLX& vertex);
 	void AddSquareVertex(VERTEX_TLX* listVertex);
@@ -194,7 +194,7 @@ public:
 	virtual void Work();
 	virtual void Render() {} //一括で描画するためオブジェクト管理での描画はしない
 	virtual void Activate() {}
-	virtual void RenderOnShotManager(D3DXMATRIX& mat) {}
+	virtual void RenderOnShotManager(D3DXMATRIX mat) {}
 	double cssn(double s, double ang);
 	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
 	virtual void ClearShotObject() { ClearIntersectionRelativeTarget(); }
@@ -215,31 +215,31 @@ public:
 	virtual void SetRenderState() {}
 
 	ref_count_ptr<StgShotObject>::unsync GetOwnObject();
-	int GetShotDataID() { return idShotData_; }
+	int GetShotDataID() const { return idShotData_; }
 	virtual void SetShotDataID(int id) { idShotData_ = id; }
-	int GetOwnerType() { return typeOwner_; }
+	int GetOwnerType() const { return typeOwner_; }
 	void SetOwnerType(int type) { typeOwner_ = type; }
 
-	bool IsValidGraze() { return frameGrazeInvalid_ <= 0; }
-	int GetDelay() { return delay_; }
+	bool IsValidGraze() const { return frameGrazeInvalid_ <= 0; }
+	int GetDelay() const { return delay_; }
 	void SetDelay(int delay) { delay_ = delay; }
-	int GetSourceBlendType() { return typeSourceBrend_; }
+	int GetSourceBlendType() const { return typeSourceBrend_; }
 	void SetSourceBlendType(int type) { typeSourceBrend_ = type; }
-	double GetLife() { return life_; }
+	double GetLife() const { return life_; }
 	void SetLife(double life) { life_ = life; }
-	double GetDamage() { return damage_; }
+	double GetDamage() const { return damage_; }
 	void SetDamage(double damage) { damage_ = damage; }
 	virtual void SetFadeDelete()
 	{
 		if (frameFadeDelete_ < 0)
 			frameFadeDelete_ = FRAME_FADEDELETE;
 	}
-	bool IsAutoDelete() { return bAutoDelete_; }
+	bool IsAutoDelete() const { return bAutoDelete_; }
 	void SetAutoDelete(bool b) { bAutoDelete_ = b; }
 	void SetAutoDeleteFrame(int frame) { frameAutoDelete_ = frame; }
-	bool IsEraseShot() { return bEraseShot_; }
+	bool IsEraseShot() const { return bEraseShot_; }
 	void SetEraseShot(bool bErase) { bEraseShot_ = bErase; }
-	bool IsSpellFactor() { return bSpellFactor_; }
+	bool IsSpellFactor() const { return bSpellFactor_; }
 	void SetSpellFactor(bool bSpell) { bSpellFactor_ = bSpell; }
 	void SetUserIntersectionMode(bool b) { bUserIntersectionMode_ = b; }
 	void SetIntersectionEnable(bool b) { bIntersectionEnable_ = b; }
@@ -299,9 +299,9 @@ public:
 		angle_ = 0;
 	}
 	virtual ~ReserveShotListData() {}
-	int GetShotID() { return idShot_; }
-	double GetRadius() { return radius_; }
-	double GetAngle() { return angle_; }
+	int GetShotID() const { return idShot_; }
+	double GetRadius() const { return radius_; }
+	double GetAngle() const { return angle_; }
 
 private:
 	int idShot_; //対象ID
@@ -341,7 +341,7 @@ public:
 	StgNormalShotObject(StgStageController* stageController);
 	virtual ~StgNormalShotObject();
 	virtual void Work();
-	virtual void RenderOnShotManager(D3DXMATRIX& mat);
+	virtual void RenderOnShotManager(D3DXMATRIX mat);
 	virtual void ClearShotObject();
 	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
 
@@ -364,11 +364,11 @@ public:
 	virtual void ClearShotObject();
 	virtual void Intersect(ref_count_ptr<StgIntersectionTarget>::unsync ownTarget, ref_count_ptr<StgIntersectionTarget>::unsync otherTarget);
 
-	int GetLength() { return length_; }
+	int GetLength() const { return length_; }
 	void SetLength(int length);
-	int GetRenderWidth() { return widthRender_; }
+	int GetRenderWidth() const { return widthRender_; }
 	void SetRenderWidth(int width);
-	int GetIntersectionWidth() { return widthIntersection_; }
+	int GetIntersectionWidth() const { return widthIntersection_; }
 	void SetIntersectionWidth(int width) { widthIntersection_ = width; }
 	void SetInvalidLength(int start, int end)
 	{
@@ -396,7 +396,7 @@ class StgLooseLaserObject : public StgLaserObject {
 public:
 	StgLooseLaserObject(StgStageController* stageController);
 	virtual void Work();
-	virtual void RenderOnShotManager(D3DXMATRIX& mat);
+	virtual void RenderOnShotManager(D3DXMATRIX mat);
 
 	virtual void RegistIntersectionTarget();
 	virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList();
@@ -427,11 +427,11 @@ class StgStraightLaserObject : public StgLaserObject {
 public:
 	StgStraightLaserObject(StgStageController* stageController);
 	virtual void Work();
-	virtual void RenderOnShotManager(D3DXMATRIX& mat);
+	virtual void RenderOnShotManager(D3DXMATRIX mat);
 	virtual void RegistIntersectionTarget();
 	virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList();
 
-	double GetLaserAngle() { return angLaser_; }
+	double GetLaserAngle() const { return angLaser_; }
 	void SetLaserAngle(double angle) { angLaser_ = angle; }
 	void SetFadeDelete()
 	{
@@ -464,7 +464,7 @@ protected:
 public:
 	StgCurveLaserObject(StgStageController* stageController);
 	virtual void Work();
-	virtual void RenderOnShotManager(D3DXMATRIX& mat);
+	virtual void RenderOnShotManager(D3DXMATRIX mat);
 	virtual void RegistIntersectionTarget();
 	virtual std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> GetIntersectionTargetList();
 	void SetTipDecrement(double dec) { tipDecrement_ = dec; }

--- a/source/TouhouDanmakufu/Common/StgStageController.cpp
+++ b/source/TouhouDanmakufu/Common/StgStageController.cpp
@@ -11,12 +11,12 @@ StgStageController::StgStageController(StgSystemController* systemController)
 }
 StgStageController::~StgStageController()
 {
-	intersectionManager_ = NULL;
-	itemManager_ = NULL;
-	shotManager_ = NULL;
-	enemyManager_ = NULL;
-	objectManagerMain_ = NULL;
-	scriptManager_ = NULL;
+	intersectionManager_ = nullptr;
+	itemManager_ = nullptr;
+	shotManager_ = nullptr;
+	enemyManager_ = nullptr;
+	objectManagerMain_ = nullptr;
+	scriptManager_ = nullptr;
 }
 void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 {
@@ -43,7 +43,7 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 	ref_count_ptr<StgPlayerInformation> prevPlayerInfo = startData->GetPrevPlayerInformation();
 
 	infoStage_ = infoStage;
-	infoStage_->SetReplay(replayStageData != NULL);
+	infoStage_->SetReplay(replayStageData != nullptr);
 
 	//リプレイキー設定
 	int replayState = infoStage_->IsReplay() ? KeyReplayManager::STATE_REPLAY : KeyReplayManager::STATE_RECORD;
@@ -61,13 +61,11 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 	keyReplayManager_->AddTarget(EDirectInput::KEY_OK);
 	keyReplayManager_->AddTarget(EDirectInput::KEY_CANCEL);
 	std::set<int> listReplayTargetKey = infoSystem_->GetReplayTargetKeyList();
-	std::set<int>::iterator itrKey = listReplayTargetKey.begin();
-	for (; itrKey != listReplayTargetKey.end(); itrKey++) {
-		int id = *itrKey;
+	for (int id : listReplayTargetKey) {
 		keyReplayManager_->AddTarget(id);
 	}
 
-	if (replayStageData == NULL)
+	if (replayStageData == nullptr)
 		replayStageData = new ReplayInformation::StageData();
 	infoStage_->SetReplayData(replayStageData);
 
@@ -77,7 +75,7 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 	EFpsController::GetInstance()->AddFpsControlObject(wPtr);
 
 	//前ステージ情報反映
-	if (prevStageData != NULL) {
+	if (prevStageData != nullptr) {
 		infoStage_->SetScore(prevStageData->GetScore());
 		infoStage_->SetGraze(prevStageData->GetGraze());
 		infoStage_->SetPoint(prevStageData->GetPoint());
@@ -134,7 +132,7 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 
 	//パッケージスクリプトの場合は、ステージスクリプトと関連付ける
 	StgPackageController* packageController = systemController_->GetPackageController();
-	if (packageController != NULL) {
+	if (packageController != nullptr) {
 		ref_count_ptr<ScriptManager> packageScriptManager = packageController->GetScriptManager();
 		ref_count_ptr<ScriptManager> stageScriptManager = scriptManager_;
 		ScriptManager::AddRelativeScriptManagerMutual(packageScriptManager, stageScriptManager);
@@ -152,24 +150,24 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 	std::wstring pathSystemScript = infoMain->GetSystemPath();
 	if (pathSystemScript == ScriptInformation::DEFAULT)
 		pathSystemScript = EPathProperty::GetStgDefaultScriptDirectory() + L"Default_System.txt";
-	if (pathSystemScript.size() > 0) {
+	if (!pathSystemScript.empty()) {
 		pathSystemScript = EPathProperty::ExtendRelativeToFull(dirInfo, pathSystemScript);
 		ELogger::WriteTop(StringUtility::Format(L"システムスクリプト[%s]", pathSystemScript.c_str()));
-		_int64 idScript = scriptManager_->LoadScript(pathSystemScript, StgStageScript::TYPE_SYSTEM);
+		int64_t idScript = scriptManager_->LoadScript(pathSystemScript, StgStageScript::TYPE_SYSTEM);
 		scriptManager_->StartScript(idScript);
 	}
 
 	//自機スクリプト
-	ref_count_ptr<StgPlayerObject>::unsync objPlayer = NULL;
+	ref_count_ptr<StgPlayerObject>::unsync objPlayer = nullptr;
 	ref_count_ptr<ScriptInformation> infoPlayer = infoStage_->GetPlayerScriptInformation();
 	std::wstring pathPlayerScript = infoPlayer->GetScriptPath();
 
-	if (pathPlayerScript.size() > 0) {
+	if (!pathPlayerScript.empty()) {
 		ELogger::WriteTop(StringUtility::Format(L"自機スクリプト[%s]", pathPlayerScript.c_str()));
 		int idPlayer = objectManager->CreatePlayerObject();
 		objPlayer = ref_count_ptr<StgPlayerObject>::unsync::DownCast(GetMainRenderObject(idPlayer));
 
-		_int64 idScript = scriptManager_->LoadScript(pathPlayerScript, StgStageScript::TYPE_PLAYER);
+		int64_t idScript = scriptManager_->LoadScript(pathPlayerScript, StgStageScript::TYPE_PLAYER);
 		_SetupReplayTargetCommonDataArea(idScript);
 
 		ref_count_ptr<StgStagePlayerScript> script = ref_count_ptr<StgStagePlayerScript>::DownCast(scriptManager_->GetScript(idScript));
@@ -178,25 +176,25 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 		scriptManager_->StartScript(idScript);
 
 		//前ステージ情報反映
-		if (prevPlayerInfo != NULL)
+		if (prevPlayerInfo != nullptr)
 			objPlayer->SetPlayerInforamtion(prevPlayerInfo);
 	}
-	if (objPlayer != NULL)
+	if (objPlayer != nullptr)
 		infoStage_->SetPlayerObjectInformation(objPlayer->GetPlayerInformation());
 
 	//メインスクリプト
 	if (infoMain->GetType() == ScriptInformation::TYPE_SINGLE) {
 		std::wstring pathMainScript = EPathProperty::GetSystemResourceDirectory() + L"script/System_SingleStage.txt";
-		_int64 idScript = scriptManager_->LoadScript(pathMainScript, StgStageScript::TYPE_STAGE);
+		int64_t idScript = scriptManager_->LoadScript(pathMainScript, StgStageScript::TYPE_STAGE);
 		scriptManager_->StartScript(idScript);
 	} else if (infoMain->GetType() == ScriptInformation::TYPE_PLURAL) {
 		std::wstring pathMainScript = EPathProperty::GetSystemResourceDirectory() + L"script/System_PluralStage.txt";
-		_int64 idScript = scriptManager_->LoadScript(pathMainScript, StgStageScript::TYPE_STAGE);
+		int64_t idScript = scriptManager_->LoadScript(pathMainScript, StgStageScript::TYPE_STAGE);
 		scriptManager_->StartScript(idScript);
 	} else {
 		std::wstring pathMainScript = infoMain->GetScriptPath();
-		if (pathMainScript.size() > 0) {
-			_int64 idScript = scriptManager_->LoadScript(pathMainScript, StgStageScript::TYPE_STAGE);
+		if (!pathMainScript.empty()) {
+			int64_t idScript = scriptManager_->LoadScript(pathMainScript, StgStageScript::TYPE_STAGE);
 			_SetupReplayTargetCommonDataArea(idScript);
 			scriptManager_->StartScript(idScript);
 		}
@@ -206,10 +204,10 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 	std::wstring pathBack = infoMain->GetBackgroundPath();
 	if (pathBack == ScriptInformation::DEFAULT)
 		pathBack = L"";
-	if (pathBack.size() > 0) {
+	if (!pathBack.empty()) {
 		pathBack = EPathProperty::ExtendRelativeToFull(dirInfo, pathBack);
 		ELogger::WriteTop(StringUtility::Format(L"背景スクリプト[%s]", pathBack.c_str()));
-		_int64 idScript = scriptManager_->LoadScript(pathBack, StgStageScript::TYPE_STAGE);
+		int64_t idScript = scriptManager_->LoadScript(pathBack, StgStageScript::TYPE_STAGE);
 		scriptManager_->StartScript(idScript);
 	}
 
@@ -217,11 +215,11 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 	std::wstring pathBGM = infoMain->GetBgmPath();
 	if (pathBGM == ScriptInformation::DEFAULT)
 		pathBGM = L"";
-	if (pathBGM.size() > 0) {
+	if (!pathBGM.empty()) {
 		pathBGM = EPathProperty::ExtendRelativeToFull(dirInfo, pathBGM);
 		ELogger::WriteTop(StringUtility::Format(L"BGM[%s]", pathBGM.c_str()));
 		ref_count_ptr<SoundPlayer> player = DirectSoundManager::GetBase()->GetPlayer(pathBGM);
-		if (player != NULL) {
+		if (player != nullptr) {
 			player->SetSoundDivision(SoundDivision::DIVISION_BGM);
 			SoundPlayer::PlayStyle style;
 			style.SetLoopEnable(true);
@@ -233,7 +231,7 @@ void StgStageController::Initialize(ref_count_ptr<StgStageStartData> startData)
 	if (!infoStage_->IsReplay()) {
 		//自機情報
 		ref_count_ptr<StgPlayerObject>::unsync objPlayer = GetPlayerObject();
-		if (objPlayer != NULL) {
+		if (objPlayer != nullptr) {
 			replayStageData->SetPlayerLife(objPlayer->GetLife());
 			replayStageData->SetPlayerBombCount(objPlayer->GetSpell());
 			replayStageData->SetPlayerPower(objPlayer->GetPower());
@@ -269,10 +267,10 @@ void StgStageController::CloseScene()
 		replayStageData->SetLastScore(infoStage_->GetScore());
 	}
 }
-void StgStageController::_SetupReplayTargetCommonDataArea(_int64 idScript)
+void StgStageController::_SetupReplayTargetCommonDataArea(int64_t idScript)
 {
 	ref_count_ptr<StgStageScript> script = ref_count_ptr<StgStageScript>::DownCast(scriptManager_->GetScript(idScript));
-	if (script == NULL)
+	if (script == nullptr)
 		return;
 
 	gstd::value res = script->RequestEvent(StgStageScript::EV_REQUEST_REPLAY_TARGET_COMMON_AREA);
@@ -293,16 +291,12 @@ void StgStageController::_SetupReplayTargetCommonDataArea(_int64 idScript)
 
 	gstd::ref_count_ptr<ScriptCommonDataManager> scriptCommonDataManager = systemController_->GetCommonDataManager();
 	if (!infoStage_->IsReplay()) {
-		std::set<std::string>::iterator itrArea = listArea.begin();
-		for (; itrArea != listArea.end(); itrArea++) {
-			std::string area = (*itrArea);
+		for (auto& area : listArea) {
 			ref_count_ptr<ScriptCommonData> commonData = scriptCommonDataManager->GetData(area);
 			replayStageData->SetCommonData(area, commonData);
 		}
 	} else {
-		std::set<std::string>::iterator itrArea = listArea.begin();
-		for (; itrArea != listArea.end(); itrArea++) {
-			std::string area = (*itrArea);
+		for (auto& area : listArea) {
 			ref_count_ptr<ScriptCommonData> commonData = replayStageData->GetCommonData(area);
 			scriptCommonDataManager->SetData(area, commonData);
 		}
@@ -350,7 +344,7 @@ void StgStageController::Work()
 			scriptManager_->Work(StgStageScript::TYPE_ITEM);
 
 			ref_count_ptr<StgPlayerObject>::unsync objPlayer = GetPlayerObject();
-			if (objPlayer != NULL)
+			if (objPlayer != nullptr)
 				objPlayer->Move(); //自機だけ先に移動
 			scriptManager_->Work(StgStageScript::TYPE_PLAYER);
 
@@ -422,7 +416,7 @@ void StgStageController::RenderToTransitionTexture()
 	systemController_->RenderScriptObject();
 
 	graphics->EndScene();
-	graphics->SetRenderTarget(NULL);
+	graphics->SetRenderTarget(nullptr);
 }
 
 ref_count_ptr<DxScriptObjectBase>::unsync StgStageController::GetMainRenderObject(int idObject)
@@ -433,7 +427,7 @@ ref_count_ptr<StgPlayerObject>::unsync StgStageController::GetPlayerObject()
 {
 	int idPlayer = objectManagerMain_->GetPlayerObjectID();
 	if (idPlayer == DxScript::ID_INVALID)
-		return NULL;
+		return nullptr;
 	return ref_count_ptr<StgPlayerObject>::unsync::DownCast(GetMainRenderObject(idPlayer));
 }
 
@@ -466,9 +460,7 @@ StgStageInformation::StgStageInformation()
 
 	timeStart_ = 0;
 }
-StgStageInformation::~StgStageInformation()
-{
-}
+StgStageInformation::~StgStageInformation() = default;
 void StgStageInformation::SetStgFrameRect(RECT rect, bool bUpdateFocusResetValue)
 {
 	rcStgFrame_ = rect;

--- a/source/TouhouDanmakufu/Common/StgStageController.hpp
+++ b/source/TouhouDanmakufu/Common/StgStageController.hpp
@@ -78,15 +78,15 @@ public:
 public:
 	StgStageInformation();
 	virtual ~StgStageInformation();
-	bool IsEnd() { return bEndStg_; }
+	bool IsEnd() const { return bEndStg_; }
 	void SetEnd() { bEndStg_ = true; }
-	bool IsPause() { return bPause_; }
+	bool IsPause() const { return bPause_; }
 	void SetPause(bool bPause) { bPause_ = bPause; }
-	bool IsReplay() { return bReplay_; }
+	bool IsReplay() const { return bReplay_; }
 	void SetReplay(bool bReplay) { bReplay_ = bReplay; }
-	int GetCurrentFrame() { return frame_; }
+	int GetCurrentFrame() const { return frame_; }
 	void AdvanceFrame() { frame_++; }
-	int GetStageIndex() { return stageIndex_; }
+	int GetStageIndex() const { return stageIndex_; }
 	void SetStageIndex(int index) { stageIndex_ = index; }
 
 	ref_count_ptr<ScriptInformation> GetMainScriptInformation() { return infoMainScript_; }
@@ -98,37 +98,37 @@ public:
 	ref_count_ptr<ReplayInformation::StageData> GetReplayData() { return replayStageData_; }
 	void SetReplayData(ref_count_ptr<ReplayInformation::StageData> data) { replayStageData_ = data; }
 
-	RECT GetStgFrameRect() { return rcStgFrame_; }
+	RECT GetStgFrameRect() const { return rcStgFrame_; }
 	void SetStgFrameRect(RECT rect, bool bUpdateFocusResetValue = true);
-	int GetStgFrameMinPriority() { return priMinStgFrame_; }
+	int GetStgFrameMinPriority() const { return priMinStgFrame_; }
 	void SetStgFrameMinPriority(int pri) { priMinStgFrame_ = pri; }
-	int GetStgFrameMaxPriority() { return priMaxStgFrame_; }
+	int GetStgFrameMaxPriority() const { return priMaxStgFrame_; }
 	void SetStgFrameMaxPriority(int pri) { priMaxStgFrame_ = pri; }
-	int GetShotObjectPriority() { return priShotObject_; }
+	int GetShotObjectPriority() const { return priShotObject_; }
 	void SetShotObjectPriority(int pri) { priShotObject_ = pri; }
-	int GetItemObjectPriority() { return priItemObject_; }
+	int GetItemObjectPriority() const { return priItemObject_; }
 	void SetItemObjectPriority(int pri) { priItemObject_ = pri; }
-	int GetCameraFocusPermitPriority() { return priCameraFocusPermit_; }
+	int GetCameraFocusPermitPriority() const { return priCameraFocusPermit_; }
 	void SetCameraFocusPermitPriority(int pri) { priCameraFocusPermit_ = pri; }
-	RECT GetShotAutoDeleteClip() { return rcShotAutoDeleteClip_; }
+	RECT GetShotAutoDeleteClip() const { return rcShotAutoDeleteClip_; }
 	void SetShotAutoDeleteClip(RECT rect) { rcShotAutoDeleteClip_ = rect; }
 
 	ref_count_ptr<MersenneTwister> GetMersenneTwister() { return rand_; }
 	void SetMersenneTwisterSeed(int seed) { rand_->Initialize(seed); }
-	_int64 GetScore() { return score_; }
+	_int64 GetScore() const { return score_; }
 	void SetScore(_int64 score) { score_ = score; }
 	void AddScore(_int64 inc) { score_ += inc; }
-	_int64 GetGraze() { return graze_; }
+	_int64 GetGraze() const { return graze_; }
 	void SetGraze(_int64 graze) { graze_ = graze; }
 	void AddGraze(_int64 inc) { graze_ += inc; }
-	_int64 GetPoint() { return point_; }
+	_int64 GetPoint() const { return point_; }
 	void SetPoint(_int64 point) { point_ = point; }
 	void AddPoint(_int64 inc) { point_ += inc; }
 
-	int GetResult() { return result_; }
+	int GetResult() const { return result_; }
 	void SetResult(int result) { result_ = result; }
 
-	int GetStageStartTime() { return timeStart_; }
+	int GetStageStartTime() const { return timeStart_; }
 	void SetStageStartTime(int time) { timeStart_ = time; }
 
 private:
@@ -219,7 +219,7 @@ class PseudoSlowInformation::SlowData {
 public:
 	SlowData() { fps_ = STANDARD_FPS; }
 	virtual ~SlowData() {}
-	int GetFps() { return fps_; }
+	int GetFps() const { return fps_; }
 	void SetFps(int fps) { fps_ = fps; }
 
 private:

--- a/source/TouhouDanmakufu/Common/StgStageController.hpp
+++ b/source/TouhouDanmakufu/Common/StgStageController.hpp
@@ -46,7 +46,7 @@ public:
 	ref_count_ptr<PseudoSlowInformation> GetSlowInformation() { return infoSlow_; }
 
 private:
-	void _SetupReplayTargetCommonDataArea(_int64 idScript);
+	void _SetupReplayTargetCommonDataArea(int64_t idScript);
 
 	StgSystemController* systemController_;
 	ref_count_ptr<StgSystemInformation> infoSystem_;
@@ -115,15 +115,15 @@ public:
 
 	ref_count_ptr<MersenneTwister> GetMersenneTwister() { return rand_; }
 	void SetMersenneTwisterSeed(int seed) { rand_->Initialize(seed); }
-	_int64 GetScore() const { return score_; }
-	void SetScore(_int64 score) { score_ = score; }
-	void AddScore(_int64 inc) { score_ += inc; }
-	_int64 GetGraze() const { return graze_; }
-	void SetGraze(_int64 graze) { graze_ = graze; }
-	void AddGraze(_int64 inc) { graze_ += inc; }
-	_int64 GetPoint() const { return point_; }
-	void SetPoint(_int64 point) { point_ = point; }
-	void AddPoint(_int64 inc) { point_ += inc; }
+	int64_t GetScore() const { return score_; }
+	void SetScore(int64_t score) { score_ = score; }
+	void AddScore(int64_t inc) { score_ += inc; }
+	int64_t GetGraze() const { return graze_; }
+	void SetGraze(int64_t graze) { graze_ = graze; }
+	void AddGraze(int64_t inc) { graze_ += inc; }
+	int64_t GetPoint() const { return point_; }
+	void SetPoint(int64_t point) { point_ = point; }
+	void AddPoint(int64_t inc) { point_ += inc; }
 
 	int GetResult() const { return result_; }
 	void SetResult(int result) { result_ = result; }
@@ -154,9 +154,9 @@ private:
 
 	//STG情報
 	ref_count_ptr<MersenneTwister> rand_;
-	_int64 score_;
-	_int64 graze_;
-	_int64 point_;
+	int64_t score_;
+	int64_t graze_;
+	int64_t point_;
 	int result_;
 	int timeStart_;
 };
@@ -166,8 +166,8 @@ private:
 **********************************************************/
 class StgStageStartData {
 public:
-	StgStageStartData() {}
-	virtual ~StgStageStartData() {}
+	StgStageStartData() = default;
+	virtual ~StgStageStartData() = default;
 
 	ref_count_ptr<StgStageInformation> GetStageInformation() { return infoStage_; }
 	void SetStageInformation(ref_count_ptr<StgStageInformation> info) { infoStage_ = info; }
@@ -199,8 +199,8 @@ public:
 
 public:
 	PseudoSlowInformation() { current_ = 0; }
-	virtual ~PseudoSlowInformation() {}
-	virtual int GetFps();
+	~PseudoSlowInformation() override = default;
+	int GetFps() override;
 
 	bool IsValidFrame(int target);
 	void Next();
@@ -218,7 +218,7 @@ private:
 class PseudoSlowInformation::SlowData {
 public:
 	SlowData() { fps_ = STANDARD_FPS; }
-	virtual ~SlowData() {}
+	virtual ~SlowData() = default;
 	int GetFps() const { return fps_; }
 	void SetFps(int fps) { fps_ = fps; }
 

--- a/source/TouhouDanmakufu/Common/StgStageScript.cpp
+++ b/source/TouhouDanmakufu/Common/StgStageScript.cpp
@@ -15,9 +15,7 @@ StgStageScriptManager::StgStageScriptManager(StgStageController* stageController
 	idItemScript_ = ID_INVALID;
 	idShotScript_ = ID_INVALID;
 }
-StgStageScriptManager::~StgStageScriptManager()
-{
-}
+StgStageScriptManager::~StgStageScriptManager() = default;
 
 void StgStageScriptManager::SetError(std::wstring error)
 {
@@ -26,13 +24,12 @@ void StgStageScriptManager::SetError(std::wstring error)
 }
 bool StgStageScriptManager::IsError()
 {
-	bool res = error_ != L"" || stageController_->GetSystemInformation()->IsError();
-	return res;
+	return !error_.empty() || stageController_->GetSystemInformation()->IsError();
 }
 
 ref_count_ptr<ManagedScript> StgStageScriptManager::Create(int type)
 {
-	ref_count_ptr<ManagedScript> res = NULL;
+	ref_count_ptr<ManagedScript> res = nullptr;
 	switch (type) {
 	case StgStageScript::TYPE_STAGE:
 		res = new StgStageScript(stageController_);
@@ -51,7 +48,7 @@ ref_count_ptr<ManagedScript> StgStageScriptManager::Create(int type)
 		break;
 	}
 
-	if (res != NULL) {
+	if (res != nullptr) {
 		res->SetScriptManager(stageController_->GetScriptManagerP());
 	}
 
@@ -59,14 +56,14 @@ ref_count_ptr<ManagedScript> StgStageScriptManager::Create(int type)
 }
 ref_count_ptr<ManagedScript> StgStageScriptManager::GetItemScript()
 {
-	ref_count_ptr<ManagedScript> res = NULL;
+	ref_count_ptr<ManagedScript> res = nullptr;
 	if (idItemScript_ != StgControlScriptManager::ID_INVALID)
 		res = GetScript(idItemScript_);
 	return res;
 }
 ref_count_ptr<ManagedScript> StgStageScriptManager::GetShotScript()
 {
-	ref_count_ptr<ManagedScript> res = NULL;
+	ref_count_ptr<ManagedScript> res = nullptr;
 	if (idShotScript_ != StgControlScriptManager::ID_INVALID)
 		res = GetScript(idShotScript_);
 	return res;
@@ -86,7 +83,7 @@ StgStageScriptObjectManager::~StgStageScriptObjectManager()
 {
 	if (idObjPleyer_ != DxScript::ID_INVALID) {
 		ref_count_ptr<StgPlayerObject>::unsync obj = ref_count_ptr<StgPlayerObject>::unsync::DownCast(GetObject(idObjPleyer_));
-		if (obj != NULL)
+		if (obj != nullptr)
 			obj->Clear();
 	}
 }
@@ -529,6 +526,7 @@ function const stgFunction[] = {
 
 	{ "NO_CHANGE", constant<StgMovePattern::NO_CHANGE>::func, 0 },
 };
+
 StgStageScript::StgStageScript(StgStageController* stageController)
 	: StgControlScript(stageController->GetSystemController())
 {
@@ -541,15 +539,13 @@ StgStageScript::StgStageScript(StgStageController* stageController)
 	mt_ = info->GetMersenneTwister();
 
 	scriptManager_ = stageController_->GetScriptManagerP();
-	StgStageScriptManager* scriptManager = (StgStageScriptManager*)scriptManager_;
+	auto* scriptManager = (StgStageScriptManager*)scriptManager_;
 	SetObjectManager(scriptManager->GetObjectManager());
 }
-StgStageScript::~StgStageScript()
-{
-}
+StgStageScript::~StgStageScript() = default;
 ref_count_ptr<StgStageScriptObjectManager> StgStageScript::GetStgObjectManager()
 {
-	StgStageScriptManager* scriptManager = (StgStageScriptManager*)scriptManager_;
+	auto* scriptManager = (StgStageScriptManager*)scriptManager_;
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = scriptManager->GetObjectManager();
 	return objectManager;
 }
@@ -557,7 +553,7 @@ ref_count_ptr<StgStageScriptObjectManager> StgStageScript::GetStgObjectManager()
 //STG制御共通関数：共通データ
 gstd::value StgStageScript::Func_SaveCommonDataAreaToReplayFile(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgStageInformation> infoStage = stageController->GetStageInformation();
 	ref_count_ptr<ReplayInformation::StageData> replayStageData = infoStage->GetReplayData();
@@ -568,7 +564,7 @@ gstd::value StgStageScript::Func_SaveCommonDataAreaToReplayFile(gstd::script_mac
 
 	std::string area = to_mbcs(argv[0].as_string());
 	ref_count_ptr<ScriptCommonData> commonDataO = commonDataManager->GetData(area);
-	if (commonDataO == NULL)
+	if (commonDataO == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	ref_count_ptr<ScriptCommonData> commonDataS = new ScriptCommonData();
@@ -579,7 +575,7 @@ gstd::value StgStageScript::Func_SaveCommonDataAreaToReplayFile(gstd::script_mac
 }
 gstd::value StgStageScript::Func_LoadCommonDataAreaFromReplayFile(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgStageInformation> infoStage = stageController->GetStageInformation();
 	ref_count_ptr<ReplayInformation::StageData> replayStageData = infoStage->GetReplayData();
@@ -590,7 +586,7 @@ gstd::value StgStageScript::Func_LoadCommonDataAreaFromReplayFile(gstd::script_m
 
 	std::string area = to_mbcs(argv[0].as_string());
 	ref_count_ptr<ScriptCommonData> commonDataS = replayStageData->GetCommonData(area);
-	if (commonDataS == NULL)
+	if (commonDataS == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	ref_count_ptr<ScriptCommonData> commonDataO = new ScriptCommonData();
@@ -603,7 +599,7 @@ gstd::value StgStageScript::Func_LoadCommonDataAreaFromReplayFile(gstd::script_m
 //STG共通関数：システム関連
 gstd::value StgStageScript::Func_GetMainStgScriptPath(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<ScriptInformation> infoMain = stageController->GetStageInformation()->GetMainScriptInformation();
 
@@ -614,7 +610,7 @@ gstd::value StgStageScript::Func_GetMainStgScriptPath(gstd::script_machine* mach
 }
 gstd::value StgStageScript::Func_GetMainStgScriptDirectory(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<ScriptInformation> infoMain = stageController->GetStageInformation()->GetMainScriptInformation();
 
@@ -627,7 +623,7 @@ gstd::value StgStageScript::Func_GetMainStgScriptDirectory(gstd::script_machine*
 }
 gstd::value StgStageScript::Func_SetStgFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	RECT rect;
 	rect.left = (int)argv[0].as_real();
@@ -648,7 +644,7 @@ gstd::value StgStageScript::Func_SetStgFrame(gstd::script_machine* machine, int 
 
 gstd::value StgStageScript::Func_SetItemRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgStageInformation> info = stageController->GetStageInformation();
 	int pri = (int)argv[0].as_real();
@@ -659,7 +655,7 @@ gstd::value StgStageScript::Func_SetItemRenderPriorityI(gstd::script_machine* ma
 }
 gstd::value StgStageScript::Func_SetShotRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgStageInformation> info = stageController->GetStageInformation();
 	int pri = (int)argv[0].as_real();
@@ -670,41 +666,41 @@ gstd::value StgStageScript::Func_SetShotRenderPriorityI(gstd::script_machine* ma
 }
 gstd::value StgStageScript::Func_GetStgFrameRenderPriorityMinI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	long double res = stageController->GetStageInformation()->GetStgFrameMinPriority();
 	return value(machine->get_engine()->get_real_type(), res);
 }
 gstd::value StgStageScript::Func_GetStgFrameRenderPriorityMaxI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	long double res = stageController->GetStageInformation()->GetStgFrameMaxPriority();
 	return value(machine->get_engine()->get_real_type(), res);
 }
 gstd::value StgStageScript::Func_GetItemRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	long double res = stageController->GetStageInformation()->GetItemObjectPriority();
 	return value(machine->get_engine()->get_real_type(), res);
 }
 gstd::value StgStageScript::Func_GetShotRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	long double res = stageController->GetStageInformation()->GetShotObjectPriority();
 	return value(machine->get_engine()->get_real_type(), res);
 }
 gstd::value StgStageScript::Func_GetPlayerRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = script->GetStgObjectManager();
 	int idObjPlayer = objectManager->GetPlayerObjectID();
 
 	long double res = 30;
-	StgPlayerObject* obj = dynamic_cast<StgPlayerObject*>(script->GetObjectPointer(idObjPlayer));
-	if (obj != NULL) {
+	auto* obj = dynamic_cast<StgPlayerObject*>(script->GetObjectPointer(idObjPlayer));
+	if (obj != nullptr) {
 		double pri = obj->GetRenderPriority();
 		int vacket = objectManager->GetRenderBucketCapacity();
 		res = pri * (vacket - 1);
@@ -713,7 +709,7 @@ gstd::value StgStageScript::Func_GetPlayerRenderPriorityI(gstd::script_machine* 
 }
 gstd::value StgStageScript::Func_GetCameraFocusPermitPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	long double res = stageController->GetStageInformation()->GetCameraFocusPermitPriority();
 	return value(machine->get_engine()->get_real_type(), res);
@@ -721,7 +717,7 @@ gstd::value StgStageScript::Func_GetCameraFocusPermitPriorityI(gstd::script_mach
 
 gstd::value StgStageScript::Func_CloseStgScene(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgSystemController* systemController = script->stageController_->GetSystemController();
 
 	StgStageController* stageController = script->stageController_;
@@ -732,7 +728,7 @@ gstd::value StgStageScript::Func_CloseStgScene(gstd::script_machine* machine, in
 }
 gstd::value StgStageScript::Func_GetReplayFps(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgStageInformation> infoStage = stageController->GetStageInformation();
 
@@ -749,26 +745,26 @@ gstd::value StgStageScript::Func_GetReplayFps(gstd::script_machine* machine, int
 //STG共通関数：自機
 gstd::value StgStageScript::Func_GetPlayerObjectID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = script->GetStgObjectManager();
 	long double res = objectManager->GetPlayerObjectID();
 	return value(machine->get_engine()->get_real_type(), res);
 }
 gstd::value StgStageScript::Func_GetPlayerScriptID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgStageScriptManager* scriptManager = stageController->GetScriptManagerP();
 
-	_int64 res = scriptManager->GetPlayerScriptID();
+	int64_t res = scriptManager->GetPlayerScriptID();
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 gstd::value StgStageScript::Func_SetPlayerSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
+	auto* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	double speedFast = argv[0].as_real();
@@ -779,12 +775,12 @@ gstd::value StgStageScript::Func_SetPlayerSpeed(gstd::script_machine* machine, i
 }
 gstd::value StgStageScript::Func_SetPlayerClip(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = script->GetStgObjectManager();
 	int idObjPlayer = objectManager->GetPlayerObjectID();
 
-	StgPlayerObject* obj = dynamic_cast<StgPlayerObject*>(script->GetObjectPointer(idObjPlayer));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgPlayerObject*>(script->GetObjectPointer(idObjPlayer));
+	if (obj == nullptr)
 		return value();
 
 	RECT rect;
@@ -798,10 +794,10 @@ gstd::value StgStageScript::Func_SetPlayerClip(gstd::script_machine* machine, in
 }
 gstd::value StgStageScript::Func_SetPlayerLife(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	double life = argv[0].as_real();
@@ -811,10 +807,10 @@ gstd::value StgStageScript::Func_SetPlayerLife(gstd::script_machine* machine, in
 }
 gstd::value StgStageScript::Func_SetPlayerSpell(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	double spell = argv[0].as_real();
@@ -824,10 +820,10 @@ gstd::value StgStageScript::Func_SetPlayerSpell(gstd::script_machine* machine, i
 }
 gstd::value StgStageScript::Func_SetPlayerPower(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	double power = argv[0].as_real();
@@ -837,10 +833,10 @@ gstd::value StgStageScript::Func_SetPlayerPower(gstd::script_machine* machine, i
 }
 gstd::value StgStageScript::Func_SetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	int invi = (int)argv[0].as_real();
@@ -850,10 +846,10 @@ gstd::value StgStageScript::Func_SetPlayerInvincibilityFrame(gstd::script_machin
 }
 gstd::value StgStageScript::Func_SetPlayerDownStateFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	int frame = (int)argv[0].as_real();
@@ -863,10 +859,10 @@ gstd::value StgStageScript::Func_SetPlayerDownStateFrame(gstd::script_machine* m
 }
 gstd::value StgStageScript::Func_SetPlayerRebirthFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	int frame = (int)argv[0].as_real();
@@ -877,10 +873,10 @@ gstd::value StgStageScript::Func_SetPlayerRebirthFrame(gstd::script_machine* mac
 }
 gstd::value StgStageScript::Func_SetPlayerRebirthLossFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	int frame = (int)argv[0].as_real();
@@ -890,10 +886,10 @@ gstd::value StgStageScript::Func_SetPlayerRebirthLossFrame(gstd::script_machine*
 }
 gstd::value StgStageScript::Func_SetPlayerAutoItemCollectLine(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	int posY = (int)argv[0].as_real();
@@ -903,10 +899,10 @@ gstd::value StgStageScript::Func_SetPlayerAutoItemCollectLine(gstd::script_machi
 }
 gstd::value StgStageScript::Func_SetForbidPlayerShot(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	bool bForbid = argv[0].as_boolean();
@@ -916,10 +912,10 @@ gstd::value StgStageScript::Func_SetForbidPlayerShot(gstd::script_machine* machi
 }
 gstd::value StgStageScript::Func_SetForbidPlayerSpell(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	bool bForbid = argv[0].as_boolean();
@@ -929,31 +925,31 @@ gstd::value StgStageScript::Func_SetForbidPlayerSpell(gstd::script_machine* mach
 }
 gstd::value StgStageScript::Func_GetPlayerX(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	double res = obj != NULL ? obj->GetX() : 0;
+	double res = obj != nullptr ? obj->GetX() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 gstd::value StgStageScript::Func_GetPlayerY(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	double res = obj != NULL ? obj->GetY() : 0;
+	double res = obj != nullptr ? obj->GetY() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 gstd::value StgStageScript::Func_GetPlayerState(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	double res = obj != NULL ? obj->GetState() : StgPlayerObject::STATE_END;
+	double res = obj != nullptr ? obj->GetState() : StgPlayerObject::STATE_END;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 gstd::value StgStageScript::Func_GetPlayerSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
 
@@ -966,7 +962,7 @@ gstd::value StgStageScript::Func_GetPlayerSpeed(gstd::script_machine* machine, i
 }
 gstd::value StgStageScript::Func_GetPlayerClip(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
 
@@ -982,65 +978,65 @@ gstd::value StgStageScript::Func_GetPlayerClip(gstd::script_machine* machine, in
 }
 gstd::value StgStageScript::Func_GetPlayerLife(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	double res = obj != NULL ? obj->GetLife() : 0;
+	double res = obj != nullptr ? obj->GetLife() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 gstd::value StgStageScript::Func_GetPlayerSpell(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	double res = obj != NULL ? obj->GetSpell() : 0;
+	double res = obj != nullptr ? obj->GetSpell() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 gstd::value StgStageScript::Func_GetPlayerPower(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	double res = obj != NULL ? obj->GetPower() : 0;
+	double res = obj != nullptr ? obj->GetPower() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 gstd::value StgStageScript::Func_GetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	double res = obj != NULL ? obj->GetInvincibilityFrame() : 0;
+	double res = obj != nullptr ? obj->GetInvincibilityFrame() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 gstd::value StgStageScript::Func_GetPlayerDownStateFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	double res = obj != NULL ? obj->GetDownStateFrame() : 0;
+	double res = obj != nullptr ? obj->GetDownStateFrame() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 gstd::value StgStageScript::Func_GetPlayerRebirthFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	double res = obj != NULL ? obj->GetRebirthFrame() : 0;
+	double res = obj != nullptr ? obj->GetRebirthFrame() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 gstd::value StgStageScript::Func_GetAngleToPlayer(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController->GetPlayerObject();
-	if (objPlayer == NULL)
+	if (objPlayer == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)-1);
 	double px = objPlayer->GetPositionX();
 	double py = objPlayer->GetPositionY();
 
 	int id = (int)argv[0].as_real();
 	ref_count_ptr<DxScriptRenderObject>::unsync objMove = ref_count_ptr<DxScriptRenderObject>::unsync::DownCast(script->GetObject(id));
-	if (objMove == NULL)
+	if (objMove == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)-1);
 	double tx = objMove->GetPosition().x;
 	double ty = objMove->GetPosition().y;
@@ -1051,38 +1047,38 @@ gstd::value StgStageScript::Func_GetAngleToPlayer(gstd::script_machine* machine,
 
 gstd::value StgStageScript::Func_IsPermitPlayerShot(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	bool res = obj != NULL ? obj->IsPermitShot() : false;
+	bool res = obj != nullptr ? obj->IsPermitShot() : false;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
 gstd::value StgStageScript::Func_IsPermitPlayerSpell(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	bool res = obj != NULL ? obj->IsPermitSpell() : false;
+	bool res = obj != nullptr ? obj->IsPermitSpell() : false;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
 gstd::value StgStageScript::Func_IsPlayerLastSpellWait(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
-	bool res = obj != NULL ? obj->IsWaitLastSpell() : false;
+	bool res = obj != nullptr ? obj->IsWaitLastSpell() : false;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
 gstd::value StgStageScript::Func_IsPlayerSpellActive(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	bool res = false;
 	ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController->GetPlayerObject();
-	if (objPlayer != NULL) {
+	if (objPlayer != nullptr) {
 		ref_count_ptr<StgPlayerSpellManageObject>::unsync objSpell = objPlayer->GetSpellManageObject();
-		res = (objSpell != NULL && !objSpell->IsDeleted());
+		res = (objSpell != nullptr && !objSpell->IsDeleted());
 	}
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
@@ -1090,34 +1086,33 @@ gstd::value StgStageScript::Func_IsPlayerSpellActive(gstd::script_machine* machi
 //STG共通関数：敵
 gstd::value StgStageScript::Func_GetEnemyBossSceneObjectID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgEnemyManager* enemyManager = stageController->GetEnemyManager();
 
 	int res = ID_INVALID;
 	ref_count_ptr<StgEnemyBossSceneObject>::unsync obj = enemyManager->GetBossSceneObject();
-	if (obj != NULL && !obj->IsDeleted())
+	if (obj != nullptr && !obj->IsDeleted())
 		res = obj->GetObjectID();
 
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 gstd::value StgStageScript::Func_GetEnemyBossObjectID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgEnemyManager* enemyManager = stageController->GetEnemyManager();
 	ref_count_ptr<StgEnemyBossSceneObject>::unsync scene = enemyManager->GetBossSceneObject();
 
 	std::vector<long double> listLD;
-	if (scene != NULL) {
+	if (scene != nullptr) {
 		ref_count_ptr<StgEnemyBossSceneData>::unsync data = scene->GetActiveData();
-		if (data != NULL) {
+		if (data != nullptr) {
 			const std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& listEnemy = data->GetEnemyObjectList();
-			for (int iEnemy = 0; iEnemy < listEnemy.size(); iEnemy++) {
-				ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemy[iEnemy];
-				if (obj->IsDeleted())
+			for (auto& object : listEnemy) {
+				if (object->IsDeleted())
 					continue;
-				int id = obj->GetObjectID();
+				int id = object->GetObjectID();
 				listLD.push_back(id);
 			}
 		}
@@ -1127,19 +1122,17 @@ gstd::value StgStageScript::Func_GetEnemyBossObjectID(gstd::script_machine* mach
 }
 gstd::value StgStageScript::Func_GetAllEnemyID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgEnemyManager* enemyManager = stageController->GetEnemyManager();
 
 	std::list<ref_count_ptr<StgEnemyObject>::unsync>& listEnemy = enemyManager->GetEnemyList();
 
 	std::vector<long double> listLD;
-	std::list<ref_count_ptr<StgEnemyObject>::unsync>::iterator itr = listEnemy.begin();
-	for (; itr != listEnemy.end(); itr++) {
-		ref_count_ptr<StgEnemyObject>::unsync obj = (*itr);
-		if (obj->IsDeleted())
+	for (auto& object : listEnemy) {
+		if (object->IsDeleted())
 			continue;
-		int id = obj->GetObjectID();
+		int id = object->GetObjectID();
 		listLD.push_back(id);
 	}
 
@@ -1147,14 +1140,13 @@ gstd::value StgStageScript::Func_GetAllEnemyID(gstd::script_machine* machine, in
 }
 gstd::value StgStageScript::Func_GetIntersectionRegistedEnemyID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgIntersectionManager* interSectionManager = stageController->GetIntersectionManager();
 
 	std::vector<long double> listLD;
 	std::vector<StgIntersectionTargetPoint>* listPoint = interSectionManager->GetAllEnemyTargetPoint();
-	for (int iPoint = 0; iPoint < listPoint->size(); iPoint++) {
-		StgIntersectionTargetPoint& target = listPoint->at(iPoint);
+	for (auto& target : *listPoint) {
 		int id = target.GetObjectID();
 		listLD.push_back(id);
 	}
@@ -1163,14 +1155,13 @@ gstd::value StgStageScript::Func_GetIntersectionRegistedEnemyID(gstd::script_mac
 }
 gstd::value StgStageScript::Func_GetAllEnemyIntersectionPosition(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgIntersectionManager* interSectionManager = stageController->GetIntersectionManager();
 
 	std::vector<gstd::value> listV;
 	std::vector<StgIntersectionTargetPoint>* listPoint = interSectionManager->GetAllEnemyTargetPoint();
-	for (int iPoint = 0; iPoint < listPoint->size(); iPoint++) {
-		StgIntersectionTargetPoint& target = listPoint->at(iPoint);
+	for (auto& target : *listPoint) {
 		POINT pos = target.GetPoint();
 		std::vector<long double> listLD;
 		listLD.push_back(pos.x);
@@ -1182,21 +1173,20 @@ gstd::value StgStageScript::Func_GetAllEnemyIntersectionPosition(gstd::script_ma
 }
 gstd::value StgStageScript::Func_GetEnemyIntersectionPosition(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 
 	struct SortDistance {
-		static std::vector<POINT> Sort(int posX, int posY, std::vector<_int64>& listDist, std::vector<POINT>& listRes)
+		static std::vector<POINT> Sort(int posX, int posY, std::vector<int64_t>& listDist, std::vector<POINT>& listRes)
 		{
 			std::sort(listDist.begin(), listDist.end());
 			std::vector<POINT> listResCopy = listRes;
-			std::vector<_int64> listDistCopy = listDist;
+			std::vector<int64_t> listDistCopy = listDist;
 
-			for (int iRes = 0; iRes < listResCopy.size(); iRes++) {
-				POINT& pos = listResCopy[iRes];
-				_int64 dist = (pos.x - posX) * (pos.x - posX) + (pos.y - posY) * (pos.y - posY);
-				for (int iDist = 0; iDist < listDistCopy.size(); iDist++) {
+			for (auto & pos : listResCopy) {
+				int64_t dist = (pos.x - posX) * (pos.x - posX) + (pos.y - posY) * (pos.y - posY);
+				for (int iDist = 0; iDist < listDistCopy.size(); ++iDist) {
 					if (dist == listDistCopy[iDist]) {
 						listRes[iDist] = pos;
 						listDistCopy[iDist] = -1;
@@ -1215,9 +1205,8 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPosition(gstd::script_machi
 
 	std::vector<StgIntersectionTargetPoint>* listPoint = intersectionManager->GetAllEnemyTargetPoint();
 	std::vector<POINT> listRes;
-	std::vector<_int64> listDist;
-	int iPoint = 0;
-	for (iPoint = 0; iPoint < listPoint->size() && countRes > 0; iPoint++) {
+	std::vector<int64_t> listDist;
+	for (int iPoint = 0; iPoint < listPoint->size() && countRes > 0; iPoint++) {
 		StgIntersectionTargetPoint& target = listPoint->at(iPoint);
 		POINT pos = target.GetPoint();
 		if (listRes.size() < countRes) {
@@ -1228,8 +1217,8 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPosition(gstd::script_machi
 				listRes = SortDistance::Sort(posX, posY, listDist, listRes);
 			}
 		} else {
-			_int64 dist = (pos.x - posX) * (pos.x - posX) + (pos.y - posY) * (pos.y - posY);
-			_int64 target = listDist[listDist.size() - 1];
+			int64_t dist = (pos.x - posX) * (pos.x - posX) + (pos.y - posY) * (pos.y - posY);
+			int64_t target = listDist[listDist.size() - 1];
 			if (dist >= target)
 				continue;
 
@@ -1246,8 +1235,7 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPosition(gstd::script_machi
 
 	std::vector<gstd::value> listV;
 	listRes = SortDistance::Sort(posX, posY, listDist, listRes);
-	for (iPoint = 0; iPoint < listRes.size(); iPoint++) {
-		POINT& pos = listRes[iPoint];
+	for (auto& pos : listRes) {
 		std::vector<long double> listLD;
 		listLD.push_back(pos.x);
 		listLD.push_back(pos.y);
@@ -1261,31 +1249,29 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA1(gstd::script
 	//引数1（敵オブジェクトID）自機からもアクセス可能
 	//指定した敵オブジェクトIDが持つ自機ショットへの当たり判定位置を全て取得
 	//二次元配列が返る。([<インデックス>][<0:x座標, 1:y座標>])　配列の0番目が最も敵本体の座標に近い
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgEnemyObject* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
+	auto* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
 
 	std::vector<gstd::value> listV;
-	if (obj != NULL) {
-		std::map<_int64, POINT> mapPos;
+	if (obj != nullptr) {
+		std::map<int64_t, POINT> mapPos;
 		int enemyX = obj->GetPositionX();
 		int enemyY = obj->GetPositionY();
 		StgStageController* stageController = script->stageController_;
 		StgIntersectionManager* interSectionManager = stageController->GetIntersectionManager();
 		std::vector<StgIntersectionTargetPoint>* listPoint = interSectionManager->GetAllEnemyTargetPoint();
-		for (int iPoint = 0; iPoint < listPoint->size(); iPoint++) {
-			StgIntersectionTargetPoint& target = listPoint->at(iPoint);
+		for (auto& target : *listPoint) {
 			if (target.GetObjectID() != id)
 				continue;
 
 			POINT pos = target.GetPoint();
-			_int64 dist = (pos.x - enemyX) * (pos.x - enemyX) + (pos.y - enemyY) * (pos.y - enemyY);
+			int64_t dist = (pos.x - enemyX) * (pos.x - enemyX) + (pos.y - enemyY) * (pos.y - enemyY);
 			mapPos[dist] = pos;
 		}
 
-		std::map<_int64, POINT>::iterator itr = mapPos.begin();
-		for (; itr != mapPos.end(); itr++) {
-			POINT pos = (itr->second);
+		for (auto& posItr : mapPos) {
+			POINT pos = posItr.second;
 			std::vector<long double> listLD;
 			listLD.push_back(pos.x);
 			listLD.push_back(pos.y);
@@ -1302,31 +1288,29 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA2(gstd::script
 	//指定した敵オブジェクトIDが持つ、自機ショットへの当たり判定のうち、指定座標に最も近い1つを取得
 	//配列が返る。([<0:x座標, 1:y座標>])
 
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgEnemyObject* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
+	auto* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
 
 	std::vector<gstd::value> listV;
-	if (obj != NULL) {
-		std::map<_int64, POINT> mapPos;
+	if (obj != nullptr) {
+		std::map<int64_t, POINT> mapPos;
 		int tX = (int)argv[1].as_real();
 		int tY = (int)argv[2].as_real();
 		StgStageController* stageController = script->stageController_;
 		StgIntersectionManager* interSectionManager = stageController->GetIntersectionManager();
 		std::vector<StgIntersectionTargetPoint>* listPoint = interSectionManager->GetAllEnemyTargetPoint();
-		for (int iPoint = 0; iPoint < listPoint->size(); iPoint++) {
-			StgIntersectionTargetPoint& target = listPoint->at(iPoint);
+		for (auto& target : *listPoint) {
 			if (target.GetObjectID() != id)
 				continue;
 
 			POINT pos = target.GetPoint();
-			_int64 dist = (pos.x - tX) * (pos.x - tX) + (pos.y - tY) * (pos.y - tY);
+			int64_t dist = (pos.x - tX) * (pos.x - tX) + (pos.y - tY) * (pos.y - tY);
 			mapPos[dist] = pos;
 		}
 
-		std::map<_int64, POINT>::iterator itr = mapPos.begin();
-		for (; itr != mapPos.end(); itr++) {
-			POINT pos = (itr->second);
+		for (auto& posItr : mapPos) {
+			POINT pos = posItr.second;
 			std::vector<long double> listLD;
 			listLD.push_back(pos.x);
 			listLD.push_back(pos.y);
@@ -1340,7 +1324,7 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA2(gstd::script
 
 gstd::value StgStageScript::Func_LoadEnemyShotData(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgShotManager* shotManager = stageController->GetShotManager();
 
@@ -1353,7 +1337,7 @@ gstd::value StgStageScript::Func_LoadEnemyShotData(gstd::script_machine* machine
 }
 gstd::value StgStageScript::Func_ReloadEnemyShotData(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgShotManager* shotManager = stageController->GetShotManager();
 
@@ -1368,7 +1352,7 @@ gstd::value StgStageScript::Func_ReloadEnemyShotData(gstd::script_machine* machi
 //STG共通関数：弾
 gstd::value StgStageScript::Func_DeleteShotAll(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int typeDel = (int)argv[0].as_real();
@@ -1404,7 +1388,7 @@ gstd::value StgStageScript::Func_DeleteShotAll(gstd::script_machine* machine, in
 }
 gstd::value StgStageScript::Func_DeleteShotInCircle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int typeDel = (int)argv[0].as_real();
@@ -1443,7 +1427,7 @@ gstd::value StgStageScript::Func_DeleteShotInCircle(gstd::script_machine* machin
 }
 gstd::value StgStageScript::Func_CreateShotA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	ref_count_ptr<StgNormalShotObject>::unsync obj = new StgNormalShotObject(stageController);
@@ -1472,7 +1456,7 @@ gstd::value StgStageScript::Func_CreateShotA1(gstd::script_machine* machine, int
 }
 gstd::value StgStageScript::Func_CreateShotA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	ref_count_ptr<StgNormalShotObject>::unsync obj = new StgNormalShotObject(stageController);
@@ -1498,7 +1482,7 @@ gstd::value StgStageScript::Func_CreateShotA2(gstd::script_machine* machine, int
 		obj->SetDelay(delay);
 		obj->SetOwnerType(typeOwner);
 
-		StgMoveObject* objMove = (StgMoveObject*)obj.GetPointer();
+		auto* objMove = (StgMoveObject*)obj.GetPointer();
 		StgMovePattern_Angle* pattern = (StgMovePattern_Angle*)objMove->GetPattern().GetPointer();
 		pattern->SetAcceleration(accele);
 		pattern->SetMaxSpeed(maxSpeed);
@@ -1508,12 +1492,12 @@ gstd::value StgStageScript::Func_CreateShotA2(gstd::script_machine* machine, int
 }
 gstd::value StgStageScript::Func_CreateShotOA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int tId = (int)argv[0].as_real();
-	DxScriptRenderObject* tObj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(tId));
-	if (tObj == NULL)
+	auto* tObj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(tId));
+	if (tObj == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)ID_INVALID);
 
 	double posX = tObj->GetPosition().x;
@@ -1543,7 +1527,7 @@ gstd::value StgStageScript::Func_CreateShotOA1(gstd::script_machine* machine, in
 }
 gstd::value StgStageScript::Func_CreateShotB1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	ref_count_ptr<StgNormalShotObject>::unsync obj = new StgNormalShotObject(stageController);
@@ -1575,7 +1559,7 @@ gstd::value StgStageScript::Func_CreateShotB1(gstd::script_machine* machine, int
 }
 gstd::value StgStageScript::Func_CreateShotB2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	ref_count_ptr<StgNormalShotObject>::unsync obj = new StgNormalShotObject(stageController);
@@ -1615,12 +1599,12 @@ gstd::value StgStageScript::Func_CreateShotB2(gstd::script_machine* machine, int
 }
 gstd::value StgStageScript::Func_CreateShotOB1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int tId = (int)argv[0].as_real();
-	DxScriptRenderObject* tObj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(tId));
-	if (tObj == NULL)
+	auto* tObj = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(tId));
+	if (tObj == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)ID_INVALID);
 
 	double posX = tObj->GetPosition().x;
@@ -1654,7 +1638,7 @@ gstd::value StgStageScript::Func_CreateShotOB1(gstd::script_machine* machine, in
 
 gstd::value StgStageScript::Func_CreateLooseLaserA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	ref_count_ptr<StgLooseLaserObject>::unsync obj = new StgLooseLaserObject(stageController);
@@ -1688,7 +1672,7 @@ gstd::value StgStageScript::Func_CreateLooseLaserA1(gstd::script_machine* machin
 
 gstd::value StgStageScript::Func_CreateStraightLaserA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	ref_count_ptr<StgStraightLaserObject>::unsync obj = new StgStraightLaserObject(stageController);
@@ -1720,7 +1704,7 @@ gstd::value StgStageScript::Func_CreateStraightLaserA1(gstd::script_machine* mac
 }
 gstd::value StgStageScript::Func_CreateCurveLaserA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	ref_count_ptr<StgCurveLaserObject>::unsync obj = new StgCurveLaserObject(stageController);
@@ -1754,7 +1738,7 @@ gstd::value StgStageScript::Func_CreateCurveLaserA1(gstd::script_machine* machin
 
 gstd::value StgStageScript::Func_SetShotIntersectionCircle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int typeTarget = script->GetScriptType() == TYPE_PLAYER ? StgIntersectionTarget::TYPE_PLAYER_SHOT : StgIntersectionTarget::TYPE_ENEMY_SHOT;
@@ -1776,7 +1760,7 @@ gstd::value StgStageScript::Func_SetShotIntersectionCircle(gstd::script_machine*
 }
 gstd::value StgStageScript::Func_SetShotIntersectionLine(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int typeTarget = script->GetScriptType() == TYPE_PLAYER ? StgIntersectionTarget::TYPE_PLAYER_SHOT : StgIntersectionTarget::TYPE_ENEMY_SHOT;
@@ -1800,7 +1784,7 @@ gstd::value StgStageScript::Func_SetShotIntersectionLine(gstd::script_machine* m
 }
 gstd::value StgStageScript::Func_GetShotIdInCircleA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	StgShotManager* shotManager = stageController->GetShotManager();
@@ -1811,15 +1795,15 @@ gstd::value StgStageScript::Func_GetShotIdInCircleA1(gstd::script_machine* machi
 
 	std::vector<int> listID = shotManager->GetShotIdInCircle(typeOwner, px, py, radius);
 	std::vector<long double> listRes;
-	for (int iID = 0; iID < listID.size(); iID++)
-		listRes.push_back(listID[iID]);
+	for (int iID : listID)
+		listRes.push_back(iID);
 	gstd::value res = script->CreateRealArrayValue(listRes);
 
 	return res;
 }
 gstd::value StgStageScript::Func_GetShotIdInCircleA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	StgShotManager* shotManager = stageController->GetShotManager();
@@ -1843,15 +1827,15 @@ gstd::value StgStageScript::Func_GetShotIdInCircleA2(gstd::script_machine* machi
 
 	std::vector<int> listID = shotManager->GetShotIdInCircle(typeOwner, px, py, radius);
 	std::vector<long double> listRes;
-	for (int iID = 0; iID < listID.size(); iID++)
-		listRes.push_back(listID[iID]);
+	for (int iID : listID)
+		listRes.push_back(iID);
 	gstd::value res = script->CreateRealArrayValue(listRes);
 
 	return res;
 }
 gstd::value StgStageScript::Func_GetShotCount(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgShotManager* shotManager = stageController->GetShotManager();
 
@@ -1874,7 +1858,7 @@ gstd::value StgStageScript::Func_GetShotCount(gstd::script_machine* machine, int
 }
 gstd::value StgStageScript::Func_SetShotAutoDeleteClip(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgStageInformation> infoStage = stageController->GetStageInformation();
 
@@ -1889,7 +1873,7 @@ gstd::value StgStageScript::Func_SetShotAutoDeleteClip(gstd::script_machine* mac
 }
 gstd::value StgStageScript::Func_GetShotDataInfoA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	ref_count_ptr<StgStageInformation> infoStage = stageController->GetStageInformation();
 
@@ -1900,11 +1884,11 @@ gstd::value StgStageScript::Func_GetShotDataInfoA1(gstd::script_machine* machine
 	StgShotManager* shotManager = stageController->GetShotManager();
 	StgShotDataList* dataList = (target == TARGET_PLAYER) ? shotManager->GetPlayerShotDataList() : shotManager->GetEnemyShotDataList();
 
-	ref_count_ptr<StgShotData>::unsync shotData = NULL;
-	if (dataList != NULL)
+	ref_count_ptr<StgShotData>::unsync shotData = nullptr;
+	if (dataList != nullptr)
 		shotData = dataList->GetData(idShot);
 
-	if (shotData == NULL)
+	if (shotData == nullptr)
 		script->RaiseError(ErrorUtility::GetErrorMessage(ErrorUtility::ERROR_OUTOFRANGE_INDEX));
 
 	gstd::value res;
@@ -1943,7 +1927,7 @@ gstd::value StgStageScript::Func_GetShotDataInfoA1(gstd::script_machine* machine
 	case INFO_COLLISION: {
 		double radius = 0;
 		std::vector<DxCircle>* listCircle = shotData->GetIntersectionCircleList();
-		if (listCircle->size() > 0) {
+		if (!listCircle->empty()) {
 			DxCircle circle = listCircle->at(0);
 			radius = circle.GetR();
 		}
@@ -1954,8 +1938,7 @@ gstd::value StgStageScript::Func_GetShotDataInfoA1(gstd::script_machine* machine
 	case INFO_COLLISION_LIST: {
 		std::vector<DxCircle>* listCircle = shotData->GetIntersectionCircleList();
 		std::vector<gstd::value> listValue;
-		for (int iCircle = 0; iCircle < listCircle->size(); iCircle++) {
-			DxCircle circle = listCircle->at(iCircle);
+		for (auto circle : *listCircle) {
 			std::vector<long double> list;
 			list.push_back(circle.GetR());
 			list.push_back(circle.GetX());
@@ -1972,7 +1955,7 @@ gstd::value StgStageScript::Func_GetShotDataInfoA1(gstd::script_machine* machine
 }
 gstd::value StgStageScript::Func_StartShotScript(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgStageScriptManager* scriptManager = stageController->GetScriptManagerP();
 
@@ -1983,7 +1966,7 @@ gstd::value StgStageScript::Func_StartShotScript(gstd::script_machine* machine, 
 	path = PathProperty::GetUnique(path);
 
 	int type = script->GetScriptType();
-	_int64 idScript = scriptManager->LoadScript(path, StgStageScript::TYPE_SHOT);
+	int64_t idScript = scriptManager->LoadScript(path, StgStageScript::TYPE_SHOT);
 	scriptManager->StartScript(idScript);
 	scriptManager->SetShotScriptID(idScript);
 	return value();
@@ -1992,7 +1975,7 @@ gstd::value StgStageScript::Func_StartShotScript(gstd::script_machine* machine, 
 //STG共通関数：アイテム
 gstd::value StgStageScript::Func_CreateItemA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgItemManager* itemManager = stageController->GetItemManager();
 
@@ -2014,7 +1997,7 @@ gstd::value StgStageScript::Func_CreateItemA1(gstd::script_machine* machine, int
 }
 gstd::value StgStageScript::Func_CreateItemA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgItemManager* itemManager = stageController->GetItemManager();
 
@@ -2036,7 +2019,7 @@ gstd::value StgStageScript::Func_CreateItemA2(gstd::script_machine* machine, int
 }
 gstd::value StgStageScript::Func_CreateItemU1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgItemManager* itemManager = stageController->GetItemManager();
 
@@ -2062,7 +2045,7 @@ gstd::value StgStageScript::Func_CreateItemU1(gstd::script_machine* machine, int
 }
 gstd::value StgStageScript::Func_CreateItemU2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgItemManager* itemManager = stageController->GetItemManager();
 
@@ -2087,7 +2070,7 @@ gstd::value StgStageScript::Func_CreateItemU2(gstd::script_machine* machine, int
 }
 gstd::value StgStageScript::Func_CreateItemScore(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgItemManager* itemManager = stageController->GetItemManager();
 
@@ -2108,7 +2091,7 @@ gstd::value StgStageScript::Func_CreateItemScore(gstd::script_machine* machine, 
 }
 gstd::value StgStageScript::Func_CollectAllItems(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgItemManager* itemManager = stageController->GetItemManager();
 	itemManager->CollectItemsAll();
@@ -2117,7 +2100,7 @@ gstd::value StgStageScript::Func_CollectAllItems(gstd::script_machine* machine, 
 }
 gstd::value StgStageScript::Func_CollectItemsByType(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgItemManager* itemManager = stageController->GetItemManager();
 
@@ -2127,7 +2110,7 @@ gstd::value StgStageScript::Func_CollectItemsByType(gstd::script_machine* machin
 }
 gstd::value StgStageScript::Func_CollectItemsInCircle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgItemManager* itemManager = stageController->GetItemManager();
 
@@ -2140,7 +2123,7 @@ gstd::value StgStageScript::Func_CollectItemsInCircle(gstd::script_machine* mach
 }
 gstd::value StgStageScript::Func_CancelCollectItems(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgItemManager* itemManager = stageController->GetItemManager();
 
@@ -2149,7 +2132,7 @@ gstd::value StgStageScript::Func_CancelCollectItems(gstd::script_machine* machin
 }
 gstd::value StgStageScript::Func_StartItemScript(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgStageScriptManager* scriptManager = stageController->GetScriptManagerP();
 
@@ -2160,14 +2143,14 @@ gstd::value StgStageScript::Func_StartItemScript(gstd::script_machine* machine, 
 	path = PathProperty::GetUnique(path);
 
 	int type = script->GetScriptType();
-	_int64 idScript = scriptManager->LoadScript(path, StgStageScript::TYPE_ITEM);
+	int64_t idScript = scriptManager->LoadScript(path, StgStageScript::TYPE_ITEM);
 	scriptManager->StartScript(idScript);
 	scriptManager->SetItemScriptID(idScript);
 	return value();
 }
 gstd::value StgStageScript::Func_SetDefaultBonusItemEnable(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgItemManager* itemManager = stageController->GetItemManager();
 
@@ -2177,7 +2160,7 @@ gstd::value StgStageScript::Func_SetDefaultBonusItemEnable(gstd::script_machine*
 }
 gstd::value StgStageScript::Func_LoadItemData(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgItemManager* itemManager = stageController->GetItemManager();
 
@@ -2189,7 +2172,7 @@ gstd::value StgStageScript::Func_LoadItemData(gstd::script_machine* machine, int
 }
 gstd::value StgStageScript::Func_ReloadItemData(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgItemManager* itemManager = stageController->GetItemManager();
 
@@ -2203,7 +2186,7 @@ gstd::value StgStageScript::Func_ReloadItemData(gstd::script_machine* machine, i
 //STG共通関数：その他
 gstd::value StgStageScript::Func_StartSlow(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int target = (int)argv[0].as_real();
@@ -2219,7 +2202,7 @@ gstd::value StgStageScript::Func_StartSlow(gstd::script_machine* machine, int ar
 }
 gstd::value StgStageScript::Func_StopSlow(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int target = (int)argv[0].as_real();
@@ -2251,16 +2234,16 @@ gstd::value StgStageScript::Func_IsIntersected_Line_Circle(gstd::script_machine*
 }
 gstd::value StgStageScript::Func_IsIntersected_Obj_Obj(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id1 = (int)argv[0].as_real();
 	int id2 = (int)argv[1].as_real();
 
-	StgShotObject* obj1 = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id1));
-	if (obj1 == NULL)
+	auto* obj1 = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id1));
+	if (obj1 == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
-	StgShotObject* obj2 = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id2));
-	if (obj2 == NULL)
+	auto* obj2 = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id2));
+	if (obj2 == nullptr)
 		return value(machine->get_engine()->get_boolean_type(), false);
 
 	std::vector<ref_count_ptr<StgIntersectionTarget>::unsync> listTaget1 = obj1->GetIntersectionTargetList();
@@ -2280,17 +2263,17 @@ gstd::value StgStageScript::Func_IsIntersected_Obj_Obj(gstd::script_machine* mac
 //STD共通関数：移動オブジェクト操作
 gstd::value StgStageScript::Func_ObjMove_SetX(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double pos = argv[1].as_real();
 	obj->SetPositionX(pos);
 
-	DxScriptRenderObject* objR = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (objR == NULL)
+	auto* objR = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (objR == nullptr)
 		return value();
 	objR->SetX(pos);
 
@@ -2298,17 +2281,17 @@ gstd::value StgStageScript::Func_ObjMove_SetX(gstd::script_machine* machine, int
 }
 gstd::value StgStageScript::Func_ObjMove_SetY(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double pos = argv[1].as_real();
 	obj->SetPositionY(pos);
 
-	DxScriptRenderObject* objR = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (objR == NULL)
+	auto* objR = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (objR == nullptr)
 		return value();
 	objR->SetY(pos);
 
@@ -2316,10 +2299,10 @@ gstd::value StgStageScript::Func_ObjMove_SetY(gstd::script_machine* machine, int
 }
 gstd::value StgStageScript::Func_ObjMove_SetPosition(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double posX = argv[1].as_real();
@@ -2327,8 +2310,8 @@ gstd::value StgStageScript::Func_ObjMove_SetPosition(gstd::script_machine* machi
 	obj->SetPositionX(posX);
 	obj->SetPositionY(posY);
 
-	DxScriptRenderObject* objR = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
-	if (objR == NULL)
+	auto* objR = dynamic_cast<DxScriptRenderObject*>(script->GetObjectPointer(id));
+	if (objR == nullptr)
 		return value();
 	objR->SetX(posX);
 	objR->SetY(posY);
@@ -2337,10 +2320,10 @@ gstd::value StgStageScript::Func_ObjMove_SetPosition(gstd::script_machine* machi
 }
 gstd::value StgStageScript::Func_ObjMove_SetSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double speed = argv[1].as_real();
@@ -2349,10 +2332,10 @@ gstd::value StgStageScript::Func_ObjMove_SetSpeed(gstd::script_machine* machine,
 }
 gstd::value StgStageScript::Func_ObjMove_SetAngle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double angle = argv[1].as_real();
@@ -2361,13 +2344,13 @@ gstd::value StgStageScript::Func_ObjMove_SetAngle(gstd::script_machine* machine,
 }
 gstd::value StgStageScript::Func_ObjMove_SetAcceleration(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<StgMovePattern_Angle>::unsync pattern = ref_count_ptr<StgMovePattern_Angle>::unsync::DownCast(obj->GetPattern());
-	if (pattern == NULL) {
+	if (pattern == nullptr) {
 		pattern = new StgMovePattern_Angle(obj);
 		obj->SetPattern(pattern);
 	}
@@ -2378,13 +2361,13 @@ gstd::value StgStageScript::Func_ObjMove_SetAcceleration(gstd::script_machine* m
 }
 gstd::value StgStageScript::Func_ObjMove_SetAngularVelocity(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<StgMovePattern_Angle>::unsync pattern = ref_count_ptr<StgMovePattern_Angle>::unsync::DownCast(obj->GetPattern());
-	if (pattern == NULL) {
+	if (pattern == nullptr) {
 		pattern = new StgMovePattern_Angle(obj);
 		obj->SetPattern(pattern);
 	}
@@ -2395,13 +2378,13 @@ gstd::value StgStageScript::Func_ObjMove_SetAngularVelocity(gstd::script_machine
 }
 gstd::value StgStageScript::Func_ObjMove_SetMaxSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<StgMovePattern_Angle>::unsync pattern = ref_count_ptr<StgMovePattern_Angle>::unsync::DownCast(obj->GetPattern());
-	if (pattern == NULL) {
+	if (pattern == nullptr) {
 		pattern = new StgMovePattern_Angle(obj);
 		obj->SetPattern(pattern);
 	}
@@ -2413,10 +2396,10 @@ gstd::value StgStageScript::Func_ObjMove_SetMaxSpeed(gstd::script_machine* machi
 
 gstd::value StgStageScript::Func_ObjMove_SetDestAtSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double tx = argv[1].as_real();
@@ -2431,10 +2414,10 @@ gstd::value StgStageScript::Func_ObjMove_SetDestAtSpeed(gstd::script_machine* ma
 }
 gstd::value StgStageScript::Func_ObjMove_SetDestAtFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double tx = argv[1].as_real();
@@ -2449,10 +2432,10 @@ gstd::value StgStageScript::Func_ObjMove_SetDestAtFrame(gstd::script_machine* ma
 }
 gstd::value StgStageScript::Func_ObjMove_SetDestAtWeight(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double tx = argv[1].as_real();
@@ -2468,10 +2451,10 @@ gstd::value StgStageScript::Func_ObjMove_SetDestAtWeight(gstd::script_machine* m
 }
 gstd::value StgStageScript::Func_ObjMove_AddPatternA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int frame = (int)argv[1].as_real();
@@ -2487,10 +2470,10 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternA1(gstd::script_machine* mach
 }
 gstd::value StgStageScript::Func_ObjMove_AddPatternA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int frame = (int)argv[1].as_real();
@@ -2512,10 +2495,10 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternA2(gstd::script_machine* mach
 }
 gstd::value StgStageScript::Func_ObjMove_AddPatternA3(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int frame = (int)argv[1].as_real();
@@ -2539,10 +2522,10 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternA3(gstd::script_machine* mach
 }
 gstd::value StgStageScript::Func_ObjMove_AddPatternA4(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int frame = (int)argv[1].as_real();
@@ -2568,10 +2551,10 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternA4(gstd::script_machine* mach
 }
 gstd::value StgStageScript::Func_ObjMove_AddPatternB1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int frame = (int)argv[1].as_real();
@@ -2587,10 +2570,10 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternB1(gstd::script_machine* mach
 }
 gstd::value StgStageScript::Func_ObjMove_AddPatternB2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int frame = (int)argv[1].as_real();
@@ -2614,10 +2597,10 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternB2(gstd::script_machine* mach
 }
 gstd::value StgStageScript::Func_ObjMove_AddPatternB3(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int frame = (int)argv[1].as_real();
@@ -2643,10 +2626,10 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternB3(gstd::script_machine* mach
 }
 gstd::value StgStageScript::Func_ObjMove_GetX(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return script->CreateRealValue(0);
 
 	double pos = obj->GetPositionX();
@@ -2654,10 +2637,10 @@ gstd::value StgStageScript::Func_ObjMove_GetX(gstd::script_machine* machine, int
 }
 gstd::value StgStageScript::Func_ObjMove_GetY(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return script->CreateRealValue(0);
 
 	double pos = obj->GetPositionY();
@@ -2665,10 +2648,10 @@ gstd::value StgStageScript::Func_ObjMove_GetY(gstd::script_machine* machine, int
 }
 gstd::value StgStageScript::Func_ObjMove_GetSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)0);
 
 	double speed = obj->GetSpeed();
@@ -2676,10 +2659,10 @@ gstd::value StgStageScript::Func_ObjMove_GetSpeed(gstd::script_machine* machine,
 }
 gstd::value StgStageScript::Func_ObjMove_GetAngle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgMoveObject* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgMoveObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value(machine->get_engine()->get_real_type(), (long double)0);
 
 	double angle = obj->GetDirectionAngle();
@@ -2689,7 +2672,7 @@ gstd::value StgStageScript::Func_ObjMove_GetAngle(gstd::script_machine* machine,
 //STG共通関数：敵オブジェクト操作
 gstd::value StgStageScript::Func_ObjEnemy_Create(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgEnemyManager* enemyManager = stageController->GetEnemyManager();
 
@@ -2699,7 +2682,7 @@ gstd::value StgStageScript::Func_ObjEnemy_Create(gstd::script_machine* machine, 
 		obj = new StgEnemyObject(stageController);
 	} else if (type == OBJ_ENEMY_BOSS) {
 		ref_count_ptr<StgEnemyBossSceneObject>::unsync objScene = enemyManager->GetBossSceneObject();
-		if (objScene == NULL) {
+		if (objScene == nullptr) {
 			throw gstd::wexception(L"EnemyBossSceneが作成されていません");
 		}
 
@@ -2709,7 +2692,7 @@ gstd::value StgStageScript::Func_ObjEnemy_Create(gstd::script_machine* machine, 
 	}
 
 	int id = ID_INVALID;
-	if (obj != NULL) {
+	if (obj != nullptr) {
 		obj->SetObjectManager(script->objManager_.GetPointer());
 		id = script->AddObject(obj, false);
 	}
@@ -2717,13 +2700,13 @@ gstd::value StgStageScript::Func_ObjEnemy_Create(gstd::script_machine* machine, 
 }
 gstd::value StgStageScript::Func_ObjEnemy_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
 
 	ref_count_ptr<StgEnemyObject>::unsync objEnemy = ref_count_ptr<StgEnemyObject>::unsync::DownCast(stageController->GetMainRenderObject(id));
-	if (objEnemy != NULL) {
+	if (objEnemy != nullptr) {
 		StgEnemyManager* enemyManager = stageController->GetEnemyManager();
 		enemyManager->AddEnemy(objEnemy);
 		objEnemy->Activate();
@@ -2735,12 +2718,12 @@ gstd::value StgStageScript::Func_ObjEnemy_Regist(gstd::script_machine* machine, 
 }
 gstd::value StgStageScript::Func_ObjEnemy_GetInfo(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	int type = (int)argv[1].as_real();
 
-	StgEnemyObject* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
-	if (obj == NULL) {
+	auto* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr) {
 		switch (type) {
 		case INFO_LIFE:
 		case INFO_DAMAGE_RATE_SHOT:
@@ -2766,10 +2749,10 @@ gstd::value StgStageScript::Func_ObjEnemy_GetInfo(gstd::script_machine* machine,
 }
 gstd::value StgStageScript::Func_ObjEnemy_SetLife(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgEnemyObject* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double param = argv[1].as_real();
@@ -2779,10 +2762,10 @@ gstd::value StgStageScript::Func_ObjEnemy_SetLife(gstd::script_machine* machine,
 }
 gstd::value StgStageScript::Func_ObjEnemy_AddLife(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgEnemyObject* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double inc = argv[1].as_real();
@@ -2792,10 +2775,10 @@ gstd::value StgStageScript::Func_ObjEnemy_AddLife(gstd::script_machine* machine,
 }
 gstd::value StgStageScript::Func_ObjEnemy_SetDamageRate(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgEnemyObject* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgEnemyObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double rateShot = argv[1].as_real();
@@ -2806,13 +2789,13 @@ gstd::value StgStageScript::Func_ObjEnemy_SetDamageRate(gstd::script_machine* ma
 }
 gstd::value StgStageScript::Func_ObjEnemy_AddIntersectionCircleA(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 
 	int id = (int)argv[0].as_real();
 	ref_count_ptr<StgEnemyObject>::unsync obj = ref_count_ptr<StgEnemyObject>::unsync::DownCast(script->GetObject(id));
-	if (obj == NULL)
+	if (obj == nullptr)
 		return value();
 
 	int px = (int)argv[1].as_real();
@@ -2833,7 +2816,7 @@ gstd::value StgStageScript::Func_ObjEnemy_AddIntersectionCircleA(gstd::script_ma
 }
 gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToShot(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 
@@ -2860,7 +2843,7 @@ gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToShot(gstd::scri
 }
 gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToPlayer(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgIntersectionManager* intersectionManager = stageController->GetIntersectionManager();
 
@@ -2889,7 +2872,7 @@ gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToPlayer(gstd::sc
 //STG共通関数：敵ボスシーンオブジェクト操作
 gstd::value StgStageScript::Func_ObjEnemyBossScene_Create(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	script->CheckRunInMainThread();
 	StgStageController* stageController = script->stageController_;
 	StgEnemyManager* enemyManager = stageController->GetEnemyManager();
@@ -2905,7 +2888,7 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_Create(gstd::script_machine* 
 }
 gstd::value StgStageScript::Func_ObjEnemyBossScene_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
@@ -2923,10 +2906,10 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_Regist(gstd::script_machine* 
 }
 gstd::value StgStageScript::Func_ObjEnemyBossScene_Add(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgEnemyBossSceneObject* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int step = (int)argv[1].as_real();
@@ -2941,10 +2924,10 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_Add(gstd::script_machine* mac
 }
 gstd::value StgStageScript::Func_ObjEnemyBossScene_LoadInThread(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgEnemyBossSceneObject* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	obj->LoadAllScriptInThread();
@@ -2952,12 +2935,12 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_LoadInThread(gstd::script_mac
 }
 gstd::value StgStageScript::Func_ObjEnemyBossScene_GetInfo(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	int type = (int)argv[1].as_real();
 
-	StgEnemyBossSceneObject* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
-	if (obj == NULL) {
+	auto* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr) {
 		switch (type) {
 		case INFO_IS_SPELL:
 		case INFO_IS_LAST_SPELL:
@@ -3080,8 +3063,8 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_GetInfo(gstd::script_machine*
 		if (sceneData != NULL) {
 			int dataIndex = obj->GetDataIndex();
 			std::vector<double>& listLife = sceneData->GetLifeList();
-			for (int iLife = 0; iLife < listLife.size(); iLife++) {
-				res += listLife[iLife];
+			for (double life : listLife) {
+				res += life;
 			}
 		}
 		return script->CreateRealValue(res);
@@ -3092,10 +3075,10 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_GetInfo(gstd::script_machine*
 }
 gstd::value StgStageScript::Func_ObjEnemyBossScene_SetSpellTimer(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgEnemyBossSceneObject* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<StgEnemyBossSceneData>::unsync sceneData = obj->GetActiveData();
 	if (sceneData == NULL)
@@ -3107,10 +3090,10 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_SetSpellTimer(gstd::script_ma
 }
 gstd::value StgStageScript::Func_ObjEnemyBossScene_StartSpell(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgEnemyBossSceneObject* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgEnemyBossSceneObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 	ref_count_ptr<StgEnemyBossSceneData>::unsync sceneData = obj->GetActiveData();
 	if (sceneData == NULL)
@@ -3125,7 +3108,7 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_StartSpell(gstd::script_machi
 //STG共通関数：弾オブジェクト操作
 gstd::value StgStageScript::Func_ObjShot_Create(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	script->CheckRunInMainThread();
 	StgStageController* stageController = script->stageController_;
 
@@ -3153,7 +3136,7 @@ gstd::value StgStageScript::Func_ObjShot_Create(gstd::script_machine* machine, i
 }
 gstd::value StgStageScript::Func_ObjShot_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
@@ -3178,10 +3161,10 @@ gstd::value StgStageScript::Func_ObjShot_Regist(gstd::script_machine* machine, i
 
 gstd::value StgStageScript::Func_ObjShot_SetAutoDelete(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	bool bAutoDelete = argv[1].as_boolean();
@@ -3191,10 +3174,10 @@ gstd::value StgStageScript::Func_ObjShot_SetAutoDelete(gstd::script_machine* mac
 }
 gstd::value StgStageScript::Func_ObjShot_FadeDelete(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	obj->SetFadeDelete();
@@ -3203,10 +3186,10 @@ gstd::value StgStageScript::Func_ObjShot_FadeDelete(gstd::script_machine* machin
 }
 gstd::value StgStageScript::Func_ObjShot_SetDeleteFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int frame = (int)argv[1].as_real();
@@ -3216,10 +3199,10 @@ gstd::value StgStageScript::Func_ObjShot_SetDeleteFrame(gstd::script_machine* ma
 }
 gstd::value StgStageScript::Func_ObjShot_SetDelay(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int delay = (int)argv[1].as_real();
@@ -3230,10 +3213,10 @@ gstd::value StgStageScript::Func_ObjShot_SetDelay(gstd::script_machine* machine,
 
 gstd::value StgStageScript::Func_ObjShot_SetSpellResist(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	bool bRegist = argv[1].as_boolean();
@@ -3250,10 +3233,10 @@ gstd::value StgStageScript::Func_ObjShot_SetSpellResist(gstd::script_machine* ma
 }
 gstd::value StgStageScript::Func_ObjShot_SetGraphic(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int grf = (int)argv[1].as_real();
@@ -3263,10 +3246,10 @@ gstd::value StgStageScript::Func_ObjShot_SetGraphic(gstd::script_machine* machin
 }
 gstd::value StgStageScript::Func_ObjShot_SetSourceBlendType(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int typeBlend = (int)argv[1].as_real();
@@ -3276,10 +3259,10 @@ gstd::value StgStageScript::Func_ObjShot_SetSourceBlendType(gstd::script_machine
 }
 gstd::value StgStageScript::Func_ObjShot_SetDamage(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double damage = argv[1].as_real();
@@ -3289,10 +3272,10 @@ gstd::value StgStageScript::Func_ObjShot_SetDamage(gstd::script_machine* machine
 }
 gstd::value StgStageScript::Func_ObjShot_SetPenetration(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double life = argv[1].as_real();
@@ -3302,10 +3285,10 @@ gstd::value StgStageScript::Func_ObjShot_SetPenetration(gstd::script_machine* ma
 }
 gstd::value StgStageScript::Func_ObjShot_SetEraseShot(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	bool bErase = argv[1].as_boolean();
@@ -3315,10 +3298,10 @@ gstd::value StgStageScript::Func_ObjShot_SetEraseShot(gstd::script_machine* mach
 }
 gstd::value StgStageScript::Func_ObjShot_SetSpellFactor(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	bool bErase = argv[1].as_boolean();
@@ -3328,10 +3311,10 @@ gstd::value StgStageScript::Func_ObjShot_SetSpellFactor(gstd::script_machine* ma
 }
 gstd::value StgStageScript::Func_ObjShot_ToItem(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	obj->ConvertToItem();
@@ -3340,10 +3323,10 @@ gstd::value StgStageScript::Func_ObjShot_ToItem(gstd::script_machine* machine, i
 }
 gstd::value StgStageScript::Func_ObjShot_AddShotA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int idShot = (int)argv[1].as_real();
@@ -3353,10 +3336,10 @@ gstd::value StgStageScript::Func_ObjShot_AddShotA1(gstd::script_machine* machine
 }
 gstd::value StgStageScript::Func_ObjShot_AddShotA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int idShot = (int)argv[1].as_real();
@@ -3368,7 +3351,7 @@ gstd::value StgStageScript::Func_ObjShot_AddShotA2(gstd::script_machine* machine
 }
 gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
 	ref_count_ptr<StgShotObject>::unsync obj = ref_count_ptr<StgShotObject>::unsync::DownCast(script->GetObject(id));
@@ -3399,7 +3382,7 @@ gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA1(gstd::script_ma
 }
 gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
 	ref_count_ptr<StgShotObject>::unsync obj = ref_count_ptr<StgShotObject>::unsync::DownCast(script->GetObject(id));
@@ -3430,7 +3413,7 @@ gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA2(gstd::script_ma
 }
 gstd::value StgStageScript::Func_ObjShot_SetIntersectionLine(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
@@ -3464,11 +3447,11 @@ gstd::value StgStageScript::Func_ObjShot_SetIntersectionLine(gstd::script_machin
 }
 gstd::value StgStageScript::Func_ObjShot_SetIntersectionEnable(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	bool bEnable = argv[1].as_boolean();
@@ -3478,11 +3461,11 @@ gstd::value StgStageScript::Func_ObjShot_SetIntersectionEnable(gstd::script_mach
 }
 gstd::value StgStageScript::Func_ObjShot_SetItemChange(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	bool bEnable = argv[1].as_boolean();
@@ -3493,11 +3476,11 @@ gstd::value StgStageScript::Func_ObjShot_SetItemChange(gstd::script_machine* mac
 
 gstd::value StgStageScript::Func_ObjShot_GetDelay(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int res = obj->GetDelay();
@@ -3505,11 +3488,11 @@ gstd::value StgStageScript::Func_ObjShot_GetDelay(gstd::script_machine* machine,
 }
 gstd::value StgStageScript::Func_ObjShot_GetDamage(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int res = obj->GetDamage();
@@ -3517,11 +3500,11 @@ gstd::value StgStageScript::Func_ObjShot_GetDamage(gstd::script_machine* machine
 }
 gstd::value StgStageScript::Func_ObjShot_GetPenetration(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int res = obj->GetLife();
@@ -3529,11 +3512,11 @@ gstd::value StgStageScript::Func_ObjShot_GetPenetration(gstd::script_machine* ma
 }
 gstd::value StgStageScript::Func_ObjShot_IsSpellResist(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	bool res = obj->GetLife() == StgShotObject::LIFE_SPELL_REGIST;
@@ -3542,11 +3525,11 @@ gstd::value StgStageScript::Func_ObjShot_IsSpellResist(gstd::script_machine* mac
 
 gstd::value StgStageScript::Func_ObjShot_GetImageID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	int id = (int)argv[0].as_real();
-	StgShotObject* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgShotObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int res = obj->GetShotDataID();
@@ -3555,10 +3538,10 @@ gstd::value StgStageScript::Func_ObjShot_GetImageID(gstd::script_machine* machin
 
 gstd::value StgStageScript::Func_ObjLaser_SetLength(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int length = (int)argv[1].as_real();
@@ -3568,10 +3551,10 @@ gstd::value StgStageScript::Func_ObjLaser_SetLength(gstd::script_machine* machin
 }
 gstd::value StgStageScript::Func_ObjLaser_SetRenderWidth(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int width = (int)argv[1].as_real();
@@ -3581,10 +3564,10 @@ gstd::value StgStageScript::Func_ObjLaser_SetRenderWidth(gstd::script_machine* m
 }
 gstd::value StgStageScript::Func_ObjLaser_SetIntersectionWidth(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int width = (int)argv[1].as_real() / 2;
@@ -3594,10 +3577,10 @@ gstd::value StgStageScript::Func_ObjLaser_SetIntersectionWidth(gstd::script_mach
 }
 gstd::value StgStageScript::Func_ObjLaser_SetInvalidLength(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int start = (int)argv[1].as_real();
@@ -3608,10 +3591,10 @@ gstd::value StgStageScript::Func_ObjLaser_SetInvalidLength(gstd::script_machine*
 }
 gstd::value StgStageScript::Func_ObjLaser_SetGrazeInvalidFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int frame = (int)argv[1].as_real();
@@ -3621,10 +3604,10 @@ gstd::value StgStageScript::Func_ObjLaser_SetGrazeInvalidFrame(gstd::script_mach
 }
 gstd::value StgStageScript::Func_ObjLaser_SetItemDistance(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double dist = argv[1].as_real();
@@ -3634,10 +3617,10 @@ gstd::value StgStageScript::Func_ObjLaser_SetItemDistance(gstd::script_machine* 
 }
 gstd::value StgStageScript::Func_ObjLaser_GetLength(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return script->CreateRealValue(0);
 
 	int length = obj->GetLength();
@@ -3645,10 +3628,10 @@ gstd::value StgStageScript::Func_ObjLaser_GetLength(gstd::script_machine* machin
 }
 gstd::value StgStageScript::Func_ObjLaser_GetRenderWidth(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return script->CreateRealValue(0);
 
 	int width = obj->GetRenderWidth();
@@ -3656,10 +3639,10 @@ gstd::value StgStageScript::Func_ObjLaser_GetRenderWidth(gstd::script_machine* m
 }
 gstd::value StgStageScript::Func_ObjLaser_GetIntersectionWidth(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgLaserObject* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgLaserObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return script->CreateRealValue(0);
 
 	int width = obj->GetIntersectionWidth();
@@ -3667,10 +3650,10 @@ gstd::value StgStageScript::Func_ObjLaser_GetIntersectionWidth(gstd::script_mach
 }
 gstd::value StgStageScript::Func_ObjStLaser_SetAngle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgStraightLaserObject* obj = dynamic_cast<StgStraightLaserObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgStraightLaserObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double angle = argv[1].as_real();
@@ -3680,10 +3663,10 @@ gstd::value StgStageScript::Func_ObjStLaser_SetAngle(gstd::script_machine* machi
 }
 gstd::value StgStageScript::Func_ObjStLaser_GetAngle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgStraightLaserObject* obj = dynamic_cast<StgStraightLaserObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgStraightLaserObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return script->CreateRealValue(0);
 
 	double angle = obj->GetLaserAngle();
@@ -3691,10 +3674,10 @@ gstd::value StgStageScript::Func_ObjStLaser_GetAngle(gstd::script_machine* machi
 }
 gstd::value StgStageScript::Func_ObjStLaser_SetSource(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgStraightLaserObject* obj = dynamic_cast<StgStraightLaserObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgStraightLaserObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	bool bEnable = argv[1].as_boolean();
@@ -3704,10 +3687,10 @@ gstd::value StgStageScript::Func_ObjStLaser_SetSource(gstd::script_machine* mach
 }
 gstd::value StgStageScript::Func_ObjCrLaser_SetTipDecrement(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgCurveLaserObject* obj = dynamic_cast<StgCurveLaserObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgCurveLaserObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	double dec = argv[1].as_real();
@@ -3721,7 +3704,7 @@ gstd::value StgStageScript::Func_ObjCrLaser_SetTipDecrement(gstd::script_machine
 //STG共通関数：アイテムオブジェクト操作
 gstd::value StgStageScript::Func_ObjItem_Create(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	script->CheckRunInMainThread();
 	StgStageController* stageController = script->stageController_;
 
@@ -3740,7 +3723,7 @@ gstd::value StgStageScript::Func_ObjItem_Create(gstd::script_machine* machine, i
 }
 gstd::value StgStageScript::Func_ObjItem_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
@@ -3758,10 +3741,10 @@ gstd::value StgStageScript::Func_ObjItem_Regist(gstd::script_machine* machine, i
 }
 gstd::value StgStageScript::Func_ObjItem_SetItemID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgItemObject_User* obj = dynamic_cast<StgItemObject_User*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgItemObject_User*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int grf = (int)argv[1].as_real();
@@ -3771,10 +3754,10 @@ gstd::value StgStageScript::Func_ObjItem_SetItemID(gstd::script_machine* machine
 }
 gstd::value StgStageScript::Func_ObjItem_SetRenderScoreEnable(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgItemObject* obj = dynamic_cast<StgItemObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgItemObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	bool bEnable = (bool)argv[1].as_boolean();
@@ -3784,10 +3767,10 @@ gstd::value StgStageScript::Func_ObjItem_SetRenderScoreEnable(gstd::script_machi
 }
 gstd::value StgStageScript::Func_ObjItem_SetAutoCollectEnable(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgItemObject* obj = dynamic_cast<StgItemObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgItemObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	bool bEnable = (bool)argv[1].as_boolean();
@@ -3797,10 +3780,10 @@ gstd::value StgStageScript::Func_ObjItem_SetAutoCollectEnable(gstd::script_machi
 }
 gstd::value StgStageScript::Func_ObjItem_SetDefinedMovePatternA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageScript* script = (StgStageScript*)machine->data;
+	auto* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	StgItemObject* obj = dynamic_cast<StgItemObject*>(script->GetObjectPointer(id));
-	if (obj == NULL)
+	auto* obj = dynamic_cast<StgItemObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr)
 		return value();
 
 	int type = (int)argv[1].as_real();
@@ -3812,12 +3795,12 @@ gstd::value StgStageScript::Func_ObjItem_SetDefinedMovePatternA1(gstd::script_ma
 }
 gstd::value StgStageScript::Func_ObjItem_GetInfo(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	int type = (int)argv[1].as_real();
 
-	StgItemObject* obj = dynamic_cast<StgItemObject*>(script->GetObjectPointer(id));
-	if (obj == NULL) {
+	auto* obj = dynamic_cast<StgItemObject*>(script->GetObjectPointer(id));
+	if (obj == nullptr) {
 		switch (type) {
 		case INFO_ITEM_SCORE:
 			return value(machine->get_engine()->get_real_type(), (long double)0);
@@ -3836,7 +3819,7 @@ gstd::value StgStageScript::Func_ObjItem_GetInfo(gstd::script_machine* machine, 
 //STG共通関数：自機オブジェクト操作
 gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	ref_count_ptr<StgPlayerObject>::unsync obj = ref_count_ptr<StgPlayerObject>::unsync::DownCast(script->GetObject(id));
 	if (obj == NULL)
@@ -3867,7 +3850,7 @@ gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA1(gstd::script_
 }
 gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	ref_count_ptr<StgPlayerObject>::unsync obj = ref_count_ptr<StgPlayerObject>::unsync::DownCast(script->GetObject(id));
 	if (obj == NULL)
@@ -3891,7 +3874,7 @@ gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA2(gstd::script_
 }
 gstd::value StgStageScript::Func_ObjPlayer_ClearIntersection(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	ref_count_ptr<StgPlayerObject>::unsync obj = ref_count_ptr<StgPlayerObject>::unsync::DownCast(script->GetObject(id));
 	if (obj == NULL)
@@ -3904,10 +3887,10 @@ gstd::value StgStageScript::Func_ObjPlayer_ClearIntersection(gstd::script_machin
 //STG共通関数：当たり判定オブジェクト操作
 gstd::value StgStageScript::Func_ObjCol_IsIntersected(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptObjectBase* objBase = dynamic_cast<DxScriptObjectBase*>(script->GetObjectPointer(id));
-	if (objBase == NULL)
+	auto* objBase = dynamic_cast<DxScriptObjectBase*>(script->GetObjectPointer(id));
+	if (objBase == nullptr)
 		return value();
 
 	ref_count_ptr<StgIntersectionObject>::unsync obj = ref_count_ptr<StgIntersectionObject>::unsync::DownCast(script->GetObject(id));
@@ -3919,17 +3902,17 @@ gstd::value StgStageScript::Func_ObjCol_IsIntersected(gstd::script_machine* mach
 }
 gstd::value StgStageScript::Func_ObjCol_GetListOfIntersectedEnemyID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
-	DxScriptObjectBase* objBase = dynamic_cast<DxScriptObjectBase*>(script->GetObjectPointer(id));
-	if (objBase == NULL)
+	auto* objBase = dynamic_cast<DxScriptObjectBase*>(script->GetObjectPointer(id));
+	if (objBase == nullptr)
 		return value();
 
 	ref_count_ptr<StgIntersectionObject>::unsync obj = ref_count_ptr<StgIntersectionObject>::unsync::DownCast(script->GetObject(id));
 	if (obj == NULL)
 		return value();
 
-	std::vector<int>& list = obj->GetIntersectedIdList();
+	const std::vector<int>& list = obj->GetIntersectedIdList();
 	std::vector<long double> listLD;
 	for (int iList = 0; iList < list.size(); iList++) {
 		int idObject = list[iList];
@@ -3943,7 +3926,7 @@ gstd::value StgStageScript::Func_ObjCol_GetListOfIntersectedEnemyID(gstd::script
 }
 gstd::value StgStageScript::Func_ObjCol_GetIntersectedCount(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	DxScript* script = (DxScript*)machine->data;
+	auto* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
 	ref_count_ptr<StgIntersectionObject>::unsync obj = ref_count_ptr<StgIntersectionObject>::unsync::DownCast(script->GetObject(id));
 	if (obj == NULL)
@@ -3969,9 +3952,7 @@ StgStageSystemScript::StgStageSystemScript(StgStageController* stageController)
 	typeScript_ = TYPE_SYSTEM;
 	_AddFunction(stgSystemFunction, sizeof(stgSystemFunction) / sizeof(function));
 }
-StgStageSystemScript::~StgStageSystemScript()
-{
-}
+StgStageSystemScript::~StgStageSystemScript() = default;
 
 /**********************************************************
 //StgStageItemScript
@@ -3989,9 +3970,7 @@ StgStageItemScript::StgStageItemScript(StgStageController* stageController)
 	typeScript_ = TYPE_ITEM;
 	_AddFunction(stgItemFunction, sizeof(stgItemFunction) / sizeof(function));
 }
-StgStageItemScript::~StgStageItemScript()
-{
-}
+StgStageItemScript::~StgStageItemScript() = default;
 
 /**********************************************************
 //StgStageShotScript
@@ -4010,13 +3989,11 @@ StgStageShotScript::StgStageShotScript(StgStageController* stageController)
 	typeScript_ = TYPE_SHOT;
 	_AddFunction(stgShotFunction, sizeof(stgShotFunction) / sizeof(function));
 }
-StgStageShotScript::~StgStageShotScript()
-{
-}
+StgStageShotScript::~StgStageShotScript() = default;
 
 gstd::value StgStageShotScript::Func_SetShotDeleteEventEnable(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStageShotScript* script = (StgStageShotScript*)machine->data;
+	auto* script = (StgStageShotScript*)machine->data;
 	int type = (int)argv[0].as_real();
 	bool bEnable = argv[1].as_boolean();
 
@@ -4060,14 +4037,12 @@ StgStagePlayerScript::StgStagePlayerScript(StgStageController* stageController)
 	typeScript_ = TYPE_PLAYER;
 	_AddFunction(stgPlayerFunction, sizeof(stgPlayerFunction) / sizeof(function));
 }
-StgStagePlayerScript::~StgStagePlayerScript()
-{
-}
+StgStagePlayerScript::~StgStagePlayerScript() = default;
 
 //自機専用関数
 gstd::value StgStagePlayerScript::Func_CreatePlayerShotA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
+	auto* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController->GetPlayerObject();
@@ -4083,8 +4058,8 @@ gstd::value StgStagePlayerScript::Func_CreatePlayerShotA1(gstd::script_machine* 
 		long double posY = argv[1].as_real();
 		long double speed = argv[2].as_real();
 		long double angle = argv[3].as_real();
-		double damage = (double)argv[4].as_real();
-		double life = (double)argv[5].as_real();
+		auto damage = (double)argv[4].as_real();
+		auto life = (double)argv[5].as_real();
 		int idShot = (int)argv[6].as_real();
 
 		obj->SetOwnerType(StgShotObject::OWNER_PLAYER);
@@ -4101,7 +4076,7 @@ gstd::value StgStagePlayerScript::Func_CreatePlayerShotA1(gstd::script_machine* 
 }
 gstd::value StgStagePlayerScript::Func_CallSpell(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
+	auto* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController->GetPlayerObject();
@@ -4114,7 +4089,7 @@ gstd::value StgStagePlayerScript::Func_CallSpell(gstd::script_machine* machine, 
 }
 gstd::value StgStagePlayerScript::Func_LoadPlayerShotData(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
+	auto* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgShotManager* shotManager = stageController->GetShotManager();
 
@@ -4126,7 +4101,7 @@ gstd::value StgStagePlayerScript::Func_LoadPlayerShotData(gstd::script_machine* 
 }
 gstd::value StgStagePlayerScript::Func_ReloadPlayerShotData(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
+	auto* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	StgShotManager* shotManager = stageController->GetShotManager();
 
@@ -4138,7 +4113,7 @@ gstd::value StgStagePlayerScript::Func_ReloadPlayerShotData(gstd::script_machine
 }
 gstd::value StgStagePlayerScript::Func_GetSpellManageObject(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
+	auto* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	ref_count_ptr<StgPlayerObject>::unsync obj = stageController->GetPlayerObject();
@@ -4155,7 +4130,7 @@ gstd::value StgStagePlayerScript::Func_GetSpellManageObject(gstd::script_machine
 //自機専用関数：スペルオブジェクト操作
 gstd::value StgStagePlayerScript::Func_ObjSpell_Create(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
+	auto* script = (StgStagePlayerScript*)machine->data;
 	script->CheckRunInMainThread();
 	StgStageController* stageController = script->stageController_;
 
@@ -4170,7 +4145,7 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_Create(gstd::script_machine* mac
 }
 gstd::value StgStagePlayerScript::Func_ObjSpell_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
+	auto* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
@@ -4183,7 +4158,7 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_Regist(gstd::script_machine* mac
 }
 gstd::value StgStagePlayerScript::Func_ObjSpell_SetDamage(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
+	auto* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
@@ -4197,7 +4172,7 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_SetDamage(gstd::script_machine* 
 }
 gstd::value StgStagePlayerScript::Func_ObjSpell_SetPenetration(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
+	auto* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
@@ -4211,7 +4186,7 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_SetPenetration(gstd::script_mach
 }
 gstd::value StgStagePlayerScript::Func_ObjSpell_SetEraseShot(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
+	auto* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
@@ -4225,7 +4200,7 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_SetEraseShot(gstd::script_machin
 }
 gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionCircle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
+	auto* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();
@@ -4253,7 +4228,7 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionCircle(gstd::scri
 }
 gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionLine(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
-	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
+	auto* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 
 	int id = (int)argv[0].as_real();

--- a/source/TouhouDanmakufu/Common/StgStageScript.cpp
+++ b/source/TouhouDanmakufu/Common/StgStageScript.cpp
@@ -555,7 +555,7 @@ ref_count_ptr<StgStageScriptObjectManager> StgStageScript::GetStgObjectManager()
 }
 
 //STG制御共通関数：共通データ
-gstd::value StgStageScript::Func_SaveCommonDataAreaToReplayFile(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SaveCommonDataAreaToReplayFile(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -577,7 +577,7 @@ gstd::value StgStageScript::Func_SaveCommonDataAreaToReplayFile(gstd::script_mac
 
 	return value(machine->get_engine()->get_boolean_type(), true);
 }
-gstd::value StgStageScript::Func_LoadCommonDataAreaFromReplayFile(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_LoadCommonDataAreaFromReplayFile(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -601,7 +601,7 @@ gstd::value StgStageScript::Func_LoadCommonDataAreaFromReplayFile(gstd::script_m
 }
 
 //STG共通関数：システム関連
-gstd::value StgStageScript::Func_GetMainStgScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetMainStgScriptPath(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -612,7 +612,7 @@ gstd::value StgStageScript::Func_GetMainStgScriptPath(gstd::script_machine* mach
 
 	return value(machine->get_engine()->get_string_type(), path);
 }
-gstd::value StgStageScript::Func_GetMainStgScriptDirectory(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetMainStgScriptDirectory(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -625,7 +625,7 @@ gstd::value StgStageScript::Func_GetMainStgScriptDirectory(gstd::script_machine*
 
 	return value(machine->get_engine()->get_string_type(), dir);
 }
-gstd::value StgStageScript::Func_SetStgFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetStgFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -646,7 +646,7 @@ gstd::value StgStageScript::Func_SetStgFrame(gstd::script_machine* machine, int 
 	return value();
 }
 
-gstd::value StgStageScript::Func_SetItemRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetItemRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -657,7 +657,7 @@ gstd::value StgStageScript::Func_SetItemRenderPriorityI(gstd::script_machine* ma
 	info->SetItemObjectPriority(pri);
 	return value();
 }
-gstd::value StgStageScript::Func_SetShotRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetShotRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -668,35 +668,35 @@ gstd::value StgStageScript::Func_SetShotRenderPriorityI(gstd::script_machine* ma
 	info->SetShotObjectPriority(pri);
 	return value();
 }
-gstd::value StgStageScript::Func_GetStgFrameRenderPriorityMinI(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetStgFrameRenderPriorityMinI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	long double res = stageController->GetStageInformation()->GetStgFrameMinPriority();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgStageScript::Func_GetStgFrameRenderPriorityMaxI(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetStgFrameRenderPriorityMaxI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	long double res = stageController->GetStageInformation()->GetStgFrameMaxPriority();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgStageScript::Func_GetItemRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetItemRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	long double res = stageController->GetStageInformation()->GetItemObjectPriority();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgStageScript::Func_GetShotRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetShotRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
 	long double res = stageController->GetStageInformation()->GetShotObjectPriority();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgStageScript::Func_GetPlayerRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetPlayerRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = script->GetStgObjectManager();
@@ -711,7 +711,7 @@ gstd::value StgStageScript::Func_GetPlayerRenderPriorityI(gstd::script_machine* 
 	}
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgStageScript::Func_GetCameraFocusPermitPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetCameraFocusPermitPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -719,7 +719,7 @@ gstd::value StgStageScript::Func_GetCameraFocusPermitPriorityI(gstd::script_mach
 	return value(machine->get_engine()->get_real_type(), res);
 }
 
-gstd::value StgStageScript::Func_CloseStgScene(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CloseStgScene(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgSystemController* systemController = script->stageController_->GetSystemController();
@@ -730,7 +730,7 @@ gstd::value StgStageScript::Func_CloseStgScene(gstd::script_machine* machine, in
 
 	return value();
 }
-gstd::value StgStageScript::Func_GetReplayFps(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetReplayFps(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -747,14 +747,14 @@ gstd::value StgStageScript::Func_GetReplayFps(gstd::script_machine* machine, int
 }
 
 //STG共通関数：自機
-gstd::value StgStageScript::Func_GetPlayerObjectID(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetPlayerObjectID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = script->GetStgObjectManager();
 	long double res = objectManager->GetPlayerObjectID();
 	return value(machine->get_engine()->get_real_type(), res);
 }
-gstd::value StgStageScript::Func_GetPlayerScriptID(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetPlayerScriptID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -763,7 +763,7 @@ gstd::value StgStageScript::Func_GetPlayerScriptID(gstd::script_machine* machine
 	_int64 res = scriptManager->GetPlayerScriptID();
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_SetPlayerSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetPlayerSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -777,7 +777,7 @@ gstd::value StgStageScript::Func_SetPlayerSpeed(gstd::script_machine* machine, i
 	obj->SetSlowSpeed(speedSlow);
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerClip(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetPlayerClip(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	ref_count_ptr<StgStageScriptObjectManager> objectManager = script->GetStgObjectManager();
@@ -796,7 +796,7 @@ gstd::value StgStageScript::Func_SetPlayerClip(gstd::script_machine* machine, in
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerLife(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetPlayerLife(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -809,7 +809,7 @@ gstd::value StgStageScript::Func_SetPlayerLife(gstd::script_machine* machine, in
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetPlayerSpell(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -822,7 +822,7 @@ gstd::value StgStageScript::Func_SetPlayerSpell(gstd::script_machine* machine, i
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerPower(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetPlayerPower(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -835,7 +835,7 @@ gstd::value StgStageScript::Func_SetPlayerPower(gstd::script_machine* machine, i
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -848,7 +848,7 @@ gstd::value StgStageScript::Func_SetPlayerInvincibilityFrame(gstd::script_machin
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerDownStateFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetPlayerDownStateFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -861,7 +861,7 @@ gstd::value StgStageScript::Func_SetPlayerDownStateFrame(gstd::script_machine* m
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerRebirthFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetPlayerRebirthFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -875,7 +875,7 @@ gstd::value StgStageScript::Func_SetPlayerRebirthFrame(gstd::script_machine* mac
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerRebirthLossFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetPlayerRebirthLossFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -888,7 +888,7 @@ gstd::value StgStageScript::Func_SetPlayerRebirthLossFrame(gstd::script_machine*
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetPlayerAutoItemCollectLine(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetPlayerAutoItemCollectLine(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -901,7 +901,7 @@ gstd::value StgStageScript::Func_SetPlayerAutoItemCollectLine(gstd::script_machi
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetForbidPlayerShot(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetForbidPlayerShot(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -914,7 +914,7 @@ gstd::value StgStageScript::Func_SetForbidPlayerShot(gstd::script_machine* machi
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetForbidPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetForbidPlayerSpell(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -927,7 +927,7 @@ gstd::value StgStageScript::Func_SetForbidPlayerSpell(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_GetPlayerX(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetPlayerX(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -935,7 +935,7 @@ gstd::value StgStageScript::Func_GetPlayerX(gstd::script_machine* machine, int a
 	double res = obj != NULL ? obj->GetX() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerY(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetPlayerY(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -943,7 +943,7 @@ gstd::value StgStageScript::Func_GetPlayerY(gstd::script_machine* machine, int a
 	double res = obj != NULL ? obj->GetY() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerState(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetPlayerState(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -951,7 +951,7 @@ gstd::value StgStageScript::Func_GetPlayerState(gstd::script_machine* machine, i
 	double res = obj != NULL ? obj->GetState() : StgPlayerObject::STATE_END;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetPlayerSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -964,7 +964,7 @@ gstd::value StgStageScript::Func_GetPlayerSpeed(gstd::script_machine* machine, i
 	gstd::value res = script->CreateRealArrayValue(listValue);
 	return res;
 }
-gstd::value StgStageScript::Func_GetPlayerClip(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetPlayerClip(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -980,7 +980,7 @@ gstd::value StgStageScript::Func_GetPlayerClip(gstd::script_machine* machine, in
 	gstd::value res = script->CreateRealArrayValue(listValue);
 	return res;
 }
-gstd::value StgStageScript::Func_GetPlayerLife(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetPlayerLife(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -988,7 +988,7 @@ gstd::value StgStageScript::Func_GetPlayerLife(gstd::script_machine* machine, in
 	double res = obj != NULL ? obj->GetLife() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetPlayerSpell(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -996,7 +996,7 @@ gstd::value StgStageScript::Func_GetPlayerSpell(gstd::script_machine* machine, i
 	double res = obj != NULL ? obj->GetSpell() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerPower(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetPlayerPower(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1004,7 +1004,7 @@ gstd::value StgStageScript::Func_GetPlayerPower(gstd::script_machine* machine, i
 	double res = obj != NULL ? obj->GetPower() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1012,7 +1012,7 @@ gstd::value StgStageScript::Func_GetPlayerInvincibilityFrame(gstd::script_machin
 	double res = obj != NULL ? obj->GetInvincibilityFrame() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerDownStateFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetPlayerDownStateFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1020,7 +1020,7 @@ gstd::value StgStageScript::Func_GetPlayerDownStateFrame(gstd::script_machine* m
 	double res = obj != NULL ? obj->GetDownStateFrame() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetPlayerRebirthFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetPlayerRebirthFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1028,7 +1028,7 @@ gstd::value StgStageScript::Func_GetPlayerRebirthFrame(gstd::script_machine* mac
 	double res = obj != NULL ? obj->GetRebirthFrame() : 0;
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetAngleToPlayer(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetAngleToPlayer(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1049,7 +1049,7 @@ gstd::value StgStageScript::Func_GetAngleToPlayer(gstd::script_machine* machine,
 	return value(machine->get_engine()->get_real_type(), (long double)angle);
 }
 
-gstd::value StgStageScript::Func_IsPermitPlayerShot(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_IsPermitPlayerShot(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1057,7 +1057,7 @@ gstd::value StgStageScript::Func_IsPermitPlayerShot(gstd::script_machine* machin
 	bool res = obj != NULL ? obj->IsPermitShot() : false;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStageScript::Func_IsPermitPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_IsPermitPlayerSpell(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1065,7 +1065,7 @@ gstd::value StgStageScript::Func_IsPermitPlayerSpell(gstd::script_machine* machi
 	bool res = obj != NULL ? obj->IsPermitSpell() : false;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStageScript::Func_IsPlayerLastSpellWait(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_IsPlayerLastSpellWait(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1073,7 +1073,7 @@ gstd::value StgStageScript::Func_IsPlayerLastSpellWait(gstd::script_machine* mac
 	bool res = obj != NULL ? obj->IsWaitLastSpell() : false;
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStageScript::Func_IsPlayerSpellActive(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_IsPlayerSpellActive(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1088,7 +1088,7 @@ gstd::value StgStageScript::Func_IsPlayerSpellActive(gstd::script_machine* machi
 }
 
 //STG共通関数：敵
-gstd::value StgStageScript::Func_GetEnemyBossSceneObjectID(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetEnemyBossSceneObjectID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1101,7 +1101,7 @@ gstd::value StgStageScript::Func_GetEnemyBossSceneObjectID(gstd::script_machine*
 
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_GetEnemyBossObjectID(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetEnemyBossObjectID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1112,7 +1112,7 @@ gstd::value StgStageScript::Func_GetEnemyBossObjectID(gstd::script_machine* mach
 	if (scene != NULL) {
 		ref_count_ptr<StgEnemyBossSceneData>::unsync data = scene->GetActiveData();
 		if (data != NULL) {
-			std::vector<ref_count_ptr<StgEnemyBossObject>::unsync> listEnemy = data->GetEnemyObjectList();
+			const std::vector<ref_count_ptr<StgEnemyBossObject>::unsync>& listEnemy = data->GetEnemyObjectList();
 			for (int iEnemy = 0; iEnemy < listEnemy.size(); iEnemy++) {
 				ref_count_ptr<StgEnemyBossObject>::unsync obj = listEnemy[iEnemy];
 				if (obj->IsDeleted())
@@ -1125,7 +1125,7 @@ gstd::value StgStageScript::Func_GetEnemyBossObjectID(gstd::script_machine* mach
 
 	return script->CreateRealArrayValue(listLD);
 }
-gstd::value StgStageScript::Func_GetAllEnemyID(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetAllEnemyID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1145,7 +1145,7 @@ gstd::value StgStageScript::Func_GetAllEnemyID(gstd::script_machine* machine, in
 
 	return script->CreateRealArrayValue(listLD);
 }
-gstd::value StgStageScript::Func_GetIntersectionRegistedEnemyID(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetIntersectionRegistedEnemyID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1161,7 +1161,7 @@ gstd::value StgStageScript::Func_GetIntersectionRegistedEnemyID(gstd::script_mac
 
 	return script->CreateRealArrayValue(listLD);
 }
-gstd::value StgStageScript::Func_GetAllEnemyIntersectionPosition(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetAllEnemyIntersectionPosition(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1180,7 +1180,7 @@ gstd::value StgStageScript::Func_GetAllEnemyIntersectionPosition(gstd::script_ma
 	}
 	return script->CreateValueArrayValue(listV);
 }
-gstd::value StgStageScript::Func_GetEnemyIntersectionPosition(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetEnemyIntersectionPosition(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1256,7 +1256,7 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPosition(gstd::script_machi
 	}
 	return script->CreateValueArrayValue(listV);
 }
-gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	//引数1（敵オブジェクトID）自機からもアクセス可能
 	//指定した敵オブジェクトIDが持つ自機ショットへの当たり判定位置を全て取得
@@ -1296,7 +1296,7 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA1(gstd::script
 
 	return script->CreateValueArrayValue(listV);
 }
-gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	//引数3（敵オブジェクトID・x座標・y座標）自機からもアクセス可能
 	//指定した敵オブジェクトIDが持つ、自機ショットへの当たり判定のうち、指定座標に最も近い1つを取得
@@ -1338,7 +1338,7 @@ gstd::value StgStageScript::Func_GetEnemyIntersectionPositionByIdA2(gstd::script
 	return script->CreateValueArrayValue(listV);
 }
 
-gstd::value StgStageScript::Func_LoadEnemyShotData(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_LoadEnemyShotData(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1351,7 +1351,7 @@ gstd::value StgStageScript::Func_LoadEnemyShotData(gstd::script_machine* machine
 
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStageScript::Func_ReloadEnemyShotData(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ReloadEnemyShotData(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1366,7 +1366,7 @@ gstd::value StgStageScript::Func_ReloadEnemyShotData(gstd::script_machine* machi
 }
 
 //STG共通関数：弾
-gstd::value StgStageScript::Func_DeleteShotAll(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_DeleteShotAll(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1402,7 +1402,7 @@ gstd::value StgStageScript::Func_DeleteShotAll(gstd::script_machine* machine, in
 
 	return value();
 }
-gstd::value StgStageScript::Func_DeleteShotInCircle(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_DeleteShotInCircle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1441,7 +1441,7 @@ gstd::value StgStageScript::Func_DeleteShotInCircle(gstd::script_machine* machin
 
 	return value();
 }
-gstd::value StgStageScript::Func_CreateShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CreateShotA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1470,7 +1470,7 @@ gstd::value StgStageScript::Func_CreateShotA1(gstd::script_machine* machine, int
 
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateShotA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CreateShotA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1506,7 +1506,7 @@ gstd::value StgStageScript::Func_CreateShotA2(gstd::script_machine* machine, int
 
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateShotOA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CreateShotOA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1541,7 +1541,7 @@ gstd::value StgStageScript::Func_CreateShotOA1(gstd::script_machine* machine, in
 
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateShotB1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CreateShotB1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1573,7 +1573,7 @@ gstd::value StgStageScript::Func_CreateShotB1(gstd::script_machine* machine, int
 
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateShotB2(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CreateShotB2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1613,7 +1613,7 @@ gstd::value StgStageScript::Func_CreateShotB2(gstd::script_machine* machine, int
 
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateShotOB1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CreateShotOB1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1652,7 +1652,7 @@ gstd::value StgStageScript::Func_CreateShotOB1(gstd::script_machine* machine, in
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
 
-gstd::value StgStageScript::Func_CreateLooseLaserA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CreateLooseLaserA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1686,7 +1686,7 @@ gstd::value StgStageScript::Func_CreateLooseLaserA1(gstd::script_machine* machin
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
 
-gstd::value StgStageScript::Func_CreateStraightLaserA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CreateStraightLaserA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1718,7 +1718,7 @@ gstd::value StgStageScript::Func_CreateStraightLaserA1(gstd::script_machine* mac
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateCurveLaserA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CreateCurveLaserA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1752,7 +1752,7 @@ gstd::value StgStageScript::Func_CreateCurveLaserA1(gstd::script_machine* machin
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
 
-gstd::value StgStageScript::Func_SetShotIntersectionCircle(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetShotIntersectionCircle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1774,7 +1774,7 @@ gstd::value StgStageScript::Func_SetShotIntersectionCircle(gstd::script_machine*
 
 	return value();
 }
-gstd::value StgStageScript::Func_SetShotIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetShotIntersectionLine(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1798,7 +1798,7 @@ gstd::value StgStageScript::Func_SetShotIntersectionLine(gstd::script_machine* m
 
 	return value();
 }
-gstd::value StgStageScript::Func_GetShotIdInCircleA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetShotIdInCircleA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1817,7 +1817,7 @@ gstd::value StgStageScript::Func_GetShotIdInCircleA1(gstd::script_machine* machi
 
 	return res;
 }
-gstd::value StgStageScript::Func_GetShotIdInCircleA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetShotIdInCircleA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1849,7 +1849,7 @@ gstd::value StgStageScript::Func_GetShotIdInCircleA2(gstd::script_machine* machi
 
 	return res;
 }
-gstd::value StgStageScript::Func_GetShotCount(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetShotCount(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1872,7 +1872,7 @@ gstd::value StgStageScript::Func_GetShotCount(gstd::script_machine* machine, int
 	int res = shotManager->GetShotCount(typeOwner);
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_SetShotAutoDeleteClip(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetShotAutoDeleteClip(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1887,7 +1887,7 @@ gstd::value StgStageScript::Func_SetShotAutoDeleteClip(gstd::script_machine* mac
 
 	return value();
 }
-gstd::value StgStageScript::Func_GetShotDataInfoA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_GetShotDataInfoA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1970,7 +1970,7 @@ gstd::value StgStageScript::Func_GetShotDataInfoA1(gstd::script_machine* machine
 
 	return res;
 }
-gstd::value StgStageScript::Func_StartShotScript(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_StartShotScript(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -1990,7 +1990,7 @@ gstd::value StgStageScript::Func_StartShotScript(gstd::script_machine* machine, 
 }
 
 //STG共通関数：アイテム
-gstd::value StgStageScript::Func_CreateItemA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CreateItemA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2012,7 +2012,7 @@ gstd::value StgStageScript::Func_CreateItemA1(gstd::script_machine* machine, int
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateItemA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CreateItemA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2034,7 +2034,7 @@ gstd::value StgStageScript::Func_CreateItemA2(gstd::script_machine* machine, int
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateItemU1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CreateItemU1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2060,7 +2060,7 @@ gstd::value StgStageScript::Func_CreateItemU1(gstd::script_machine* machine, int
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateItemU2(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CreateItemU2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2085,7 +2085,7 @@ gstd::value StgStageScript::Func_CreateItemU2(gstd::script_machine* machine, int
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CreateItemScore(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CreateItemScore(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2106,7 +2106,7 @@ gstd::value StgStageScript::Func_CreateItemScore(gstd::script_machine* machine, 
 
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_CollectAllItems(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CollectAllItems(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2115,7 +2115,7 @@ gstd::value StgStageScript::Func_CollectAllItems(gstd::script_machine* machine, 
 
 	return value();
 }
-gstd::value StgStageScript::Func_CollectItemsByType(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CollectItemsByType(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2125,7 +2125,7 @@ gstd::value StgStageScript::Func_CollectItemsByType(gstd::script_machine* machin
 	itemManager->CollectItemsByType(type);
 	return value();
 }
-gstd::value StgStageScript::Func_CollectItemsInCircle(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CollectItemsInCircle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2138,7 +2138,7 @@ gstd::value StgStageScript::Func_CollectItemsInCircle(gstd::script_machine* mach
 	itemManager->CollectItemsInCircle(circle);
 	return value();
 }
-gstd::value StgStageScript::Func_CancelCollectItems(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_CancelCollectItems(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2147,7 +2147,7 @@ gstd::value StgStageScript::Func_CancelCollectItems(gstd::script_machine* machin
 	itemManager->CancelCollectItems();
 	return value();
 }
-gstd::value StgStageScript::Func_StartItemScript(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_StartItemScript(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2165,7 +2165,7 @@ gstd::value StgStageScript::Func_StartItemScript(gstd::script_machine* machine, 
 	scriptManager->SetItemScriptID(idScript);
 	return value();
 }
-gstd::value StgStageScript::Func_SetDefaultBonusItemEnable(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_SetDefaultBonusItemEnable(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2175,7 +2175,7 @@ gstd::value StgStageScript::Func_SetDefaultBonusItemEnable(gstd::script_machine*
 	itemManager->SetDefaultBonusItemEnable(bEnable);
 	return value();
 }
-gstd::value StgStageScript::Func_LoadItemData(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_LoadItemData(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2187,7 +2187,7 @@ gstd::value StgStageScript::Func_LoadItemData(gstd::script_machine* machine, int
 	bool res = itemManager->LoadItemData(path);
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStageScript::Func_ReloadItemData(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ReloadItemData(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2201,7 +2201,7 @@ gstd::value StgStageScript::Func_ReloadItemData(gstd::script_machine* machine, i
 }
 
 //STG共通関数：その他
-gstd::value StgStageScript::Func_StartSlow(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_StartSlow(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2217,7 +2217,7 @@ gstd::value StgStageScript::Func_StartSlow(gstd::script_machine* machine, int ar
 
 	return value();
 }
-gstd::value StgStageScript::Func_StopSlow(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_StopSlow(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2232,7 +2232,7 @@ gstd::value StgStageScript::Func_StopSlow(gstd::script_machine* machine, int arg
 
 	return value();
 }
-gstd::value StgStageScript::Func_IsIntersected_Line_Circle(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_IsIntersected_Line_Circle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxWidthLine line(
 		argv[0].as_real(),
@@ -2249,7 +2249,7 @@ gstd::value StgStageScript::Func_IsIntersected_Line_Circle(gstd::script_machine*
 	bool res = DxMath::IsIntersected(circle, line);
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStageScript::Func_IsIntersected_Obj_Obj(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_IsIntersected_Obj_Obj(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id1 = (int)argv[0].as_real();
@@ -2278,7 +2278,7 @@ gstd::value StgStageScript::Func_IsIntersected_Obj_Obj(gstd::script_machine* mac
 }
 
 //STD共通関数：移動オブジェクト操作
-gstd::value StgStageScript::Func_ObjMove_SetX(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_SetX(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2296,7 +2296,7 @@ gstd::value StgStageScript::Func_ObjMove_SetX(gstd::script_machine* machine, int
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetY(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_SetY(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2314,7 +2314,7 @@ gstd::value StgStageScript::Func_ObjMove_SetY(gstd::script_machine* machine, int
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetPosition(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_SetPosition(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2335,7 +2335,7 @@ gstd::value StgStageScript::Func_ObjMove_SetPosition(gstd::script_machine* machi
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_SetSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2347,7 +2347,7 @@ gstd::value StgStageScript::Func_ObjMove_SetSpeed(gstd::script_machine* machine,
 	obj->SetSpeed(speed);
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_SetAngle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2359,7 +2359,7 @@ gstd::value StgStageScript::Func_ObjMove_SetAngle(gstd::script_machine* machine,
 	obj->SetDirectionAngle(angle);
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetAcceleration(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_SetAcceleration(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2376,7 +2376,7 @@ gstd::value StgStageScript::Func_ObjMove_SetAcceleration(gstd::script_machine* m
 	pattern->SetAcceleration(param);
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetAngularVelocity(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_SetAngularVelocity(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2393,7 +2393,7 @@ gstd::value StgStageScript::Func_ObjMove_SetAngularVelocity(gstd::script_machine
 	pattern->SetAngularVelocity(param);
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetMaxSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_SetMaxSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2411,7 +2411,7 @@ gstd::value StgStageScript::Func_ObjMove_SetMaxSpeed(gstd::script_machine* machi
 	return value();
 }
 
-gstd::value StgStageScript::Func_ObjMove_SetDestAtSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_SetDestAtSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2429,7 +2429,7 @@ gstd::value StgStageScript::Func_ObjMove_SetDestAtSpeed(gstd::script_machine* ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetDestAtFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_SetDestAtFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2447,7 +2447,7 @@ gstd::value StgStageScript::Func_ObjMove_SetDestAtFrame(gstd::script_machine* ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_SetDestAtWeight(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_SetDestAtWeight(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2466,7 +2466,7 @@ gstd::value StgStageScript::Func_ObjMove_SetDestAtWeight(gstd::script_machine* m
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_AddPatternA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_AddPatternA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2485,7 +2485,7 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternA1(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_AddPatternA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_AddPatternA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2510,7 +2510,7 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternA2(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_AddPatternA3(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_AddPatternA3(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2537,7 +2537,7 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternA3(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_AddPatternA4(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_AddPatternA4(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2566,7 +2566,7 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternA4(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_AddPatternB1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_AddPatternB1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2585,7 +2585,7 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternB1(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_AddPatternB2(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_AddPatternB2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2612,7 +2612,7 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternB2(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_AddPatternB3(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_AddPatternB3(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2641,7 +2641,7 @@ gstd::value StgStageScript::Func_ObjMove_AddPatternB3(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjMove_GetX(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_GetX(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2652,7 +2652,7 @@ gstd::value StgStageScript::Func_ObjMove_GetX(gstd::script_machine* machine, int
 	double pos = obj->GetPositionX();
 	return value(machine->get_engine()->get_real_type(), (long double)pos);
 }
-gstd::value StgStageScript::Func_ObjMove_GetY(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_GetY(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2663,7 +2663,7 @@ gstd::value StgStageScript::Func_ObjMove_GetY(gstd::script_machine* machine, int
 	double pos = obj->GetPositionY();
 	return value(machine->get_engine()->get_real_type(), (long double)pos);
 }
-gstd::value StgStageScript::Func_ObjMove_GetSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_GetSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2674,7 +2674,7 @@ gstd::value StgStageScript::Func_ObjMove_GetSpeed(gstd::script_machine* machine,
 	double speed = obj->GetSpeed();
 	return value(machine->get_engine()->get_real_type(), (long double)speed);
 }
-gstd::value StgStageScript::Func_ObjMove_GetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjMove_GetAngle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2687,7 +2687,7 @@ gstd::value StgStageScript::Func_ObjMove_GetAngle(gstd::script_machine* machine,
 }
 
 //STG共通関数：敵オブジェクト操作
-gstd::value StgStageScript::Func_ObjEnemy_Create(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemy_Create(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2715,7 +2715,7 @@ gstd::value StgStageScript::Func_ObjEnemy_Create(gstd::script_machine* machine, 
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_ObjEnemy_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemy_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2733,7 +2733,7 @@ gstd::value StgStageScript::Func_ObjEnemy_Regist(gstd::script_machine* machine, 
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemy_GetInfo(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemy_GetInfo(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2764,7 +2764,7 @@ gstd::value StgStageScript::Func_ObjEnemy_GetInfo(gstd::script_machine* machine,
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemy_SetLife(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemy_SetLife(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2777,7 +2777,7 @@ gstd::value StgStageScript::Func_ObjEnemy_SetLife(gstd::script_machine* machine,
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemy_AddLife(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemy_AddLife(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2790,7 +2790,7 @@ gstd::value StgStageScript::Func_ObjEnemy_AddLife(gstd::script_machine* machine,
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemy_SetDamageRate(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemy_SetDamageRate(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2804,7 +2804,7 @@ gstd::value StgStageScript::Func_ObjEnemy_SetDamageRate(gstd::script_machine* ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemy_AddIntersectionCircleA(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemy_AddIntersectionCircleA(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2831,7 +2831,7 @@ gstd::value StgStageScript::Func_ObjEnemy_AddIntersectionCircleA(gstd::script_ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToShot(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToShot(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2858,7 +2858,7 @@ gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToShot(gstd::scri
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToPlayer(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToPlayer(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2887,7 +2887,7 @@ gstd::value StgStageScript::Func_ObjEnemy_SetIntersectionCircleToPlayer(gstd::sc
 }
 
 //STG共通関数：敵ボスシーンオブジェクト操作
-gstd::value StgStageScript::Func_ObjEnemyBossScene_Create(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemyBossScene_Create(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	script->CheckRunInMainThread();
@@ -2903,7 +2903,7 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_Create(gstd::script_machine* 
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_ObjEnemyBossScene_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemyBossScene_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -2921,7 +2921,7 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_Regist(gstd::script_machine* 
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemyBossScene_Add(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemyBossScene_Add(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2939,7 +2939,7 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_Add(gstd::script_machine* mac
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemyBossScene_LoadInThread(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemyBossScene_LoadInThread(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -2950,7 +2950,7 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_LoadInThread(gstd::script_mac
 	obj->LoadAllScriptInThread();
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemyBossScene_GetInfo(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemyBossScene_GetInfo(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3090,7 +3090,7 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_GetInfo(gstd::script_machine*
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemyBossScene_SetSpellTimer(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemyBossScene_SetSpellTimer(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3105,7 +3105,7 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_SetSpellTimer(gstd::script_ma
 	sceneData->SetSpellTimer(timer);
 	return value();
 }
-gstd::value StgStageScript::Func_ObjEnemyBossScene_StartSpell(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjEnemyBossScene_StartSpell(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3123,7 +3123,7 @@ gstd::value StgStageScript::Func_ObjEnemyBossScene_StartSpell(gstd::script_machi
 }
 
 //STG共通関数：弾オブジェクト操作
-gstd::value StgStageScript::Func_ObjShot_Create(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_Create(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	script->CheckRunInMainThread();
@@ -3151,7 +3151,7 @@ gstd::value StgStageScript::Func_ObjShot_Create(gstd::script_machine* machine, i
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_ObjShot_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -3176,7 +3176,7 @@ gstd::value StgStageScript::Func_ObjShot_Regist(gstd::script_machine* machine, i
 	return value();
 }
 
-gstd::value StgStageScript::Func_ObjShot_SetAutoDelete(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetAutoDelete(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3189,7 +3189,7 @@ gstd::value StgStageScript::Func_ObjShot_SetAutoDelete(gstd::script_machine* mac
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_FadeDelete(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_FadeDelete(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3201,7 +3201,7 @@ gstd::value StgStageScript::Func_ObjShot_FadeDelete(gstd::script_machine* machin
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetDeleteFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetDeleteFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3214,7 +3214,7 @@ gstd::value StgStageScript::Func_ObjShot_SetDeleteFrame(gstd::script_machine* ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetDelay(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetDelay(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3228,7 +3228,7 @@ gstd::value StgStageScript::Func_ObjShot_SetDelay(gstd::script_machine* machine,
 	return value();
 }
 
-gstd::value StgStageScript::Func_ObjShot_SetSpellResist(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetSpellResist(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3248,7 +3248,7 @@ gstd::value StgStageScript::Func_ObjShot_SetSpellResist(gstd::script_machine* ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetGraphic(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetGraphic(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3261,7 +3261,7 @@ gstd::value StgStageScript::Func_ObjShot_SetGraphic(gstd::script_machine* machin
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetSourceBlendType(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetSourceBlendType(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3274,7 +3274,7 @@ gstd::value StgStageScript::Func_ObjShot_SetSourceBlendType(gstd::script_machine
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetDamage(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetDamage(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3287,7 +3287,7 @@ gstd::value StgStageScript::Func_ObjShot_SetDamage(gstd::script_machine* machine
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetPenetration(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetPenetration(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3300,7 +3300,7 @@ gstd::value StgStageScript::Func_ObjShot_SetPenetration(gstd::script_machine* ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetEraseShot(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetEraseShot(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3313,7 +3313,7 @@ gstd::value StgStageScript::Func_ObjShot_SetEraseShot(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetSpellFactor(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetSpellFactor(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3326,7 +3326,7 @@ gstd::value StgStageScript::Func_ObjShot_SetSpellFactor(gstd::script_machine* ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_ToItem(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_ToItem(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3338,7 +3338,7 @@ gstd::value StgStageScript::Func_ObjShot_ToItem(gstd::script_machine* machine, i
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_AddShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_AddShotA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3351,7 +3351,7 @@ gstd::value StgStageScript::Func_ObjShot_AddShotA1(gstd::script_machine* machine
 	obj->AddShot(frame, idShot, 0, 0);
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_AddShotA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_AddShotA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3366,7 +3366,7 @@ gstd::value StgStageScript::Func_ObjShot_AddShotA2(gstd::script_machine* machine
 	obj->AddShot(frame, idShot, radius, angle);
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -3397,7 +3397,7 @@ gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA1(gstd::script_ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -3428,7 +3428,7 @@ gstd::value StgStageScript::Func_ObjShot_SetIntersectionCircleA2(gstd::script_ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetIntersectionLine(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -3462,7 +3462,7 @@ gstd::value StgStageScript::Func_ObjShot_SetIntersectionLine(gstd::script_machin
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetIntersectionEnable(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetIntersectionEnable(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -3476,7 +3476,7 @@ gstd::value StgStageScript::Func_ObjShot_SetIntersectionEnable(gstd::script_mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjShot_SetItemChange(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_SetItemChange(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -3491,7 +3491,7 @@ gstd::value StgStageScript::Func_ObjShot_SetItemChange(gstd::script_machine* mac
 	return value();
 }
 
-gstd::value StgStageScript::Func_ObjShot_GetDelay(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_GetDelay(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -3503,7 +3503,7 @@ gstd::value StgStageScript::Func_ObjShot_GetDelay(gstd::script_machine* machine,
 	int res = obj->GetDelay();
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_ObjShot_GetDamage(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_GetDamage(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -3515,7 +3515,7 @@ gstd::value StgStageScript::Func_ObjShot_GetDamage(gstd::script_machine* machine
 	int res = obj->GetDamage();
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_ObjShot_GetPenetration(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_GetPenetration(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -3527,7 +3527,7 @@ gstd::value StgStageScript::Func_ObjShot_GetPenetration(gstd::script_machine* ma
 	int res = obj->GetLife();
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
-gstd::value StgStageScript::Func_ObjShot_IsSpellResist(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_IsSpellResist(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -3540,7 +3540,7 @@ gstd::value StgStageScript::Func_ObjShot_IsSpellResist(gstd::script_machine* mac
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
 
-gstd::value StgStageScript::Func_ObjShot_GetImageID(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjShot_GetImageID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -3553,7 +3553,7 @@ gstd::value StgStageScript::Func_ObjShot_GetImageID(gstd::script_machine* machin
 	return value(machine->get_engine()->get_real_type(), (long double)res);
 }
 
-gstd::value StgStageScript::Func_ObjLaser_SetLength(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjLaser_SetLength(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3566,7 +3566,7 @@ gstd::value StgStageScript::Func_ObjLaser_SetLength(gstd::script_machine* machin
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjLaser_SetRenderWidth(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjLaser_SetRenderWidth(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3579,7 +3579,7 @@ gstd::value StgStageScript::Func_ObjLaser_SetRenderWidth(gstd::script_machine* m
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjLaser_SetIntersectionWidth(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjLaser_SetIntersectionWidth(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3592,7 +3592,7 @@ gstd::value StgStageScript::Func_ObjLaser_SetIntersectionWidth(gstd::script_mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjLaser_SetInvalidLength(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjLaser_SetInvalidLength(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3606,7 +3606,7 @@ gstd::value StgStageScript::Func_ObjLaser_SetInvalidLength(gstd::script_machine*
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjLaser_SetGrazeInvalidFrame(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjLaser_SetGrazeInvalidFrame(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3619,7 +3619,7 @@ gstd::value StgStageScript::Func_ObjLaser_SetGrazeInvalidFrame(gstd::script_mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjLaser_SetItemDistance(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjLaser_SetItemDistance(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3632,7 +3632,7 @@ gstd::value StgStageScript::Func_ObjLaser_SetItemDistance(gstd::script_machine* 
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjLaser_GetLength(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjLaser_GetLength(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3643,7 +3643,7 @@ gstd::value StgStageScript::Func_ObjLaser_GetLength(gstd::script_machine* machin
 	int length = obj->GetLength();
 	return value(machine->get_engine()->get_real_type(), (long double)length);
 }
-gstd::value StgStageScript::Func_ObjLaser_GetRenderWidth(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjLaser_GetRenderWidth(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3654,7 +3654,7 @@ gstd::value StgStageScript::Func_ObjLaser_GetRenderWidth(gstd::script_machine* m
 	int width = obj->GetRenderWidth();
 	return value(machine->get_engine()->get_real_type(), (long double)width);
 }
-gstd::value StgStageScript::Func_ObjLaser_GetIntersectionWidth(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjLaser_GetIntersectionWidth(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3665,7 +3665,7 @@ gstd::value StgStageScript::Func_ObjLaser_GetIntersectionWidth(gstd::script_mach
 	int width = obj->GetIntersectionWidth();
 	return value(machine->get_engine()->get_real_type(), (long double)width);
 }
-gstd::value StgStageScript::Func_ObjStLaser_SetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjStLaser_SetAngle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3678,7 +3678,7 @@ gstd::value StgStageScript::Func_ObjStLaser_SetAngle(gstd::script_machine* machi
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjStLaser_GetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjStLaser_GetAngle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3689,7 +3689,7 @@ gstd::value StgStageScript::Func_ObjStLaser_GetAngle(gstd::script_machine* machi
 	double angle = obj->GetLaserAngle();
 	return value(machine->get_engine()->get_real_type(), (long double)angle);
 }
-gstd::value StgStageScript::Func_ObjStLaser_SetSource(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjStLaser_SetSource(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3702,7 +3702,7 @@ gstd::value StgStageScript::Func_ObjStLaser_SetSource(gstd::script_machine* mach
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjCrLaser_SetTipDecrement(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjCrLaser_SetTipDecrement(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3719,7 +3719,7 @@ gstd::value StgStageScript::Func_ObjCrLaser_SetTipDecrement(gstd::script_machine
 }
 
 //STG共通関数：アイテムオブジェクト操作
-gstd::value StgStageScript::Func_ObjItem_Create(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjItem_Create(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	script->CheckRunInMainThread();
@@ -3738,7 +3738,7 @@ gstd::value StgStageScript::Func_ObjItem_Create(gstd::script_machine* machine, i
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStageScript::Func_ObjItem_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjItem_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -3756,7 +3756,7 @@ gstd::value StgStageScript::Func_ObjItem_Regist(gstd::script_machine* machine, i
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjItem_SetItemID(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjItem_SetItemID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3769,7 +3769,7 @@ gstd::value StgStageScript::Func_ObjItem_SetItemID(gstd::script_machine* machine
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjItem_SetRenderScoreEnable(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjItem_SetRenderScoreEnable(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3782,7 +3782,7 @@ gstd::value StgStageScript::Func_ObjItem_SetRenderScoreEnable(gstd::script_machi
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjItem_SetAutoCollectEnable(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjItem_SetAutoCollectEnable(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3795,7 +3795,7 @@ gstd::value StgStageScript::Func_ObjItem_SetAutoCollectEnable(gstd::script_machi
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjItem_SetDefinedMovePatternA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjItem_SetDefinedMovePatternA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageScript* script = (StgStageScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3810,7 +3810,7 @@ gstd::value StgStageScript::Func_ObjItem_SetDefinedMovePatternA1(gstd::script_ma
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjItem_GetInfo(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjItem_GetInfo(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3834,7 +3834,7 @@ gstd::value StgStageScript::Func_ObjItem_GetInfo(gstd::script_machine* machine, 
 }
 
 //STG共通関数：自機オブジェクト操作
-gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3865,7 +3865,7 @@ gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA1(gstd::script_
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA2(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA2(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3889,7 +3889,7 @@ gstd::value StgStageScript::Func_ObjPlayer_AddIntersectionCircleA2(gstd::script_
 
 	return value();
 }
-gstd::value StgStageScript::Func_ObjPlayer_ClearIntersection(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjPlayer_ClearIntersection(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3902,7 +3902,7 @@ gstd::value StgStageScript::Func_ObjPlayer_ClearIntersection(gstd::script_machin
 }
 
 //STG共通関数：当たり判定オブジェクト操作
-gstd::value StgStageScript::Func_ObjCol_IsIntersected(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjCol_IsIntersected(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3917,7 +3917,7 @@ gstd::value StgStageScript::Func_ObjCol_IsIntersected(gstd::script_machine* mach
 	bool res = obj->IsIntersected();
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStageScript::Func_ObjCol_GetListOfIntersectedEnemyID(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjCol_GetListOfIntersectedEnemyID(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3941,7 +3941,7 @@ gstd::value StgStageScript::Func_ObjCol_GetListOfIntersectedEnemyID(gstd::script
 	gstd::value res = script->CreateRealArrayValue(listLD);
 	return res;
 }
-gstd::value StgStageScript::Func_ObjCol_GetIntersectedCount(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageScript::Func_ObjCol_GetIntersectedCount(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	DxScript* script = (DxScript*)machine->data;
 	int id = (int)argv[0].as_real();
@@ -3949,7 +3949,7 @@ gstd::value StgStageScript::Func_ObjCol_GetIntersectedCount(gstd::script_machine
 	if (obj == NULL)
 		return value(machine->get_engine()->get_real_type(), (long double)0);
 
-	std::vector<int>& list = obj->GetIntersectedIdList();
+	const std::vector<int>& list = obj->GetIntersectedIdList();
 	long double res = list.size();
 	return value(machine->get_engine()->get_real_type(), res);
 }
@@ -4014,7 +4014,7 @@ StgStageShotScript::~StgStageShotScript()
 {
 }
 
-gstd::value StgStageShotScript::Func_SetShotDeleteEventEnable(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStageShotScript::Func_SetShotDeleteEventEnable(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStageShotScript* script = (StgStageShotScript*)machine->data;
 	int type = (int)argv[0].as_real();
@@ -4065,7 +4065,7 @@ StgStagePlayerScript::~StgStagePlayerScript()
 }
 
 //自機専用関数
-gstd::value StgStagePlayerScript::Func_CreatePlayerShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStagePlayerScript::Func_CreatePlayerShotA1(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -4099,7 +4099,7 @@ gstd::value StgStagePlayerScript::Func_CreatePlayerShotA1(gstd::script_machine* 
 
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStagePlayerScript::Func_CallSpell(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStagePlayerScript::Func_CallSpell(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -4112,7 +4112,7 @@ gstd::value StgStagePlayerScript::Func_CallSpell(gstd::script_machine* machine, 
 
 	return value();
 }
-gstd::value StgStagePlayerScript::Func_LoadPlayerShotData(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStagePlayerScript::Func_LoadPlayerShotData(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -4124,7 +4124,7 @@ gstd::value StgStagePlayerScript::Func_LoadPlayerShotData(gstd::script_machine* 
 	bool res = shotManager->LoadPlayerShotData(path);
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStagePlayerScript::Func_ReloadPlayerShotData(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStagePlayerScript::Func_ReloadPlayerShotData(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -4136,7 +4136,7 @@ gstd::value StgStagePlayerScript::Func_ReloadPlayerShotData(gstd::script_machine
 	bool res = shotManager->LoadPlayerShotData(path, true);
 	return value(machine->get_engine()->get_boolean_type(), res);
 }
-gstd::value StgStagePlayerScript::Func_GetSpellManageObject(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStagePlayerScript::Func_GetSpellManageObject(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -4153,7 +4153,7 @@ gstd::value StgStagePlayerScript::Func_GetSpellManageObject(gstd::script_machine
 }
 
 //自機専用関数：スペルオブジェクト操作
-gstd::value StgStagePlayerScript::Func_ObjSpell_Create(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStagePlayerScript::Func_ObjSpell_Create(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	script->CheckRunInMainThread();
@@ -4168,7 +4168,7 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_Create(gstd::script_machine* mac
 	}
 	return value(machine->get_engine()->get_real_type(), (long double)id);
 }
-gstd::value StgStagePlayerScript::Func_ObjSpell_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStagePlayerScript::Func_ObjSpell_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -4181,7 +4181,7 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_Regist(gstd::script_machine* mac
 
 	return value();
 }
-gstd::value StgStagePlayerScript::Func_ObjSpell_SetDamage(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStagePlayerScript::Func_ObjSpell_SetDamage(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -4195,7 +4195,7 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_SetDamage(gstd::script_machine* 
 	objSpell->SetDamage(damage);
 	return value();
 }
-gstd::value StgStagePlayerScript::Func_ObjSpell_SetPenetration(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStagePlayerScript::Func_ObjSpell_SetPenetration(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -4209,7 +4209,7 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_SetPenetration(gstd::script_mach
 	objSpell->SetLife(life);
 	return value();
 }
-gstd::value StgStagePlayerScript::Func_ObjSpell_SetEraseShot(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStagePlayerScript::Func_ObjSpell_SetEraseShot(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -4223,7 +4223,7 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_SetEraseShot(gstd::script_machin
 	objSpell->SetEraseShot(bEraseShot);
 	return value();
 }
-gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionCircle(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionCircle(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;
@@ -4251,7 +4251,7 @@ gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionCircle(gstd::scri
 
 	return value();
 }
-gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const* argv)
+gstd::value StgStagePlayerScript::Func_ObjSpell_SetIntersectionLine(gstd::script_machine* machine, int argc, const gstd::value* argv)
 {
 	StgStagePlayerScript* script = (StgStagePlayerScript*)machine->data;
 	StgStageController* stageController = script->stageController_;

--- a/source/TouhouDanmakufu/Common/StgStageScript.hpp
+++ b/source/TouhouDanmakufu/Common/StgStageScript.hpp
@@ -13,30 +13,30 @@ class StgStageScript;
 class StgStageScriptManager : public StgControlScriptManager {
 public:
 	StgStageScriptManager(StgStageController* stageController);
-	virtual ~StgStageScriptManager();
+	~StgStageScriptManager() override;
 
 	virtual void SetError(std::wstring error);
 	virtual bool IsError();
 
 	gstd::ref_count_ptr<StgStageScriptObjectManager> GetObjectManager() { return objManager_; }
-	virtual ref_count_ptr<ManagedScript> Create(int type);
+	ref_count_ptr<ManagedScript> Create(int type) override;
 
-	_int64 GetPlayerScriptID() const { return idPlayerScript_; }
-	void SetPlayerScriptID(_int64 id) { idPlayerScript_ = id; }
-	_int64 GetItemScriptID() const { return idItemScript_; }
-	void SetItemScriptID(_int64 id) { idItemScript_ = id; }
+	int64_t GetPlayerScriptID() const { return idPlayerScript_; }
+	void SetPlayerScriptID(int64_t id) { idPlayerScript_ = id; }
+	int64_t GetItemScriptID() const { return idItemScript_; }
+	void SetItemScriptID(int64_t id) { idItemScript_ = id; }
 	ref_count_ptr<ManagedScript> GetItemScript();
-	_int64 GetShotScriptID() const { return idShotScript_; }
-	void SetShotScriptID(_int64 id) { idShotScript_ = id; }
+	int64_t GetShotScriptID() const { return idShotScript_; }
+	void SetShotScriptID(int64_t id) { idShotScript_ = id; }
 	ref_count_ptr<ManagedScript> GetShotScript();
 
 protected:
 	StgStageController* stageController_;
 	ref_count_ptr<StgStageScriptObjectManager> objManager_;
 
-	_int64 idPlayerScript_;
-	_int64 idItemScript_;
-	_int64 idShotScript_;
+	int64_t idPlayerScript_;
+	int64_t idItemScript_;
+	int64_t idShotScript_;
 };
 
 /**********************************************************
@@ -45,7 +45,7 @@ protected:
 class StgStageScriptObjectManager : public DxScriptObjectManager {
 public:
 	StgStageScriptObjectManager(StgStageController* stageController);
-	~StgStageScriptObjectManager();
+	~StgStageScriptObjectManager() override;
 	virtual void RenderObject();
 	virtual void RenderObject(int priMin, int priMax);
 
@@ -153,7 +153,7 @@ public:
 
 public:
 	StgStageScript(StgStageController* stageController);
-	virtual ~StgStageScript();
+	~StgStageScript() override;
 
 	ref_count_ptr<StgStageScriptObjectManager> GetStgObjectManager();
 
@@ -377,7 +377,7 @@ protected:
 class StgStageSystemScript : public StgStageScript {
 public:
 	StgStageSystemScript(StgStageController* stageController);
-	virtual ~StgStageSystemScript();
+	~StgStageSystemScript() override;
 
 	//システム専用関数：システム操作
 };
@@ -393,7 +393,7 @@ public:
 
 public:
 	StgStageItemScript(StgStageController* stageController);
-	virtual ~StgStageItemScript();
+	~StgStageItemScript() override;
 
 	//システム専用関数：アイテム操作
 };
@@ -409,7 +409,7 @@ public:
 
 public:
 	StgStageShotScript(StgStageController* stageController);
-	virtual ~StgStageShotScript();
+	~StgStageShotScript() override;
 
 	//システム専用関数：アイテム操作
 	static gstd::value Func_SetShotDeleteEventEnable(gstd::script_machine* machine, int argc, const gstd::value* argv);
@@ -428,7 +428,7 @@ public:
 
 public:
 	StgStagePlayerScript(StgStageController* stageController);
-	virtual ~StgStagePlayerScript();
+	~StgStagePlayerScript() override;
 
 	//自機専用関数
 	static gstd::value Func_CreatePlayerShotA1(gstd::script_machine* machine, int argc, const gstd::value* argv);

--- a/source/TouhouDanmakufu/Common/StgStageScript.hpp
+++ b/source/TouhouDanmakufu/Common/StgStageScript.hpp
@@ -21,12 +21,12 @@ public:
 	gstd::ref_count_ptr<StgStageScriptObjectManager> GetObjectManager() { return objManager_; }
 	virtual ref_count_ptr<ManagedScript> Create(int type);
 
-	_int64 GetPlayerScriptID() { return idPlayerScript_; }
+	_int64 GetPlayerScriptID() const { return idPlayerScript_; }
 	void SetPlayerScriptID(_int64 id) { idPlayerScript_ = id; }
-	_int64 GetItemScriptID() { return idItemScript_; }
+	_int64 GetItemScriptID() const { return idItemScript_; }
 	void SetItemScriptID(_int64 id) { idItemScript_ = id; }
 	ref_count_ptr<ManagedScript> GetItemScript();
-	_int64 GetShotScriptID() { return idShotScript_; }
+	_int64 GetShotScriptID() const { return idShotScript_; }
 	void SetShotScriptID(_int64 id) { idShotScript_ = id; }
 	ref_count_ptr<ManagedScript> GetShotScript();
 
@@ -49,7 +49,7 @@ public:
 	virtual void RenderObject();
 	virtual void RenderObject(int priMin, int priMax);
 
-	int GetPlayerObjectID() { return idObjPleyer_; }
+	int GetPlayerObjectID() const { return idObjPleyer_; }
 	int CreatePlayerObject();
 
 private:
@@ -158,214 +158,214 @@ public:
 	ref_count_ptr<StgStageScriptObjectManager> GetStgObjectManager();
 
 	//STG共通関数：共通データ
-	static gstd::value Func_SaveCommonDataAreaToReplayFile(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_LoadCommonDataAreaFromReplayFile(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SaveCommonDataAreaToReplayFile(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_LoadCommonDataAreaFromReplayFile(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 	//STG共通関数：システム関連
-	static gstd::value Func_GetMainStgScriptPath(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetMainStgScriptDirectory(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetStgFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetItemRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetShotRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetStgFrameRenderPriorityMinI(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetStgFrameRenderPriorityMaxI(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetItemRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetShotRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetPlayerRenderPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetCameraFocusPermitPriorityI(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CloseStgScene(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetReplayFps(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetMainStgScriptPath(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetMainStgScriptDirectory(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetStgFrame(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetItemRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetShotRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetStgFrameRenderPriorityMinI(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetStgFrameRenderPriorityMaxI(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetItemRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetShotRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetPlayerRenderPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetCameraFocusPermitPriorityI(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CloseStgScene(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetReplayFps(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 	//STG共通関数：自機
-	static gstd::value Func_GetPlayerObjectID(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetPlayerScriptID(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetPlayerSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetPlayerClip(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetPlayerLife(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetPlayerPower(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetPlayerDownStateFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetPlayerRebirthFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetPlayerRebirthLossFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetPlayerAutoItemCollectLine(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetForbidPlayerShot(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetForbidPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetPlayerX(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetPlayerY(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetPlayerState(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetPlayerSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetPlayerClip(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetPlayerLife(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetPlayerPower(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetPlayerDownStateFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetPlayerRebirthFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetAngleToPlayer(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_IsPermitPlayerShot(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_IsPermitPlayerSpell(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_IsPlayerLastSpellWait(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_IsPlayerSpellActive(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetPlayerObjectID(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetPlayerScriptID(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetPlayerSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetPlayerClip(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetPlayerLife(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetPlayerSpell(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetPlayerPower(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetPlayerDownStateFrame(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetPlayerRebirthFrame(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetPlayerRebirthLossFrame(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetPlayerAutoItemCollectLine(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetForbidPlayerShot(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetForbidPlayerSpell(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetPlayerX(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetPlayerY(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetPlayerState(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetPlayerSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetPlayerClip(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetPlayerLife(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetPlayerSpell(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetPlayerPower(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetPlayerInvincibilityFrame(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetPlayerDownStateFrame(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetPlayerRebirthFrame(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetAngleToPlayer(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_IsPermitPlayerShot(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_IsPermitPlayerSpell(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_IsPlayerLastSpellWait(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_IsPlayerSpellActive(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 	//STG共通関数：敵
-	static gstd::value Func_GetEnemyBossSceneObjectID(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetEnemyBossObjectID(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetAllEnemyID(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetIntersectionRegistedEnemyID(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetAllEnemyIntersectionPosition(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetEnemyIntersectionPosition(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetEnemyIntersectionPositionByIdA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetEnemyIntersectionPositionByIdA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_LoadEnemyShotData(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ReloadEnemyShotData(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_GetEnemyBossSceneObjectID(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetEnemyBossObjectID(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetAllEnemyID(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetIntersectionRegistedEnemyID(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetAllEnemyIntersectionPosition(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetEnemyIntersectionPosition(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetEnemyIntersectionPositionByIdA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetEnemyIntersectionPositionByIdA2(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_LoadEnemyShotData(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ReloadEnemyShotData(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 	//STG共通関数：弾
-	static gstd::value Func_DeleteShotAll(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_DeleteShotInCircle(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CreateShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CreateShotA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CreateShotOA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CreateShotB1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CreateShotB2(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CreateShotOB1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CreateLooseLaserA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CreateStraightLaserA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CreateCurveLaserA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetShotIntersectionCircle(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetShotIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetShotIdInCircleA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetShotIdInCircleA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetShotCount(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetShotAutoDeleteClip(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetShotDataInfoA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_StartShotScript(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_DeleteShotAll(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_DeleteShotInCircle(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CreateShotA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CreateShotA2(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CreateShotOA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CreateShotB1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CreateShotB2(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CreateShotOB1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CreateLooseLaserA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CreateStraightLaserA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CreateCurveLaserA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetShotIntersectionCircle(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetShotIntersectionLine(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetShotIdInCircleA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetShotIdInCircleA2(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetShotCount(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetShotAutoDeleteClip(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetShotDataInfoA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_StartShotScript(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 	//STG共通関数：アイテム
-	static gstd::value Func_CreateItemA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CreateItemA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CreateItemU1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CreateItemU2(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CreateItemScore(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CollectAllItems(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CollectItemsByType(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CollectItemsInCircle(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CancelCollectItems(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_StartItemScript(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_SetDefaultBonusItemEnable(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_LoadItemData(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ReloadItemData(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreateItemA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CreateItemA2(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CreateItemU1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CreateItemU2(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CreateItemScore(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CollectAllItems(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CollectItemsByType(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CollectItemsInCircle(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CancelCollectItems(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_StartItemScript(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_SetDefaultBonusItemEnable(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_LoadItemData(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ReloadItemData(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 	//STG共通関数：その他
-	static gstd::value Func_StartSlow(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_StopSlow(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_IsIntersected_Line_Circle(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_IsIntersected_Obj_Obj(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_StartSlow(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_StopSlow(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_IsIntersected_Line_Circle(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_IsIntersected_Obj_Obj(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 	//STG共通関数：移動オブジェクト操作
-	static gstd::value Func_ObjMove_SetX(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_SetY(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_SetPosition(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_SetSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_SetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_SetAcceleration(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_SetMaxSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_SetAngularVelocity(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_SetDestAtSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_SetDestAtFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_SetDestAtWeight(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_AddPatternA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_AddPatternA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_AddPatternA3(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_AddPatternA4(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_AddPatternB1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_AddPatternB2(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_AddPatternB3(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_GetX(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_GetY(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_GetSpeed(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjMove_GetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjMove_SetX(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_SetY(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_SetPosition(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_SetSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_SetAngle(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_SetAcceleration(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_SetMaxSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_SetAngularVelocity(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_SetDestAtSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_SetDestAtFrame(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_SetDestAtWeight(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_AddPatternA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_AddPatternA2(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_AddPatternA3(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_AddPatternA4(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_AddPatternB1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_AddPatternB2(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_AddPatternB3(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_GetX(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_GetY(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_GetSpeed(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjMove_GetAngle(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 	//STG共通関数：敵オブジェクト操作
-	static gstd::value Func_ObjEnemy_Create(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjEnemy_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjEnemy_GetInfo(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjEnemy_SetLife(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjEnemy_AddLife(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjEnemy_SetDamageRate(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjEnemy_AddIntersectionCircleA(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjEnemy_SetIntersectionCircleToShot(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjEnemy_SetIntersectionCircleToPlayer(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemy_Create(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjEnemy_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjEnemy_GetInfo(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjEnemy_SetLife(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjEnemy_AddLife(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjEnemy_SetDamageRate(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjEnemy_AddIntersectionCircleA(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjEnemy_SetIntersectionCircleToShot(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjEnemy_SetIntersectionCircleToPlayer(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 	//STG共通関数：敵ボスシーンオブジェクト操作
-	static gstd::value Func_ObjEnemyBossScene_Create(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjEnemyBossScene_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjEnemyBossScene_Add(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjEnemyBossScene_LoadInThread(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjEnemyBossScene_GetInfo(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjEnemyBossScene_SetSpellTimer(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjEnemyBossScene_StartSpell(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjEnemyBossScene_Create(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjEnemyBossScene_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjEnemyBossScene_Add(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjEnemyBossScene_LoadInThread(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjEnemyBossScene_GetInfo(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjEnemyBossScene_SetSpellTimer(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjEnemyBossScene_StartSpell(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 	//STG共通関数：弾オブジェクト操作
-	static gstd::value Func_ObjShot_Create(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetAutoDelete(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetDeleteFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_FadeDelete(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetDelay(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetSpellResist(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetGraphic(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetSourceBlendType(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetDamage(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetPenetration(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetEraseShot(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetSpellFactor(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_ToItem(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_AddShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_AddShotA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetIntersectionCircleA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetIntersectionCircleA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetIntersectionEnable(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_SetItemChange(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_GetDelay(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_GetDamage(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_GetPenetration(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_IsSpellResist(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjShot_GetImageID(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjShot_Create(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetAutoDelete(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetDeleteFrame(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_FadeDelete(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetDelay(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetSpellResist(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetGraphic(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetSourceBlendType(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetDamage(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetPenetration(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetEraseShot(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetSpellFactor(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_ToItem(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_AddShotA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_AddShotA2(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetIntersectionCircleA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetIntersectionCircleA2(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetIntersectionLine(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetIntersectionEnable(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_SetItemChange(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_GetDelay(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_GetDamage(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_GetPenetration(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_IsSpellResist(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjShot_GetImageID(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
-	static gstd::value Func_ObjLaser_SetLength(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjLaser_SetRenderWidth(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjLaser_SetIntersectionWidth(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjLaser_SetInvalidLength(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjLaser_SetGrazeInvalidFrame(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjLaser_SetItemDistance(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjLaser_GetLength(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjLaser_GetRenderWidth(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjLaser_GetIntersectionWidth(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjStLaser_SetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjStLaser_GetAngle(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjStLaser_SetSource(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjCrLaser_SetTipDecrement(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjLaser_SetLength(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjLaser_SetRenderWidth(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjLaser_SetIntersectionWidth(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjLaser_SetInvalidLength(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjLaser_SetGrazeInvalidFrame(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjLaser_SetItemDistance(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjLaser_GetLength(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjLaser_GetRenderWidth(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjLaser_GetIntersectionWidth(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjStLaser_SetAngle(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjStLaser_GetAngle(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjStLaser_SetSource(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjCrLaser_SetTipDecrement(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 	//STG共通関数：アイテムオブジェクト操作
-	static gstd::value Func_ObjItem_Create(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjItem_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjItem_SetItemID(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjItem_SetRenderScoreEnable(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjItem_SetAutoCollectEnable(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjItem_SetDefinedMovePatternA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjItem_GetInfo(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjItem_Create(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjItem_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjItem_SetItemID(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjItem_SetRenderScoreEnable(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjItem_SetAutoCollectEnable(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjItem_SetDefinedMovePatternA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjItem_GetInfo(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 	//STG共通関数：自機オブジェクト操作
-	static gstd::value Func_ObjPlayer_AddIntersectionCircleA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjPlayer_AddIntersectionCircleA2(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjPlayer_ClearIntersection(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjPlayer_AddIntersectionCircleA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjPlayer_AddIntersectionCircleA2(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjPlayer_ClearIntersection(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 	//STG共通関数：当たり判定オブジェクト操作
-	static gstd::value Func_ObjCol_IsIntersected(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjCol_GetListOfIntersectedEnemyID(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjCol_GetIntersectedCount(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjCol_IsIntersected(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjCol_GetListOfIntersectedEnemyID(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjCol_GetIntersectedCount(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 protected:
 	StgStageController* stageController_;
@@ -412,7 +412,7 @@ public:
 	virtual ~StgStageShotScript();
 
 	//システム専用関数：アイテム操作
-	static gstd::value Func_SetShotDeleteEventEnable(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_SetShotDeleteEventEnable(gstd::script_machine* machine, int argc, const gstd::value* argv);
 };
 
 /**********************************************************
@@ -431,20 +431,20 @@ public:
 	virtual ~StgStagePlayerScript();
 
 	//自機専用関数
-	static gstd::value Func_CreatePlayerShotA1(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_CallSpell(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_LoadPlayerShotData(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ReloadPlayerShotData(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_GetSpellManageObject(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_CreatePlayerShotA1(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_CallSpell(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_LoadPlayerShotData(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ReloadPlayerShotData(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_GetSpellManageObject(gstd::script_machine* machine, int argc, const gstd::value* argv);
 
 	//自機専用関数：スペルオブジェクト操作
-	static gstd::value Func_ObjSpell_Create(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjSpell_Regist(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjSpell_SetDamage(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjSpell_SetPenetration(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjSpell_SetEraseShot(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjSpell_SetIntersectionCircle(gstd::script_machine* machine, int argc, gstd::value const* argv);
-	static gstd::value Func_ObjSpell_SetIntersectionLine(gstd::script_machine* machine, int argc, gstd::value const* argv);
+	static gstd::value Func_ObjSpell_Create(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjSpell_Regist(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjSpell_SetDamage(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjSpell_SetPenetration(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjSpell_SetEraseShot(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjSpell_SetIntersectionCircle(gstd::script_machine* machine, int argc, const gstd::value* argv);
+	static gstd::value Func_ObjSpell_SetIntersectionLine(gstd::script_machine* machine, int argc, const gstd::value* argv);
 };
 
 #endif

--- a/source/TouhouDanmakufu/Common/StgSystem.cpp
+++ b/source/TouhouDanmakufu/Common/StgSystem.cpp
@@ -726,12 +726,10 @@ StgSystemInformation::StgSystemInformation()
 StgSystemInformation::~StgSystemInformation()
 {
 }
-std::wstring StgSystemInformation::GetErrorMessage()
+std::wstring StgSystemInformation::GetErrorMessage() const
 {
 	std::wstring res = L"";
-	std::list<std::wstring>::iterator itr = listError_.begin();
-	for (; itr != listError_.end(); itr++) {
-		std::wstring str = (*itr);
+	for (const auto& str : listError_) {
 		if (str == L"Retry")
 			continue;
 		res += str + L"\r\n" + L"\r\n";

--- a/source/TouhouDanmakufu/Common/StgSystem.cpp
+++ b/source/TouhouDanmakufu/Common/StgSystem.cpp
@@ -7,12 +7,8 @@
 /**********************************************************
 //StgSystemController
 **********************************************************/
-StgSystemController::StgSystemController()
-{
-}
-StgSystemController::~StgSystemController()
-{
-}
+StgSystemController::StgSystemController() = default;
+StgSystemController::~StgSystemController() = default;
 void StgSystemController::Initialize(ref_count_ptr<StgSystemInformation> infoSystem)
 {
 	infoSystem_ = infoSystem;
@@ -42,12 +38,12 @@ void StgSystemController::Start(ref_count_ptr<ScriptInformation> infoPlayer, ref
 	//アーカイブ
 	EFileManager* fileManager = EFileManager::GetInstance();
 	std::wstring archiveMain = infoMain->GetArchivePath();
-	if (archiveMain.size() > 0)
+	if (!archiveMain.empty())
 		fileManager->AddArchiveFile(archiveMain);
 
-	if (infoPlayer != NULL) {
+	if (infoPlayer != nullptr) {
 		std::wstring archivePlayer = infoPlayer->GetArchivePath();
-		if (archivePlayer.size() > 0) {
+		if (!archivePlayer.empty()) {
 			fileManager->AddArchiveFile(archivePlayer);
 		}
 	}
@@ -57,8 +53,8 @@ void StgSystemController::Start(ref_count_ptr<ScriptInformation> infoPlayer, ref
 		packageController_ = new StgPackageController(this);
 		packageController_->Initialize();
 	} else {
-		ref_count_ptr<ReplayInformation::StageData> replayStageData = NULL;
-		if (infoReplay != NULL)
+		ref_count_ptr<ReplayInformation::StageData> replayStageData = nullptr;
+		if (infoReplay != nullptr)
 			replayStageData = infoReplay->GetStageData(0);
 		ref_count_ptr<StgStageInformation> infoStage = new StgStageInformation();
 		infoStage->SetMainScriptInformation(infoMain);
@@ -92,7 +88,7 @@ void StgSystemController::Work()
 			ref_count_ptr<StgStageStartData> oldStageStartData;
 			ref_count_ptr<StgPackageInformation> infoPackage = packageController_->GetPackageInformation();
 			std::vector<ref_count_ptr<StgStageStartData>> listStageData = infoPackage->GetStageDataList();
-			if (listStageData.size() > 0) {
+			if (!listStageData.empty()) {
 				oldStageStartData = *listStageData.begin();
 			} else {
 				oldStageStartData = infoPackage->GetNextStageData();
@@ -123,7 +119,7 @@ void StgSystemController::Work()
 		bool bRetry = false;
 		if (infoSystem_->IsError()) {
 			std::wstring error = infoSystem_->GetErrorMessage();
-			if (error.size() > 0) {
+			if (!error.empty()) {
 				ErrorDialog::ShowErrorDialog(error);
 			} else {
 				//リトライ
@@ -137,7 +133,7 @@ void StgSystemController::Work()
 		}
 
 		ELogger* logger = ELogger::GetInstance();
-		logger->UpdateCommonDataInfoPanel(NULL);
+		logger->UpdateCommonDataInfoPanel(nullptr);
 
 		EFpsController* fpsController = EFpsController::GetInstance();
 		fpsController->SetFastModeKey(DIK_LCONTROL);
@@ -160,12 +156,12 @@ void StgSystemController::Render()
 			break;
 		}
 		case StgSystemInformation::SCENE_END: {
-			if (endScene_ != NULL)
+			if (endScene_ != nullptr)
 				endScene_->Render();
 			break;
 		}
 		case StgSystemInformation::SCENE_REPLAY_SAVE: {
-			if (replaySaveScene_ != NULL)
+			if (replaySaveScene_ != nullptr)
 				replaySaveScene_->Render();
 			break;
 		}
@@ -195,7 +191,7 @@ void StgSystemController::RenderScriptObject()
 	} else {
 		bool bReplay = false;
 		int countRender = 0;
-		if (scene == StgSystemInformation::SCENE_STG && stageController_ != NULL) {
+		if (scene == StgSystemInformation::SCENE_STG && stageController_ != nullptr) {
 			ref_count_ptr<StgStageScriptObjectManager> objectManagerStage = stageController_->GetMainObjectManager();
 			countRender = max(objectManagerStage->GetRenderBucketCapacity() - 1, countRender);
 
@@ -249,10 +245,10 @@ void StgSystemController::RenderScriptObject()
 }
 void StgSystemController::RenderScriptObject(int priMin, int priMax)
 {
-	ref_count_ptr<StgStageScriptObjectManager> objectManagerStage = NULL;
-	ref_count_ptr<DxScriptObjectManager> objectManagerPackage = NULL;
-	std::vector<std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>>* pRenderListStage = NULL;
-	std::vector<std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>>* pRenderListPackage = NULL;
+	ref_count_ptr<StgStageScriptObjectManager> objectManagerStage = nullptr;
+	ref_count_ptr<DxScriptObjectManager> objectManagerPackage = nullptr;
+	std::vector<std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>>* pRenderListStage = nullptr;
+	std::vector<std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>>* pRenderListPackage = nullptr;
 
 	int scene = infoSystem_->GetScene();
 	bool bPause = false;
@@ -265,7 +261,10 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 	//・パッケージモードでない(一時停止もステージ処理側で処理するため)
 	//・パッケージスクリプトの場合は、一時停止をパッケージスクリプトで処理するため
 	//　一時停止中はSTGシーンは描画対象外とする
-	bool bValidStage = (scene == StgSystemInformation::SCENE_STG || !infoSystem_->IsPackageMode()) && stageController_ != NULL && !bPause;
+	bool bValidStage = (scene == StgSystemInformation::SCENE_STG
+		|| !infoSystem_->IsPackageMode())
+		&& stageController_ != nullptr
+		&& !bPause;
 	if (bValidStage) {
 		objectManagerStage = stageController_->GetMainObjectManager();
 		objectManagerStage->PrepareRenderObject();
@@ -289,7 +288,7 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 	D3DXVECTOR2 orgFocusPos = camera2D->GetFocusPosition();
 	D3DXVECTOR2 focusPos = orgFocusPos;
 
-	ref_count_ptr<StgStageInformation> stageInfo = NULL;
+	ref_count_ptr<StgStageInformation> stageInfo = nullptr;
 	if (bValidStage) {
 		stageInfo = stageController_->GetStageInformation();
 		RECT rcStgFrame = stageInfo->GetStgFrameRect();
@@ -346,12 +345,12 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 	D3DCOLOR fogColor = D3DCOLOR_ARGB(255, 255, 255, 255);
 	float fogStart = 0;
 	float fogEnd = 0;
-	if (objectManagerStage != NULL) {
+	if (objectManagerStage != nullptr) {
 		bFogEnable = objectManagerStage->IsFogEneble();
 		fogColor = objectManagerStage->GetFogColor();
 		fogStart = objectManagerStage->GetFogStart();
 		fogEnd = objectManagerStage->GetFogEnd();
-	} else if (objectManagerPackage != NULL) {
+	} else if (objectManagerPackage != nullptr) {
 		bFogEnable = objectManagerPackage->IsFogEneble();
 		fogColor = objectManagerPackage->GetFogColor();
 		fogStart = objectManagerPackage->GetFogStart();
@@ -368,7 +367,7 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 	bool bClearZBufferFor2DCoordinate = false;
 	bool bRunMinStgFrame = false;
 	bool bRunMaxStgFrame = false;
-	for (int iPri = priMin; iPri <= priMax; iPri++) {
+	for (int iPri = priMin; iPri <= priMax; ++iPri) {
 		if (iPri >= priMinStgFrame && !bRunMinStgFrame) {
 			//STGフレーム開始
 			if (bValidStage && iPri < invalidPriMin)
@@ -392,10 +391,10 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 			bClearZBufferFor2DCoordinate = false;
 		}
 
-		if (objectManagerStage != NULL && !bPause) {
+		if (objectManagerStage != nullptr && !bPause) {
 			//シェーダ設定
 			ref_count_ptr<Shader> shader = objectManagerStage->GetShader(iPri);
-			if (shader != NULL) {
+			if (shader != nullptr) {
 				shader->Begin();
 			}
 
@@ -409,55 +408,53 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 				stageController_->GetItemManager()->Render(iPri);
 			}
 
-			if (pRenderListStage != NULL && iPri < (*pRenderListStage).size()) {
-				std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>::iterator itr;
-				for (itr = (*pRenderListStage)[iPri].begin(); itr != (*pRenderListStage)[iPri].end(); itr++) {
+			if (pRenderListStage != nullptr && iPri < (*pRenderListStage).size()) {
+				for (auto& objBase : (*pRenderListStage)[iPri]) {
 					if (!bClearZBufferFor2DCoordinate) {
-						DxScriptMeshObject* objMesh = dynamic_cast<DxScriptMeshObject*>((*itr).GetPointer());
-						if (objMesh != NULL) {
+						auto* objMesh = dynamic_cast<DxScriptMeshObject*>(objBase.GetPointer());
+						if (objMesh != nullptr) {
 							gstd::ref_count_ptr<DxMesh>& mesh = objMesh->GetMesh();
 							if (mesh != NULL && mesh->IsCoordinate2D()) {
-								graphics->GetDevice()->Clear(0, NULL, D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0, 0, 0), 1.0, 0);
+								graphics->GetDevice()->Clear(0, nullptr, D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0, 0, 0), 1.0, 0);
 								bClearZBufferFor2DCoordinate = true;
 							}
 						}
 					}
-					(*itr)->Render();
+					objBase->Render();
 				}
 				(*pRenderListStage)[iPri].clear();
 			}
 
-			if (shader != NULL) {
+			if (shader != nullptr) {
 				shader->End();
 			}
 		}
 
 		//パッケージ
-		if (objectManagerPackage != NULL) {
+		if (objectManagerPackage != nullptr) {
 			//シェーダ設定
 			ref_count_ptr<Shader> shader = objectManagerPackage->GetShader(iPri);
-			if (shader != NULL) {
+			if (shader != nullptr) {
 				shader->Begin();
 			}
 
-			if (pRenderListPackage != NULL && iPri < (*pRenderListPackage).size()) {
-				std::list<gstd::ref_count_ptr<DxScriptObjectBase>::unsync>::iterator itr;
-				for (itr = (*pRenderListPackage)[iPri].begin(); itr != (*pRenderListPackage)[iPri].end(); itr++) {
+			if (pRenderListPackage != nullptr && iPri < (*pRenderListPackage).size()) {
+				for (auto& objBase : (*pRenderListPackage)[iPri]) {
 					if (!bClearZBufferFor2DCoordinate) {
-						DxScriptMeshObject* objMesh = dynamic_cast<DxScriptMeshObject*>((*itr).GetPointer());
-						if (objMesh != NULL) {
+						auto* objMesh = dynamic_cast<DxScriptMeshObject*>(objBase.GetPointer());
+						if (objMesh != nullptr) {
 							gstd::ref_count_ptr<DxMesh>& mesh = objMesh->GetMesh();
 							if (mesh != NULL && mesh->IsCoordinate2D()) {
-								graphics->GetDevice()->Clear(0, NULL, D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0, 0, 0), 1.0, 0);
+								graphics->GetDevice()->Clear(0, nullptr, D3DCLEAR_ZBUFFER, D3DCOLOR_XRGB(0, 0, 0), 1.0, 0);
 								bClearZBufferFor2DCoordinate = true;
 							}
 						}
 					}
-					(*itr)->Render();
+					objBase->Render();
 				}
 				(*pRenderListPackage)[iPri].clear();
 			}
-			if (shader != NULL) {
+			if (shader != nullptr) {
 				shader->End();
 			}
 		}
@@ -483,9 +480,9 @@ void StgSystemController::RenderScriptObject(int priMin, int priMax)
 	camera2D->SetAngleZ(focusAngleZ);
 
 	//--------------------------------
-	if (objectManagerStage != NULL)
+	if (objectManagerStage != nullptr)
 		objectManagerStage->ClearRenderObject();
-	if (objectManagerPackage != NULL)
+	if (objectManagerPackage != nullptr)
 		objectManagerPackage->ClearRenderObject();
 }
 void StgSystemController::_ControlScene()
@@ -514,7 +511,7 @@ void StgSystemController::_ControlScene()
 				if (infoStage->GetResult() == StgStageInformation::RESULT_UNKNOWN) {
 					int sceneResult = StgStageInformation::RESULT_CLEARED;
 					ref_count_ptr<StgPlayerObject>::unsync objPlayer = stageController_->GetPlayerObject();
-					if (objPlayer != NULL) {
+					if (objPlayer != nullptr) {
 						int statePlayer = objPlayer->GetState();
 						if (statePlayer == StgPlayerObject::STATE_END)
 							sceneResult = StgStageInformation::RESULT_PLAYER_DOWN;
@@ -552,20 +549,20 @@ void StgSystemController::_ControlScene()
 		//ログ関連
 		int taskCount = 0;
 		int objectCount = 0;
-		if (packageController_ != NULL) {
+		if (packageController_ != nullptr) {
 			ref_count_ptr<StgControlScriptManager> scriptManager = packageController_->GetScriptManager();
 			if (scriptManager != NULL)
 				taskCount = scriptManager->GetAllScriptThreadCount();
 
 			ref_count_ptr<DxScriptObjectManager> objectManager = packageController_->GetMainObjectManager();
-			if (objectManager != NULL)
+			if (objectManager != nullptr)
 				objectCount += objectManager->GetAliveObjectCount();
 		}
-		if (stageController_ != NULL) {
+		if (stageController_ != nullptr) {
 			ref_count_ptr<StgStageInformation> infoStage = stageController_->GetStageInformation();
 			if (!infoStage->IsEnd()) {
 				StgControlScriptManager* scriptManager = stageController_->GetScriptManagerP();
-				if (scriptManager != NULL)
+				if (scriptManager != nullptr)
 					taskCount = scriptManager->GetAllScriptThreadCount();
 
 				ref_count_ptr<DxScriptObjectManager> objectManager = stageController_->GetMainObjectManager();
@@ -597,7 +594,7 @@ void StgSystemController::StartStgScene(ref_count_ptr<StgStageStartData> startDa
 void StgSystemController::TransStgEndScene()
 {
 	bool bReplay = false;
-	if (stageController_ != NULL) {
+	if (stageController_ != nullptr) {
 		ref_count_ptr<StgStageInformation> infoStage = stageController_->GetStageInformation();
 		bReplay = infoStage->IsReplay();
 	}
@@ -639,22 +636,21 @@ ref_count_ptr<ReplayInformation> StgSystemController::CreateReplayInformation()
 	res->SetPlayerScriptReplayName(infoPlayer->GetReplayName());
 
 	//システム関連
-	_int64 totalScore = infoLastStage->GetScore();
+	int64_t totalScore = infoLastStage->GetScore();
 	double fpsAvarage = 0;
 
 	//ステージ
 	if (infoSystem_->IsPackageMode()) {
 		ref_count_ptr<StgPackageInformation> infoPackage = packageController_->GetPackageInformation();
 		std::vector<ref_count_ptr<StgStageStartData>> listStageData = infoPackage->GetStageDataList();
-		for (int iStage = 0; iStage < listStageData.size(); iStage++) {
-			ref_count_ptr<StgStageStartData> stageData = listStageData[iStage];
+		for (auto& stageData : listStageData) {
 			ref_count_ptr<StgStageInformation> infoStage = stageData->GetStageInformation();
 			ref_count_ptr<ReplayInformation::StageData> replayStageData = infoStage->GetReplayData();
 			res->SetStageData(infoStage->GetStageIndex(), replayStageData);
 
 			fpsAvarage += replayStageData->GetFramePerSecondAvarage();
 		}
-		if (listStageData.size() > 0)
+		if (!listStageData.empty())
 			fpsAvarage = fpsAvarage / listStageData.size();
 	} else {
 		ref_count_ptr<StgStageController> stageController = stageController_;
@@ -675,32 +671,32 @@ ref_count_ptr<ReplayInformation> StgSystemController::CreateReplayInformation()
 void StgSystemController::TerminateScriptAll()
 {
 	std::wstring error = L"force terminate";
-	if (packageController_ != NULL) {
+	if (packageController_ != nullptr) {
 		ref_count_ptr<ScriptManager> scriptManager = packageController_->GetScriptManager();
 		if (scriptManager != NULL)
 			scriptManager->TerminateScriptAll(error);
 	}
 
-	if (stageController_ != NULL) {
+	if (stageController_ != nullptr) {
 		ScriptManager* scriptManager = stageController_->GetScriptManagerP();
-		if (scriptManager != NULL)
+		if (scriptManager != nullptr)
 			scriptManager->TerminateScriptAll(error);
 
 		ref_count_ptr<StgPauseScene> pauseScene = stageController_->GetPauseManager();
-		if (pauseScene != NULL) {
+		if (pauseScene != nullptr) {
 			ref_count_ptr<ScriptManager> pauseScriptManager = pauseScene->GetScriptManager();
 			if (pauseScriptManager != NULL)
 				pauseScriptManager->TerminateScriptAll(error);
 		}
 	}
 
-	if (endScene_ != NULL) {
+	if (endScene_ != nullptr) {
 		ref_count_ptr<ScriptManager> scriptManager = endScene_->GetScriptManager();
 		if (scriptManager != NULL)
 			scriptManager->TerminateScriptAll(error);
 	}
 
-	if (replaySaveScene_ != NULL) {
+	if (replaySaveScene_ != nullptr) {
 		ref_count_ptr<ScriptManager> scriptManager = replaySaveScene_->GetScriptManager();
 		if (scriptManager != NULL)
 			scriptManager->TerminateScriptAll(error);
@@ -723,12 +719,10 @@ StgSystemInformation::StgSystemInformation()
 	pathEndSceneScript_ = EPathProperty::GetStgDefaultScriptDirectory() + L"Default_EndScene.txt";
 	pathReplaySaveSceneScript_ = EPathProperty::GetStgDefaultScriptDirectory() + L"Default_ReplaySaveScene.txt";
 }
-StgSystemInformation::~StgSystemInformation()
-{
-}
+StgSystemInformation::~StgSystemInformation() = default;
 std::wstring StgSystemInformation::GetErrorMessage() const
 {
-	std::wstring res = L"";
+	std::wstring res;
 	for (const auto& str : listError_) {
 		if (str == L"Retry")
 			continue;
@@ -738,8 +732,7 @@ std::wstring StgSystemInformation::GetErrorMessage() const
 }
 bool StgSystemInformation::IsPackageMode()
 {
-	bool res = infoMain_->GetType() == ScriptInformation::TYPE_PACKAGE;
-	return res;
+	return infoMain_->GetType() == ScriptInformation::TYPE_PACKAGE;
 }
 void StgSystemInformation::ResetRetry()
 {

--- a/source/TouhouDanmakufu/Common/StgSystem.hpp
+++ b/source/TouhouDanmakufu/Common/StgSystem.hpp
@@ -87,22 +87,22 @@ public:
 
 	bool IsPackageMode();
 	void ResetRetry();
-	int GetScene() { return scene_; }
+	int GetScene() const { return scene_; }
 	void SetScene(int scene) { scene_ = scene; }
-	bool IsStgEnd() { return bEndStg_; }
+	bool IsStgEnd() const { return bEndStg_; }
 	void SetStgEnd() { bEndStg_ = true; }
-	bool IsRetry() { return bRetry_; }
+	bool IsRetry() const { return bRetry_; }
 	void SetRetry() { bRetry_ = true; }
-	bool IsError() { return listError_.size() > 0; }
-	void SetError(std::wstring error) { listError_.push_back(error); }
-	std::wstring GetErrorMessage();
+	bool IsError() const { return listError_.size() > 0; }
+	void SetError(const std::wstring& error) { listError_.push_back(error); }
+	std::wstring GetErrorMessage() const;
 
-	std::wstring GetPauseScriptPath() { return pathPauseScript_; }
-	void SetPauseScriptPath(std::wstring path) { pathPauseScript_ = path; }
-	std::wstring GetEndSceneScriptPath() { return pathEndSceneScript_; }
-	void SetEndSceneScriptPath(std::wstring path) { pathEndSceneScript_ = path; }
-	std::wstring GetReplaySaveSceneScriptPath() { return pathReplaySaveSceneScript_; }
-	void SetReplaySaveSceneScriptPath(std::wstring path) { pathReplaySaveSceneScript_ = path; }
+	std::wstring GetPauseScriptPath() const { return pathPauseScript_; }
+	void SetPauseScriptPath(const std::wstring& path) { pathPauseScript_ = path; }
+	std::wstring GetEndSceneScriptPath() const { return pathEndSceneScript_; }
+	void SetEndSceneScriptPath(const std::wstring& path) { pathEndSceneScript_ = path; }
+	std::wstring GetReplaySaveSceneScriptPath() const { return pathReplaySaveSceneScript_; }
+	void SetReplaySaveSceneScriptPath(const std::wstring& path) { pathReplaySaveSceneScript_ = path; }
 
 	ref_count_ptr<ScriptInformation> GetMainScriptInformation() { return infoMain_; }
 	void SetMainScriptInformation(ref_count_ptr<ScriptInformation> info) { infoMain_ = info; }
@@ -111,11 +111,11 @@ public:
 	void SetActiveReplayInformation(ref_count_ptr<ReplayInformation> info) { infoReplayActive_ = info; }
 
 	void SetInvaridRenderPriority(int priMin, int priMax);
-	int GetInvaridRenderPriorityMin() { return invalidPriMin_; }
-	int GetInvaridRenderPriorityMax() { return invalidPriMax_; }
+	int GetInvaridRenderPriorityMin() const { return invalidPriMin_; }
+	int GetInvaridRenderPriorityMax() const { return invalidPriMax_; }
 
 	void AddReplayTargetKey(int id) { listReplayTargetKey_.insert(id); }
-	std::set<int> GetReplayTargetKeyList() { return listReplayTargetKey_; }
+	std::set<int> GetReplayTargetKeyList() const { return listReplayTargetKey_; }
 
 private:
 	int scene_;

--- a/source/TouhouDanmakufu/Common/StgSystem.hpp
+++ b/source/TouhouDanmakufu/Common/StgSystem.hpp
@@ -25,7 +25,7 @@ public:
 
 public:
 	StgSystemController();
-	~StgSystemController();
+	~StgSystemController() override;
 	void Initialize(ref_count_ptr<StgSystemInformation> infoSystem);
 	void Start(ref_count_ptr<ScriptInformation> infoPlayer, ref_count_ptr<ReplayInformation> infoReplay);
 	void Work();
@@ -93,7 +93,7 @@ public:
 	void SetStgEnd() { bEndStg_ = true; }
 	bool IsRetry() const { return bRetry_; }
 	void SetRetry() { bRetry_ = true; }
-	bool IsError() const { return listError_.size() > 0; }
+	bool IsError() const { return !listError_.empty(); }
 	void SetError(const std::wstring& error) { listError_.push_back(error); }
 	std::wstring GetErrorMessage() const;
 

--- a/source/TouhouDanmakufu/Common/StgUserExtendScene.cpp
+++ b/source/TouhouDanmakufu/Common/StgUserExtendScene.cpp
@@ -20,7 +20,7 @@ void StgUserExtendScene::_InitializeTransitionTexture()
 	if (stageController != NULL)
 		stageController->RenderToTransitionTexture();
 }
-void StgUserExtendScene::_InitializeScript(std::wstring path, int type)
+void StgUserExtendScene::_InitializeScript(const std::wstring& path, int type)
 {
 	if (scriptManager_ == NULL)
 		return;
@@ -146,7 +146,7 @@ gstd::value StgUserExtendSceneScriptManager::GetResultValue()
 	}
 	return res;
 }
-bool StgUserExtendSceneScriptManager::IsRealValue(gstd::value val)
+bool StgUserExtendSceneScriptManager::IsRealValue(const gstd::value& val)
 {
 	if (listScriptRun_.size() == 0)
 		return false;

--- a/source/TouhouDanmakufu/Common/StgUserExtendScene.cpp
+++ b/source/TouhouDanmakufu/Common/StgUserExtendScene.cpp
@@ -10,50 +10,48 @@ StgUserExtendScene::StgUserExtendScene(StgSystemController* controller)
 {
 	systemController_ = controller;
 }
-StgUserExtendScene::~StgUserExtendScene()
-{
-}
+StgUserExtendScene::~StgUserExtendScene() = default;
 void StgUserExtendScene::_InitializeTransitionTexture()
 {
 	//画面キャプチャ
 	StgStageController* stageController = systemController_->GetStageController();
-	if (stageController != NULL)
+	if (stageController != nullptr)
 		stageController->RenderToTransitionTexture();
 }
 void StgUserExtendScene::_InitializeScript(const std::wstring& path, int type)
 {
-	if (scriptManager_ == NULL)
+	if (scriptManager_ == nullptr)
 		return;
-	_int64 idScript = scriptManager_->LoadScript(path, type);
+	int64_t idScript = scriptManager_->LoadScript(path, type);
 	scriptManager_->StartScript(idScript);
 }
 void StgUserExtendScene::_CallScriptMainLoop()
 {
-	if (scriptManager_ == NULL)
+	if (scriptManager_ == nullptr)
 		return;
 	scriptManager_->Work();
 }
 void StgUserExtendScene::_CallScriptFinalize()
 {
-	if (scriptManager_ == NULL)
+	if (scriptManager_ == nullptr)
 		return;
 	scriptManager_->CallScriptFinalizeAll();
 }
 void StgUserExtendScene::_AddRelativeManager()
 {
-	if (scriptManager_ == NULL)
+	if (scriptManager_ == nullptr)
 		return;
 	ref_count_ptr<ScriptManager> scriptManager = scriptManager_;
 
 	StgStageController* stageController = systemController_->GetStageController();
-	if (stageController != NULL) {
+	if (stageController != nullptr) {
 		ref_count_ptr<ScriptManager> stageScriptManager = stageController->GetScriptManagerR();
 		if (stageScriptManager != NULL)
 			ScriptManager::AddRelativeScriptManagerMutual(scriptManager, stageScriptManager);
 	}
 
 	StgPackageController* packageController = systemController_->GetPackageController();
-	if (packageController != NULL) {
+	if (packageController != nullptr) {
 		ref_count_ptr<ScriptManager> packageScriptManager = packageController->GetScriptManager();
 		if (packageScriptManager != NULL)
 			ScriptManager::AddRelativeScriptManagerMutual(scriptManager, packageScriptManager);
@@ -65,7 +63,7 @@ void StgUserExtendScene::Work()
 }
 void StgUserExtendScene::Render()
 {
-	if (scriptManager_ == NULL)
+	if (scriptManager_ == nullptr)
 		return;
 	scriptManager_->Render();
 }
@@ -85,9 +83,7 @@ StgUserExtendSceneScriptManager::StgUserExtendSceneScriptManager(StgSystemContro
 	systemController_ = controller;
 	objectManager_ = new DxScriptObjectManager();
 }
-StgUserExtendSceneScriptManager::~StgUserExtendSceneScriptManager()
-{
-}
+StgUserExtendSceneScriptManager::~StgUserExtendSceneScriptManager() = default;
 void StgUserExtendSceneScriptManager::Work()
 {
 	if (!IsError()) {
@@ -116,7 +112,7 @@ ref_count_ptr<ManagedScript> StgUserExtendSceneScriptManager::Create(int type)
 		break;
 	}
 
-	if (res != NULL) {
+	if (res != nullptr) {
 		res->SetObjectManager(objectManager_);
 		res->SetScriptManager(this);
 	}
@@ -125,9 +121,7 @@ ref_count_ptr<ManagedScript> StgUserExtendSceneScriptManager::Create(int type)
 }
 void StgUserExtendSceneScriptManager::CallScriptFinalizeAll()
 {
-	std::list<ref_count_ptr<ManagedScript>>::iterator itr = listScriptRun_.begin();
-	for (; itr != listScriptRun_.end(); itr++) {
-		ref_count_ptr<ManagedScript> script = (*itr);
+	for (auto& script :listScriptRun_) {
 		if (script->IsEventExists("Finalize"))
 			script->Run("Finalize");
 	}
@@ -135,9 +129,7 @@ void StgUserExtendSceneScriptManager::CallScriptFinalizeAll()
 gstd::value StgUserExtendSceneScriptManager::GetResultValue()
 {
 	gstd::value res;
-	std::list<ref_count_ptr<ManagedScript>>::iterator itr = listScriptRun_.begin();
-	for (; itr != listScriptRun_.end(); itr++) {
-		ref_count_ptr<ManagedScript> script = (*itr);
+	for (auto& script :listScriptRun_) {
 		gstd::value v = script->GetResultValue();
 		if (v.has_data()) {
 			res = v;
@@ -148,12 +140,11 @@ gstd::value StgUserExtendSceneScriptManager::GetResultValue()
 }
 bool StgUserExtendSceneScriptManager::IsRealValue(const gstd::value& val)
 {
-	if (listScriptRun_.size() == 0)
+	if (listScriptRun_.empty())
 		return false;
 	ref_count_ptr<ManagedScript> script = *listScriptRun_.begin();
 
-	bool res = script->IsRealValue(val);
-	return res;
+	return script->IsRealValue(val);
 }
 
 /**********************************************************
@@ -168,9 +159,7 @@ StgUserExtendSceneScript::StgUserExtendSceneScript(StgSystemController* systemCo
 
 	mainThreadID_ = scriptManager->GetMainThreadID();
 }
-StgUserExtendSceneScript::~StgUserExtendSceneScript()
-{
-}
+StgUserExtendSceneScript::~StgUserExtendSceneScript() = default;
 
 /**********************************************************
 //StgPauseScene
@@ -179,12 +168,10 @@ StgPauseScene::StgPauseScene(StgSystemController* controller)
 	: StgUserExtendScene(controller)
 {
 }
-StgPauseScene::~StgPauseScene()
-{
-}
+StgPauseScene::~StgPauseScene() = default;
 void StgPauseScene::Work()
 {
-	if (scriptManager_ == NULL)
+	if (scriptManager_ == nullptr)
 		return;
 	_CallScriptMainLoop();
 
@@ -219,7 +206,7 @@ void StgPauseScene::Start()
 	stageScriptManager->RequestEventAll(StgStageScript::EV_PAUSE_ENTER);
 
 	//停止処理初期化
-	scriptManager_ = NULL;
+	scriptManager_ = nullptr;
 	scriptManager_ = new StgUserExtendSceneScriptManager(systemController_);
 	_AddRelativeManager();
 	ref_count_ptr<StgSystemInformation> sysInfo = systemController_->GetSystemInformation();
@@ -230,19 +217,19 @@ void StgPauseScene::Start()
 	std::wstring path = sysInfo->GetPauseScriptPath();
 	_InitializeScript(path, StgUserExtendSceneScript::TYPE_PAUSE_SCENE);
 
-	if (stageController != NULL)
+	if (stageController != nullptr)
 		stageController->GetStageInformation()->SetPause(true);
 }
 void StgPauseScene::Finish()
 {
 	StgStageController* stageController = systemController_->GetStageController();
-	if (stageController != NULL)
+	if (stageController != nullptr)
 		stageController->GetStageInformation()->SetPause(false);
 
-	if (scriptManager_ == NULL)
+	if (scriptManager_ == nullptr)
 		return;
 	_CallScriptFinalize();
-	scriptManager_ = NULL;
+	scriptManager_ = nullptr;
 
 	//解除イベント呼び出し
 	StgStageScriptManager* stageScriptManager = stageController->GetScriptManagerP();
@@ -265,9 +252,7 @@ StgPauseSceneScript::StgPauseSceneScript(StgSystemController* controller)
 	typeScript_ = TYPE_PAUSE_SCENE;
 	_AddFunction(stgPauseFunction, sizeof(stgPauseFunction) / sizeof(function));
 }
-StgPauseSceneScript::~StgPauseSceneScript()
-{
-}
+StgPauseSceneScript::~StgPauseSceneScript() = default;
 
 //一時停止専用関数：一時停止操作
 
@@ -278,12 +263,10 @@ StgEndScene::StgEndScene(StgSystemController* controller)
 	: StgUserExtendScene(controller)
 {
 }
-StgEndScene::~StgEndScene()
-{
-}
+StgEndScene::~StgEndScene() = default;
 void StgEndScene::Work()
 {
-	if (scriptManager_ == NULL)
+	if (scriptManager_ == nullptr)
 		return;
 	_CallScriptMainLoop();
 
@@ -306,7 +289,7 @@ void StgEndScene::Work()
 
 void StgEndScene::Start()
 {
-	scriptManager_ = NULL;
+	scriptManager_ = nullptr;
 	scriptManager_ = new StgUserExtendSceneScriptManager(systemController_);
 	_AddRelativeManager();
 
@@ -322,10 +305,10 @@ void StgEndScene::Finish()
 {
 	ref_count_ptr<StgSystemInformation> info = systemController_->GetSystemInformation();
 
-	if (scriptManager_ == NULL)
+	if (scriptManager_ == nullptr)
 		return;
 	_CallScriptFinalize();
-	scriptManager_ = NULL;
+	scriptManager_ = nullptr;
 }
 
 /**********************************************************
@@ -344,9 +327,7 @@ StgEndSceneScript::StgEndSceneScript(StgSystemController* controller)
 	typeScript_ = TYPE_END_SCENE;
 	_AddFunction(stgEndFunction, sizeof(stgEndFunction) / sizeof(function));
 }
-StgEndSceneScript::~StgEndSceneScript()
-{
-}
+StgEndSceneScript::~StgEndSceneScript() = default;
 
 /**********************************************************
 //StgReplaySaveScene
@@ -355,12 +336,10 @@ StgReplaySaveScene::StgReplaySaveScene(StgSystemController* controller)
 	: StgUserExtendScene(controller)
 {
 }
-StgReplaySaveScene::~StgReplaySaveScene()
-{
-}
+StgReplaySaveScene::~StgReplaySaveScene() = default;
 void StgReplaySaveScene::Work()
 {
-	if (scriptManager_ == NULL)
+	if (scriptManager_ == nullptr)
 		return;
 	_CallScriptMainLoop();
 
@@ -381,7 +360,7 @@ void StgReplaySaveScene::Work()
 
 void StgReplaySaveScene::Start()
 {
-	scriptManager_ = NULL;
+	scriptManager_ = nullptr;
 	scriptManager_ = new StgUserExtendSceneScriptManager(systemController_);
 	_AddRelativeManager();
 
@@ -397,10 +376,10 @@ void StgReplaySaveScene::Finish()
 {
 	ref_count_ptr<StgSystemInformation> info = systemController_->GetSystemInformation();
 
-	if (scriptManager_ == NULL)
+	if (scriptManager_ == nullptr)
 		return;
 	_CallScriptFinalize();
-	scriptManager_ = NULL;
+	scriptManager_ = nullptr;
 }
 
 /**********************************************************
@@ -419,6 +398,4 @@ StgReplaySaveScript::StgReplaySaveScript(StgSystemController* controller)
 	typeScript_ = TYPE_REPLAY_SCENE;
 	_AddFunction(stgReplaySaveFunction, sizeof(stgReplaySaveFunction) / sizeof(function));
 }
-StgReplaySaveScript::~StgReplaySaveScript()
-{
-}
+StgReplaySaveScript::~StgReplaySaveScript() = default;

--- a/source/TouhouDanmakufu/Common/StgUserExtendScene.hpp
+++ b/source/TouhouDanmakufu/Common/StgUserExtendScene.hpp
@@ -38,10 +38,10 @@ class StgUserExtendSceneScript;
 class StgUserExtendSceneScriptManager : public StgControlScriptManager {
 public:
 	StgUserExtendSceneScriptManager(StgSystemController* controller);
-	virtual ~StgUserExtendSceneScriptManager();
-	virtual void Work();
-	virtual void Render();
-	virtual ref_count_ptr<ManagedScript> Create(int type);
+	~StgUserExtendSceneScriptManager() override;
+	void Work() override;
+	void Render() override;
+	ref_count_ptr<ManagedScript> Create(int type) override;
 
 	void CallScriptFinalizeAll();
 	gstd::value GetResultValue();
@@ -65,7 +65,7 @@ public:
 
 public:
 	StgUserExtendSceneScript(StgSystemController* controller);
-	virtual ~StgUserExtendSceneScript();
+	~StgUserExtendSceneScript() override;
 };
 
 /**********************************************************
@@ -75,12 +75,12 @@ class StgPauseSceneScript;
 class StgPauseScene : public StgUserExtendScene {
 public:
 	StgPauseScene(StgSystemController* controller);
-	virtual ~StgPauseScene();
+	~StgPauseScene() override;
 
-	virtual void Work();
+	void Work() override;
 
-	virtual void Start();
-	virtual void Finish();
+	void Start() override;
+	void Finish() override;
 };
 
 class StgPauseSceneScript : public StgUserExtendSceneScript {
@@ -91,7 +91,7 @@ public:
 
 public:
 	StgPauseSceneScript(StgSystemController* controller);
-	virtual ~StgPauseSceneScript();
+	~StgPauseSceneScript() override;
 };
 
 /**********************************************************
@@ -101,12 +101,12 @@ class StgEndScript;
 class StgEndScene : public StgUserExtendScene {
 public:
 	StgEndScene(StgSystemController* controller);
-	virtual ~StgEndScene();
+	~StgEndScene() override;
 
-	void Work();
+	void Work() override;
 
-	void Start();
-	void Finish();
+	void Start() override;
+	void Finish() override;
 };
 
 /**********************************************************
@@ -120,7 +120,7 @@ public:
 
 public:
 	StgEndSceneScript(StgSystemController* controller);
-	virtual ~StgEndSceneScript();
+	~StgEndSceneScript() override;
 };
 
 /**********************************************************
@@ -130,12 +130,12 @@ class StgReplaySaveScript;
 class StgReplaySaveScene : public StgUserExtendScene {
 public:
 	StgReplaySaveScene(StgSystemController* controller);
-	virtual ~StgReplaySaveScene();
+	~StgReplaySaveScene() override;
 
-	void Work();
+	void Work() override;
 
-	void Start();
-	void Finish();
+	void Start() override;
+	void Finish() override;
 };
 
 /**********************************************************
@@ -149,7 +149,7 @@ public:
 
 public:
 	StgReplaySaveScript(StgSystemController* controller);
-	virtual ~StgReplaySaveScript();
+	~StgReplaySaveScript() override;
 };
 
 #endif

--- a/source/TouhouDanmakufu/Common/StgUserExtendScene.hpp
+++ b/source/TouhouDanmakufu/Common/StgUserExtendScene.hpp
@@ -22,7 +22,7 @@ public:
 
 protected:
 	void _InitializeTransitionTexture();
-	void _InitializeScript(std::wstring path, int type);
+	void _InitializeScript(const std::wstring& path, int type);
 	void _CallScriptMainLoop();
 	void _CallScriptFinalize();
 	void _AddRelativeManager();
@@ -45,7 +45,7 @@ public:
 
 	void CallScriptFinalizeAll();
 	gstd::value GetResultValue();
-	bool IsRealValue(gstd::value val);
+	bool IsRealValue(const gstd::value& val);
 
 protected:
 	StgSystemController* systemController_;

--- a/source/TouhouDanmakufu/DnhExecutor/Common.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/Common.cpp
@@ -16,9 +16,7 @@ MenuTask::MenuTask()
 	bPageChangeY_ = false;
 	bWaitedKeyFree_ = false;
 }
-MenuTask::~MenuTask()
-{
-}
+MenuTask::~MenuTask() = default;
 void MenuTask::Clear()
 {
 	item_.clear();
@@ -30,13 +28,13 @@ int MenuTask::_GetCursorKeyState()
 	EDirectInput* input = EDirectInput::GetInstance();
 	int res = CURSOR_NONE;
 	int vkeys[] = { EDirectInput::KEY_LEFT, EDirectInput::KEY_RIGHT, EDirectInput::KEY_UP, EDirectInput::KEY_DOWN };
-	for (int iKey = 0; iKey < CURSOR_COUNT && res == CURSOR_NONE; iKey++) {
+	for (int iKey = 0; iKey < CURSOR_COUNT && res == CURSOR_NONE; ++iKey) {
 		int state = input->GetVirtualKeyState(vkeys[iKey]);
 		if (state == KEY_PUSH) {
 			cursorFrame_[iKey] = 0;
 			res = iKey;
 		} else if (state == KEY_HOLD) {
-			cursorFrame_[iKey]++;
+			++cursorFrame_[iKey];
 			if (cursorFrame_[iKey] % 5 == 4 && cursorFrame_[iKey] > 15)
 				res = iKey;
 		}
@@ -55,10 +53,10 @@ void MenuTask::_MoveCursor()
 		int countCurrentPageMaxX = GetCurrentPageMaxX();
 		int countCurrentPageMaxY = GetCurrentPageMaxY();
 		if (stateCursor == CURSOR_LEFT) {
-			cursorX_--;
+			--cursorX_;
 			if (cursorX_ < 0) {
 				if (bPageChangeX_) {
-					pageCurrent_--;
+					--pageCurrent_;
 					if (pageCurrent_ <= 0)
 						pageCurrent_ = GetPageCount();
 				}
@@ -66,10 +64,10 @@ void MenuTask::_MoveCursor()
 			}
 			cursorY_ = min(cursorY_, GetCurrentPageMaxY());
 		} else if (stateCursor == CURSOR_RIGHT) {
-			cursorX_++;
+			++cursorX_;
 			if (cursorX_ > countCurrentPageMaxX) {
 				if (bPageChangeX_) {
-					pageCurrent_++;
+					++pageCurrent_;
 					if (pageCurrent_ > GetPageCount())
 						pageCurrent_ = 1;
 				}
@@ -77,20 +75,20 @@ void MenuTask::_MoveCursor()
 			}
 			cursorY_ = min(cursorY_, GetCurrentPageMaxY());
 		} else if (stateCursor == CURSOR_UP) {
-			cursorY_--;
+			--cursorY_;
 			if (cursorY_ < 0) {
 				if (bPageChangeY_) {
-					pageCurrent_--;
+					--pageCurrent_;
 					if (pageCurrent_ <= 0)
 						pageCurrent_ = GetPageCount();
 				}
 				cursorY_ = countCurrentPageMaxY;
 			}
 		} else if (stateCursor == CURSOR_DOWN) {
-			cursorY_++;
+			++cursorY_;
 			if (cursorY_ > countCurrentPageMaxY) {
 				if (bPageChangeY_) {
-					pageCurrent_++;
+					++pageCurrent_;
 					if (pageCurrent_ >= GetPageCount())
 						pageCurrent_ = 1;
 				}
@@ -125,7 +123,7 @@ void MenuTask::Work()
 		for (int iItem = 0; iItem < countCurrentPageItem; iItem++) {
 			int index = indexTop + iItem;
 			ref_count_ptr<MenuItem> item = item_[index];
-			if (item == NULL)
+			if (item == nullptr)
 				continue;
 			item->Work();
 		}
@@ -133,59 +131,44 @@ void MenuTask::Work()
 }
 void MenuTask::Render()
 {
-	{
-		Lock lock(cs_);
-		int indexTop = ((pageMaxX_ + 1) * (pageMaxY_ + 1)) * (pageCurrent_ - 1);
-		int countCurrentPageItem = GetCurrentPageItemCount();
-		for (int iItem = 0; iItem < countCurrentPageItem; iItem++) {
-			int index = indexTop + iItem;
-			ref_count_ptr<MenuItem> item = item_[index];
-			if (item == NULL)
-				continue;
-			item->Render();
-		}
+	Lock lock(cs_);
+	int indexTop = ((pageMaxX_ + 1) * (pageMaxY_ + 1)) * (pageCurrent_ - 1);
+	int countCurrentPageItem = GetCurrentPageItemCount();
+	for (int iItem = 0; iItem < countCurrentPageItem; ++iItem) {
+		int index = indexTop + iItem;
+		ref_count_ptr<MenuItem> item = item_[index];
+		if (item == nullptr)
+			continue;
+		item->Render();
 	}
 }
 void MenuTask::AddMenuItem(ref_count_ptr<MenuItem> item)
 {
-	{
-		Lock lock(cs_);
-		item->menu_ = this;
-		item_.push_back(item);
-	}
+	Lock lock(cs_);
+	item->menu_ = this;
+	item_.push_back(item);
 }
 int MenuTask::GetPageCount()
 {
-	int res = 0;
-	{
-		Lock lock(cs_);
-		int countOnePage = (pageMaxX_ + 1) * (pageMaxY_ + 1);
-		int countItem = item_.size();
-		res = max(1, (countItem - 1) / countOnePage + 1);
-	}
-	return res;
+	Lock lock(cs_);
+	int countOnePage = (pageMaxX_ + 1) * (pageMaxY_ + 1);
+	int countItem = item_.size();
+	return max(1, (countItem - 1) / countOnePage + 1);
 }
 int MenuTask::GetSelectedItemIndex()
 {
-	int res = -1;
-	{
-		Lock lock(cs_);
-		int indexTop = ((pageMaxX_ + 1) * (pageMaxY_ + 1)) * (pageCurrent_ - 1);
-		res = indexTop + cursorX_ + cursorY_ * (pageMaxX_ + 1);
-	}
-	return res;
+	Lock lock(cs_);
+	int indexTop = ((pageMaxX_ + 1) * (pageMaxY_ + 1)) * (pageCurrent_ - 1);
+	return indexTop + cursorX_ + cursorY_ * (pageMaxX_ + 1);
 }
 ref_count_ptr<MenuItem> MenuTask::GetSelectedMenuItem()
 {
-	ref_count_ptr<MenuItem> res = NULL;
-	{
-		Lock lock(cs_);
-		int index = GetSelectedItemIndex();
-		if (index >= 0 && index < item_.size()) {
-			res = item_[index];
-		}
+	Lock lock(cs_);
+	int index = GetSelectedItemIndex();
+	if (index >= 0 && index < item_.size()) {
+		return item_[index];
 	}
-	return res;
+	return nullptr;
 }
 
 int MenuTask::GetCurrentPageItemCount() const
@@ -216,7 +199,7 @@ TextLightUpMenuItem::TextLightUpMenuItem()
 void TextLightUpMenuItem::_WorkSelectedItem()
 {
 	if (menu_->GetSelectedMenuItem() == this)
-		frameSelected_++;
+		++frameSelected_;
 	else
 		frameSelected_ = 0;
 }

--- a/source/TouhouDanmakufu/DnhExecutor/Common.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/Common.cpp
@@ -188,20 +188,20 @@ ref_count_ptr<MenuItem> MenuTask::GetSelectedMenuItem()
 	return res;
 }
 
-int MenuTask::GetCurrentPageItemCount()
+int MenuTask::GetCurrentPageItemCount() const
 {
 	int countItem = item_.size();
 	int countCurrentPageItem = countItem - ((pageMaxX_ + 1) * (pageMaxY_ + 1)) * (pageCurrent_ - 1);
 	countCurrentPageItem = min(countCurrentPageItem, (pageMaxX_ + 1) * (pageMaxY_ + 1));
 	return countCurrentPageItem;
 }
-int MenuTask::GetCurrentPageMaxX()
+int MenuTask::GetCurrentPageMaxX() const
 {
 	int countCurrentPageItem = GetCurrentPageItemCount();
 	int countCurrentPageMaxX = min(pageMaxX_, max(0, countCurrentPageItem - 1));
 	return countCurrentPageMaxX;
 }
-int MenuTask::GetCurrentPageMaxY()
+int MenuTask::GetCurrentPageMaxY() const
 {
 	int countCurrentPageItem = GetCurrentPageItemCount();
 	int countCurrentPageMaxY = min(pageMaxY_, max(0, (countCurrentPageItem - 1) / (pageMaxX_ + 1)));

--- a/source/TouhouDanmakufu/DnhExecutor/Common.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/Common.hpp
@@ -64,8 +64,8 @@ class MenuItem {
 	friend MenuTask;
 
 public:
-	MenuItem() {}
-	virtual ~MenuItem() {}
+	MenuItem() = default;
+	virtual ~MenuItem() = default;
 	virtual void Work() {}
 	virtual void Render() {}
 

--- a/source/TouhouDanmakufu/DnhExecutor/Common.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/Common.hpp
@@ -35,16 +35,16 @@ public:
 	int GetSelectedItemIndex();
 	ref_count_ptr<MenuItem> GetSelectedMenuItem();
 
-	int GetCurrentPageItemCount();
-	int GetCurrentPageMaxX();
-	int GetCurrentPageMaxY();
+	int GetCurrentPageItemCount() const;
+	int GetCurrentPageMaxX() const;
+	int GetCurrentPageMaxY() const;
 
 protected:
 	int _GetCursorKeyState();
 	virtual void _MoveCursor();
 	virtual void _ChangePage(){};
 
-	bool _IsWaitedKeyFree() { return bWaitedKeyFree_; }
+	bool _IsWaitedKeyFree() const { return bWaitedKeyFree_; }
 
 	CriticalSection cs_;
 	bool bActive_;

--- a/source/TouhouDanmakufu/DnhExecutor/GcLibImpl.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/GcLibImpl.cpp
@@ -5,12 +5,8 @@
 /**********************************************************
 //EApplication
 **********************************************************/
-EApplication::EApplication()
-{
-}
-EApplication::~EApplication()
-{
-}
+EApplication::EApplication() = default;
+EApplication::~EApplication() = default;
 bool EApplication::_Initialize()
 {
 	ELogger* logger = ELogger::GetInstance();
@@ -26,7 +22,7 @@ bool EApplication::_Initialize()
 
 	DnhConfiguration* config = DnhConfiguration::CreateInstance();
 	std::wstring configWindowTitle = config->GetWindowTitle();
-	if (configWindowTitle.size() > 0)
+	if (!configWindowTitle.empty())
 		appName = configWindowTitle;
 
 	//マウス表示
@@ -194,12 +190,8 @@ bool EApplication::_Finalize()
 /**********************************************************
 //EDirectGraphics
 **********************************************************/
-EDirectGraphics::EDirectGraphics()
-{
-}
-EDirectGraphics::~EDirectGraphics()
-{
-}
+EDirectGraphics::EDirectGraphics() = default;
+EDirectGraphics::~EDirectGraphics() = default;
 bool EDirectGraphics::Initialize()
 {
 	DnhConfiguration* dnhConfig = DnhConfiguration::GetInstance();

--- a/source/TouhouDanmakufu/DnhExecutor/GcLibImpl.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/GcLibImpl.hpp
@@ -14,12 +14,12 @@ private:
 	EApplication();
 
 protected:
-	bool _Initialize();
-	bool _Loop();
-	bool _Finalize();
+	bool _Initialize() override;
+	bool _Loop() override;
+	bool _Finalize() override;
 
 public:
-	~EApplication();
+	~EApplication() override;
 };
 
 /**********************************************************
@@ -32,11 +32,11 @@ private:
 	EDirectGraphics();
 
 protected:
-	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;
 
 public:
-	~EDirectGraphics();
-	virtual bool Initialize();
+	~EDirectGraphics() override;
+	bool Initialize() override;
 	void SetRenderStateFor2D(int blend);
 };
 

--- a/source/TouhouDanmakufu/DnhExecutor/ScriptSelectScene.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/ScriptSelectScene.cpp
@@ -1,5 +1,5 @@
-#include"ScriptSelectScene.hpp"
-#include"System.hpp"
+#include "ScriptSelectScene.hpp"
+#include "System.hpp"
 
 /**********************************************************
 //ScriptSelectScene
@@ -13,8 +13,8 @@ ScriptSelectScene::ScriptSelectScene()
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	int screenWidth = graphics->GetScreenWidth();
 	int screenHeight = graphics->GetScreenHeight();
-	RECT_D srcBack = {0., 0., 640., 480.};
-	RECT_D destBack = {0., 0., (double)screenWidth, (double)screenHeight};
+	RECT_D srcBack = { 0.0, 0.0, 640.0, 480.0 };
+	RECT_D destBack = { 0.0, 0.0, (double)screenWidth, (double)screenHeight };
 	spriteBack_ = new Sprite2D();
 	spriteBack_->SetTexture(textureBack);
 	spriteBack_->SetVertex(srcBack, destBack);
@@ -46,36 +46,29 @@ void ScriptSelectScene::_ChangePage()
 	dxText.SetFontBold(true);
 
 	int top = (pageCurrent_ - 1) * (pageMaxY_ + 1);
-	for(int iItem = 0 ; iItem <= pageMaxY_ ; iItem++)
-	{
+	for (int iItem = 0; iItem <= pageMaxY_; ++iItem) {
 		int index = top + iItem;
-		if(index < item_.size() && item_[index] != NULL)
-		{
-			ScriptSelectSceneMenuItem* pItem = (ScriptSelectSceneMenuItem*)item_[index].GetPointer();
-			if(pItem->GetType() == ScriptSelectSceneMenuItem::TYPE_DIR)
-			{
-				dxText.SetFontColorTop(D3DCOLOR_ARGB(255,255,255,255));
-				dxText.SetFontColorBottom(D3DCOLOR_ARGB(255,255,64,64));
-				dxText.SetFontBorderColor(D3DCOLOR_ARGB(255,128,32,32));
+		if (index < item_.size() && item_[index] != nullptr) {
+			auto* pItem = (ScriptSelectSceneMenuItem*)item_[index].GetPointer();
+			if (pItem->GetType() == ScriptSelectSceneMenuItem::TYPE_DIR) {
+				dxText.SetFontColorTop(D3DCOLOR_ARGB(255, 255, 255, 255));
+				dxText.SetFontColorBottom(D3DCOLOR_ARGB(255, 255, 64, 64));
+				dxText.SetFontBorderColor(D3DCOLOR_ARGB(255, 128, 32, 32));
 				std::wstring path = pItem->GetPath();
 				std::wstring text = L"[DIR.] ";
 				text += PathProperty::GetDirectoryName(path);
 				dxText.SetText(text);
-			}
-			else
-			{
-				dxText.SetFontColorTop(D3DCOLOR_ARGB(255,255,255,255));
-				dxText.SetFontColorBottom(D3DCOLOR_ARGB(255,64,64,255));
-				dxText.SetFontBorderColor(D3DCOLOR_ARGB(255,32,32,128));
+			} else {
+				dxText.SetFontColorTop(D3DCOLOR_ARGB(255, 255, 255, 255));
+				dxText.SetFontColorBottom(D3DCOLOR_ARGB(255, 64, 64, 255));
+				dxText.SetFontBorderColor(D3DCOLOR_ARGB(255, 32, 32, 128));
 				ref_count_ptr<ScriptInformation> info = pItem->GetScriptInformation();
 				dxText.SetText(info->GetTitle());
 			}
 
 			objMenuText_[iItem] = dxText.CreateRenderObject();
-		}
-		else
-		{
-			objMenuText_[iItem] = NULL;
+		} else {
+			objMenuText_[iItem] = nullptr;
 		}
 	}
 
@@ -85,32 +78,31 @@ void ScriptSelectScene::Work()
 {
 	{
 		ref_count_ptr<ScriptSelectFileModel> model = ref_count_ptr<ScriptSelectFileModel>::DownCast(model_);
-		if(model != NULL && model->GetStatus() == Thread::RUN)
-		{
-			if(model->GetWaitPath().size() > 0)return;
+		if (model != nullptr && model->GetStatus() == Thread::RUN) {
+			if (!model->GetWaitPath().empty())
+				return;
 		}
 	}
-	if(!bActive_)return;
+	if (!bActive_)
+		return;
 
 	int lastCursorY = cursorY_;
 
 	MenuTask::Work();
-	if(!_IsWaitedKeyFree())return;
+	if (!_IsWaitedKeyFree())
+		return;
 
 	EDirectInput* input = EDirectInput::GetInstance();
-	if(input->GetVirtualKeyState(EDirectInput::KEY_OK) == KEY_PUSH)
-	{
+	if (input->GetVirtualKeyState(EDirectInput::KEY_OK) == KEY_PUSH) {
 		ref_count_ptr<MenuItem> tItem = GetSelectedMenuItem();
 		ref_count_ptr<ScriptSelectSceneMenuItem> item = ref_count_ptr<ScriptSelectSceneMenuItem>::DownCast(tItem);
-		if(item != NULL)
-		{
+		if (item != nullptr) {
 			bool bDir = item->GetType() == ScriptSelectSceneMenuItem::TYPE_DIR;
-			if(bDir)
-			{
+			if (bDir) {
 				//ディレクトリ
-				ref_count_ptr<ScriptSelectModel> model = NULL;
+				ref_count_ptr<ScriptSelectModel> model = nullptr;
 				int index = GetSelectedItemIndex();
-				ScriptSelectSceneMenuItem* pItem = (ScriptSelectSceneMenuItem*)item_[index].GetPointer();
+				auto* pItem = (ScriptSelectSceneMenuItem*)item_[index].GetPointer();
 				std::wstring dir = pItem->GetPath();
 
 				//ページリセット
@@ -123,14 +115,12 @@ void ScriptSelectScene::Work()
 
 				SystemController::GetInstance()->GetSystemInformation()->SetLastScriptSearchDirectory(dir);
 				bWaitedKeyFree_ = false;
-			}
-			else
-			{
+			} else {
 				//スクリプト
 				SetActive(false);
 
 				int index = GetSelectedItemIndex();
-				ScriptSelectSceneMenuItem* pItem = (ScriptSelectSceneMenuItem*)item_[index].GetPointer();
+				auto* pItem = (ScriptSelectSceneMenuItem*)item_[index].GetPointer();
 				ref_count_ptr<ScriptInformation> info = pItem->GetScriptInformation();
 
 				std::wstring pathLastSelected = info->GetScriptPath();
@@ -140,25 +130,23 @@ void ScriptSelectScene::Work()
 				ref_count_ptr<PlayTypeSelectScene> task = new PlayTypeSelectScene(info);
 				taskManager->AddTask(task);
 				taskManager->AddWorkFunction(TTaskFunction<PlayTypeSelectScene>::Create(
-					task, &PlayTypeSelectScene::Work), PlayTypeSelectScene::TASK_PRI_WORK);
+					task, &PlayTypeSelectScene::Work),
+					PlayTypeSelectScene::TASK_PRI_WORK);
 				taskManager->AddRenderFunction(TTaskFunction<PlayTypeSelectScene>::Create(
-					task, &PlayTypeSelectScene::Render), PlayTypeSelectScene::TASK_PRI_RENDER);
+					task, &PlayTypeSelectScene::Render),
+					PlayTypeSelectScene::TASK_PRI_RENDER);
 
 				return;
 			}
 		}
-	}
-	else if(input->GetVirtualKeyState(EDirectInput::KEY_CANCEL) == KEY_PUSH)
-	{
+	} else if (input->GetVirtualKeyState(EDirectInput::KEY_CANCEL) == KEY_PUSH) {
 		bool bTitle = true;
 
-		if(GetType() == TYPE_DIR)
-		{
+		if (GetType() == TYPE_DIR) {
 			ref_count_ptr<ScriptSelectFileModel> fileModel = ref_count_ptr<ScriptSelectFileModel>::DownCast(model_);
 			std::wstring dir = fileModel->GetDirectory();
 			std::wstring root = EPathProperty::GetStgScriptRootDirectory();
-			if(!File::IsEqualsPath(dir, root))
-			{
+			if (!File::IsEqualsPath(dir, root)) {
 				//キャンセル
 				bTitle = false;
 				std::wstring dirOld = SystemController::GetInstance()->GetSystemInformation()->GetLastScriptSearchDirectory();
@@ -180,16 +168,17 @@ void ScriptSelectScene::Work()
 			}
 		}
 
-		if(bTitle)
-		{
+		if (bTitle) {
 			SceneManager* sceneManager = SystemController::GetInstance()->GetSceneManager();
 			sceneManager->TransTitleScene();
 			return;
 		}
 	}
 
-	if(lastCursorY != cursorY_)frameSelect_ = 0;
-	else frameSelect_++;
+	if (lastCursorY != cursorY_)
+		frameSelect_ = 0;
+	else
+		++frameSelect_;
 }
 void ScriptSelectScene::Render()
 {
@@ -199,34 +188,44 @@ void ScriptSelectScene::Render()
 	spriteBack_->Render();
 
 	std::wstring strType;
-	switch(GetType())
-	{
-		case TYPE_SINGLE: strType = L"Single"; break;
-		case TYPE_PLURAL: strType = L"Plural"; break;
-		case TYPE_STAGE: strType = L"Stage"; break;
-		case TYPE_PACKAGE: strType = L"Package"; break;
-		case TYPE_DIR: strType = L"Directory"; break;
-		case TYPE_ALL: strType = L"All"; break;
+	switch (GetType()) {
+	case TYPE_SINGLE:
+		strType = L"Single";
+		break;
+	case TYPE_PLURAL:
+		strType = L"Plural";
+		break;
+	case TYPE_STAGE:
+		strType = L"Stage";
+		break;
+	case TYPE_PACKAGE:
+		strType = L"Package";
+		break;
+	case TYPE_DIR:
+		strType = L"Directory";
+		break;
+	case TYPE_ALL:
+		strType = L"All";
+		break;
 	}
 
 	std::wstring strDescription = StringUtility::Format(
-		L"ファイルを選択してください (%s：%d/%d)", strType.c_str(), pageCurrent_, GetPageCount() );
+		L"ファイルを選択してください (%s：%d/%d)", strType.c_str(), pageCurrent_, GetPageCount());
 
 	DxText dxTextDescription;
-	dxTextDescription.SetFontColorTop(D3DCOLOR_ARGB(255,128,128,255));
-	dxTextDescription.SetFontColorBottom(D3DCOLOR_ARGB(255,64,64,255));
+	dxTextDescription.SetFontColorTop(D3DCOLOR_ARGB(255, 128, 128, 255));
+	dxTextDescription.SetFontColorBottom(D3DCOLOR_ARGB(255, 64, 64, 255));
 	dxTextDescription.SetFontBorderType(directx::DxFont::BORDER_FULL);
-	dxTextDescription.SetFontBorderColor(D3DCOLOR_ARGB(255,255,255,255));
+	dxTextDescription.SetFontBorderColor(D3DCOLOR_ARGB(255, 255, 255, 255));
 	dxTextDescription.SetFontBorderWidth(2);
 	dxTextDescription.SetFontSize(20);
 	dxTextDescription.SetFontBold(true);
 	dxTextDescription.SetText(strDescription);
-	dxTextDescription.SetPosition(32,8);
+	dxTextDescription.SetPosition(32, 8);
 	dxTextDescription.Render();
 
 	//ディレクトリ名
-	if(GetType() == TYPE_DIR)
-	{
+	if (GetType() == TYPE_DIR) {
 		ref_count_ptr<ScriptSelectFileModel> fileModel = ref_count_ptr<ScriptSelectFileModel>::DownCast(model_);
 		std::wstring dir = fileModel->GetDirectory();
 		std::wstring root = EPathProperty::GetStgScriptRootDirectory();
@@ -236,14 +235,14 @@ void ScriptSelectScene::Render()
 		std::wstring textDir = L"script/" + StringUtility::ReplaceAll(dir, root, L"");
 
 		DxText dxTextDir;
-		dxTextDir.SetFontColorTop(D3DCOLOR_ARGB(255,255,255,255));
-		dxTextDir.SetFontColorBottom(D3DCOLOR_ARGB(255,255,128,128));
+		dxTextDir.SetFontColorTop(D3DCOLOR_ARGB(255, 255, 255, 255));
+		dxTextDir.SetFontColorBottom(D3DCOLOR_ARGB(255, 255, 128, 128));
 		dxTextDir.SetFontBorderType(directx::DxFont::BORDER_NONE);
 		dxTextDir.SetFontBorderWidth(0);
 		dxTextDir.SetFontSize(14);
 		dxTextDir.SetFontBold(true);
 		dxTextDir.SetText(strDescription);
-		dxTextDir.SetPosition(40,32);
+		dxTextDir.SetPosition(40, 32);
 		dxTextDir.SetText(textDir);
 		dxTextDir.Render();
 	}
@@ -251,37 +250,36 @@ void ScriptSelectScene::Render()
 	{
 		//タイトル
 		Lock lock(cs_);
-		for(int iItem = 0 ; iItem <= pageMaxY_ ; iItem++)
-		{
+		for (int iItem = 0; iItem <= pageMaxY_; ++iItem) {
 			ref_count_ptr<DxTextRenderObject> obj = objMenuText_[iItem];
-			if(obj == NULL)continue;
+			if (obj == nullptr)
+				continue;
 			int alphaText = bActive_ ? 255 : 128;
 			obj->SetVertexColor(D3DCOLOR_ARGB(255, alphaText, alphaText, alphaText));
 			obj->SetPosition(32, 48 + iItem * 18);
 			obj->Render();
 
-			if(iItem == cursorY_)
-			{
+			if (iItem == cursorY_) {
 				graphics->SetBlendMode(DirectGraphics::MODE_BLEND_ADD_RGB);
 				int cycle = 60;
 				int alpha = frameSelect_ % cycle;
-				if(alpha < cycle / 2)alpha = 255 * (float)((float)(cycle / 2 - alpha) / (float)(cycle / 2));
-				else alpha = 255 * (float)((float)(alpha - cycle / 2) / (float)(cycle / 2));
-				obj->SetVertexColor(D3DCOLOR_ARGB(255, alpha, alpha, alpha ));
+				if (alpha < cycle / 2)
+					alpha = 255 * (float)((float)(cycle / 2 - alpha) / (float)(cycle / 2));
+				else
+					alpha = 255 * (float)((float)(alpha - cycle / 2) / (float)(cycle / 2));
+				obj->SetVertexColor(D3DCOLOR_ARGB(255, alpha, alpha, alpha));
 				obj->Render();
 				obj->SetVertexColor(D3DCOLOR_ARGB(255, 255, 255, 255));
 				graphics->SetBlendMode(DirectGraphics::MODE_BLEND_ALPHA);
 			}
 		}
 
-		ref_count_ptr<ScriptSelectSceneMenuItem> item =
-			ref_count_ptr<ScriptSelectSceneMenuItem>::DownCast(GetSelectedMenuItem());
-		if(bActive_ && item != NULL && item->GetType() != ScriptSelectSceneMenuItem::TYPE_DIR)
-		{
+		ref_count_ptr<ScriptSelectSceneMenuItem> item = ref_count_ptr<ScriptSelectSceneMenuItem>::DownCast(GetSelectedMenuItem());
+		if (bActive_ && item != nullptr && item->GetType() != ScriptSelectSceneMenuItem::TYPE_DIR) {
 			ref_count_ptr<ScriptInformation> info = item->GetScriptInformation();
 
 			DxText dxTextInfo;
-			dxTextInfo.SetFontBorderColor(D3DCOLOR_ARGB(255,255,255,255));
+			dxTextInfo.SetFontBorderColor(D3DCOLOR_ARGB(255, 255, 255, 255));
 			dxTextInfo.SetFontBorderType(directx::DxFont::BORDER_NONE);
 			dxTextInfo.SetFontBorderWidth(0);
 			dxTextInfo.SetFontSize(16);
@@ -289,28 +287,24 @@ void ScriptSelectScene::Render()
 
 			//イメージ
 			ref_count_ptr<Texture> texture = spriteImage_->GetTexture();
-			std::wstring pathImage1 = L"";
-			if(texture != NULL)pathImage1 = texture->GetName();
+			std::wstring pathImage1;
+			if (texture != nullptr)
+				pathImage1 = texture->GetName();
 			std::wstring pathImage2 = info->GetImagePath();
-			if(pathImage1 != pathImage2)
-			{
+			if (pathImage1 != pathImage2) {
 				texture = new Texture();
 				File file(pathImage2);
-				if(file.IsExists())
-				{
+				if (file.IsExists()) {
 					texture->CreateFromFileInLoadThread(pathImage2);
 					spriteImage_->SetTexture(texture);
-				}
-				else
-					spriteImage_->SetTexture(NULL);
-
+				} else
+					spriteImage_->SetTexture(nullptr);
 			}
 
 			texture = spriteImage_->GetTexture();
-			if(texture != NULL && texture->IsLoad())
-			{
-				RECT_D rcSrc = {0., 0., (double)texture->GetWidth(), (double)texture->GetHeight()};
-				RECT_D rcDest = {340., 250., (double)(rcDest.left + 280), (double)(rcDest.top + 210)};
+			if (texture != nullptr && texture->IsLoad()) {
+				RECT_D rcSrc = { 0., 0., (double)texture->GetWidth(), (double)texture->GetHeight() };
+				RECT_D rcDest = { 340., 250., (double)(rcDest.left + 280), (double)(rcDest.top + 210) };
 				spriteImage_->SetSourceRect(rcSrc);
 				spriteImage_->SetDestinationRect(rcDest);
 				spriteImage_->Render();
@@ -324,59 +318,62 @@ void ScriptSelectScene::Render()
 			path = StringUtility::ReplaceAll(path, root, L"");
 
 			std::wstring archive = info->GetArchivePath();
-			if(archive.size() > 0)
-			{
+			if (!archive.empty()) {
 				archive = PathProperty::ReplaceYenToSlash(archive);
 				archive = StringUtility::ReplaceAll(archive, root, L"");
 				path += StringUtility::Format(L" [%s]", archive.c_str());
 			}
 
-			dxTextInfo.SetFontColorTop(D3DCOLOR_ARGB(255,255,255,255));
-			dxTextInfo.SetFontColorBottom(D3DCOLOR_ARGB(255,255,64,64));
+			dxTextInfo.SetFontColorTop(D3DCOLOR_ARGB(255, 255, 255, 255));
+			dxTextInfo.SetFontColorBottom(D3DCOLOR_ARGB(255, 255, 64, 64));
 			dxTextInfo.SetText(path);
 			dxTextInfo.SetPosition(16, 240);
 			dxTextInfo.Render();
 
 			//スクリプト種別
 			int type = info->GetType();
-			std::wstring strType = L"";
-			switch(type)
-			{
-			case ScriptInformation::TYPE_SINGLE:strType = L"(Single)";break;
-			case ScriptInformation::TYPE_PLURAL:strType = L"(Plural)";break;
-			case ScriptInformation::TYPE_STAGE:strType = L"(Stage)";break;
-			case ScriptInformation::TYPE_PACKAGE:strType = L"(Package)";break;
+			std::wstring strType;
+			switch (type) {
+			case ScriptInformation::TYPE_SINGLE:
+				strType = L"(Single)";
+				break;
+			case ScriptInformation::TYPE_PLURAL:
+				strType = L"(Plural)";
+				break;
+			case ScriptInformation::TYPE_STAGE:
+				strType = L"(Stage)";
+				break;
+			case ScriptInformation::TYPE_PACKAGE:
+				strType = L"(Package)";
+				break;
 			}
-			dxTextInfo.SetFontColorTop(D3DCOLOR_ARGB(255,255,255,255));
-			dxTextInfo.SetFontColorBottom(D3DCOLOR_ARGB(255,255,64,255));
+			dxTextInfo.SetFontColorTop(D3DCOLOR_ARGB(255, 255, 255, 255));
+			dxTextInfo.SetFontColorBottom(D3DCOLOR_ARGB(255, 255, 64, 255));
 			dxTextInfo.SetText(strType);
 			dxTextInfo.SetPosition(32, 256);
 			dxTextInfo.Render();
 
 			//テキスト
 			std::wstring text = info->GetText();
-			dxTextInfo.SetFontColorTop(D3DCOLOR_ARGB(255,255,255,255));
-			dxTextInfo.SetFontColorBottom(D3DCOLOR_ARGB(255,64,64,255));
+			dxTextInfo.SetFontColorTop(D3DCOLOR_ARGB(255, 255, 255, 255));
+			dxTextInfo.SetFontColorBottom(D3DCOLOR_ARGB(255, 64, 64, 255));
 			dxTextInfo.SetFontSize(18);
 			dxTextInfo.SetLinePitch(9);
 			dxTextInfo.SetText(text);
 			dxTextInfo.SetPosition(24, 288);
 			dxTextInfo.SetMaxWidth(320);
 			dxTextInfo.Render();
-
 		}
-
 	}
 
-	if(!model_->IsCreated())
-	{
+	if (!model_->IsCreated()) {
 		//ロード中
 		std::wstring text = L"Now Loading...";
 		DxText dxTextNowLoad;
-		dxTextNowLoad.SetFontColorTop(D3DCOLOR_ARGB(255,128,128,128));
-		dxTextNowLoad.SetFontColorBottom(D3DCOLOR_ARGB(255,64,64,64));
+		dxTextNowLoad.SetFontColorTop(D3DCOLOR_ARGB(255, 128, 128, 128));
+		dxTextNowLoad.SetFontColorBottom(D3DCOLOR_ARGB(255, 64, 64, 64));
 		dxTextNowLoad.SetFontBorderType(directx::DxFont::BORDER_FULL);
-		dxTextNowLoad.SetFontBorderColor(D3DCOLOR_ARGB(255,255,255,255));
+		dxTextNowLoad.SetFontBorderColor(D3DCOLOR_ARGB(255, 255, 255, 255));
 		dxTextNowLoad.SetFontBorderWidth(2);
 		dxTextNowLoad.SetFontSize(18);
 		dxTextNowLoad.SetFontBold(true);
@@ -391,8 +388,7 @@ int ScriptSelectScene::GetType()
 {
 	int res = TYPE_SINGLE;
 	ref_count_ptr<ScriptSelectFileModel> fileModel = ref_count_ptr<ScriptSelectFileModel>::DownCast(model_);
-	if(fileModel != NULL)
-	{
+	if (fileModel != nullptr) {
 		res = fileModel->GetType();
 	}
 	return res;
@@ -401,13 +397,13 @@ void ScriptSelectScene::SetModel(ref_count_ptr<ScriptSelectModel> model)
 {
 	ClearModel();
 
-	if(model == NULL)return;
+	if (model == nullptr)
+		return;
 	model->scene_ = this;
 	model_ = model;
 
 	ref_count_ptr<ScriptSelectFileModel> fileModel = ref_count_ptr<ScriptSelectFileModel>::DownCast(model_);
-	if(fileModel != NULL)
-	{
+	if (fileModel != nullptr) {
 		SystemController::GetInstance()->GetSystemInformation()->SetLastSelectScriptSceneType(
 			fileModel->GetType());
 	}
@@ -417,77 +413,71 @@ void ScriptSelectScene::SetModel(ref_count_ptr<ScriptSelectModel> model)
 void ScriptSelectScene::ClearModel()
 {
 	Clear();
-	if(model_ != NULL)
-	{
+	if (model_ != nullptr) {
 		ref_count_ptr<ScriptSelectFileModel> fileModel = ref_count_ptr<ScriptSelectFileModel>::DownCast(model_);
-		if(fileModel != NULL)
-		{
+		if (fileModel != nullptr) {
 			fileModel->Stop();
 		}
 		fileModel->Join();
 	}
 
-	model_ = NULL;
+	model_ = nullptr;
 }
 
-void ScriptSelectScene::AddMenuItem(std::list<ref_count_ptr<ScriptSelectSceneMenuItem> >& listItem)
+void ScriptSelectScene::AddMenuItem(std::list<ref_count_ptr<ScriptSelectSceneMenuItem>>& listItem)
 {
-	if(listItem.size() == 0)return;
+	if (listItem.empty())
+		return;
 
-	{
-		Lock lock(cs_);
+	Lock lock(cs_);
 
-		std::list<ref_count_ptr<ScriptSelectSceneMenuItem> >::iterator itr = listItem.begin();
-		for(;itr != listItem.end() ; itr++)
-		{
-			MenuTask::AddMenuItem((*itr));
-		}
-
-		//現在選択中のアイテム
-		ref_count_ptr<MenuItem> item = GetSelectedMenuItem();
-
-		//ソート
-		std::sort(item_.begin(), item_.end(), ScriptSelectScene::Sort());
-
-		//現在選択中のアイテムに移動
-		if(item != NULL)
-		{
-			bool bWait = false;
-			std::wstring path = L"";
-			ref_count_ptr<ScriptSelectFileModel> model = ref_count_ptr<ScriptSelectFileModel>::DownCast(model_);
-			if(model != NULL)
-			{
-				path = model->GetWaitPath();
-				if(path.size() > 0)
-					bWait = true;
-			}
-
-			if(path.size() == 0 && (pageCurrent_ > 1 || cursorY_ > 0))
-			{
-				ScriptSelectSceneMenuItem* pItem = (ScriptSelectSceneMenuItem*)item.GetPointer();
-				path = pItem->GetPath();
-			}
-
-			for(int iItem = 0 ; iItem < item_.size() ; iItem++)
-			{
-				ScriptSelectSceneMenuItem* itrItem = (ScriptSelectSceneMenuItem*)item_[iItem].GetPointer();
-				if(itrItem == NULL)continue;
-
-				bool bEqualsPath = File::IsEqualsPath(path , itrItem->GetPath());;
-				if(!bEqualsPath)continue;
-
-				pageCurrent_ = iItem / (pageMaxY_ + 1) + 1;
-				cursorY_ = iItem % (pageMaxY_ + 1);
-
-				if(bWait)
-					model->SetWaitPath(L"");
-
-				break;
-			}
-		}
-
-		_ChangePage();
+	for (auto& item : listItem) {
+		MenuTask::AddMenuItem(item);
 	}
+
+	//現在選択中のアイテム
+	ref_count_ptr<MenuItem> item = GetSelectedMenuItem();
+
+	//ソート
+	std::sort(item_.begin(), item_.end(), ScriptSelectScene::Sort());
+
+	//現在選択中のアイテムに移動
+	if (item != nullptr) {
+		bool bWait = false;
+		std::wstring path;
+		ref_count_ptr<ScriptSelectFileModel> model = ref_count_ptr<ScriptSelectFileModel>::DownCast(model_);
+		if (model != nullptr) {
+			path = model->GetWaitPath();
+			if (!path.empty())
+				bWait = true;
+		}
+
+		if (path.empty() && (pageCurrent_ > 1 || cursorY_ > 0)) {
+			auto* pItem = (ScriptSelectSceneMenuItem*)item.GetPointer();
+			path = pItem->GetPath();
+		}
+
+		for (int iItem = 0; iItem < item_.size(); ++iItem) {
+			auto* itrItem = (ScriptSelectSceneMenuItem*)item_[iItem].GetPointer();
+			if (itrItem == nullptr)
+				continue;
+
+			bool bEqualsPath = File::IsEqualsPath(path, itrItem->GetPath());
+			;
+			if (!bEqualsPath)
+				continue;
+
+			pageCurrent_ = iItem / (pageMaxY_ + 1) + 1;
+			cursorY_ = iItem % (pageMaxY_ + 1);
+
+			if (bWait)
+				model->SetWaitPath(L"");
+
+			break;
+		}
+	}
+
+	_ChangePage();
 }
 
 //ScriptSelectSceneMenuItem
@@ -497,9 +487,7 @@ ScriptSelectSceneMenuItem::ScriptSelectSceneMenuItem(int type, const std::wstrin
 	path_ = PathProperty::ReplaceYenToSlash(path);
 	info_ = info;
 }
-ScriptSelectSceneMenuItem::~ScriptSelectSceneMenuItem()
-{
-}
+ScriptSelectSceneMenuItem::~ScriptSelectSceneMenuItem() = default;
 
 /**********************************************************
 //ScriptSelectModel
@@ -508,10 +496,7 @@ ScriptSelectModel::ScriptSelectModel()
 {
 	bCreated_ = false;
 }
-ScriptSelectModel::~ScriptSelectModel()
-{
-}
-
+ScriptSelectModel::~ScriptSelectModel() = default;
 
 //ScriptSelectFileModel
 ScriptSelectFileModel::ScriptSelectFileModel(int type, const std::wstring& dir)
@@ -519,20 +504,16 @@ ScriptSelectFileModel::ScriptSelectFileModel(int type, const std::wstring& dir)
 	type_ = type;
 	dir_ = dir;
 }
-ScriptSelectFileModel::~ScriptSelectFileModel()
-{
-
-}
+ScriptSelectFileModel::~ScriptSelectFileModel() = default;
 void ScriptSelectFileModel::_Run()
 {
 	timeLastUpdate_ = ::timeGetTime() - 1000;
 	_SearchScript(dir_);
-	if(GetStatus() == RUN)
-	{
+	if (GetStatus() == RUN) {
 		scene_->AddMenuItem(listItem_);
 		listItem_.clear();
 	}
-	bCreated_= true;
+	bCreated_ = true;
 }
 void ScriptSelectFileModel::_SearchScript(const std::wstring& dir)
 {
@@ -540,13 +521,12 @@ void ScriptSelectFileModel::_SearchScript(const std::wstring& dir)
 	HANDLE hFind;
 	std::wstring findDir = dir + L"*.*";
 	hFind = FindFirstFile(findDir.c_str(), &data);
-	do
-	{
-		if(GetStatus() != RUN)return;
+	do {
+		if (GetStatus() != RUN)
+			return;
 
 		int time = ::timeGetTime();
-		if(abs(time - timeLastUpdate_) > 500)
-		{
+		if (abs(time - timeLastUpdate_) > 500) {
 			//500ms毎に更新
 			timeLastUpdate_ = time;
 			scene_->AddMenuItem(listItem_);
@@ -554,27 +534,22 @@ void ScriptSelectFileModel::_SearchScript(const std::wstring& dir)
 		}
 
 		std::wstring name = data.cFileName;
-		if((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
-			(name != L".." && name != L"."))
-		{
+		if (((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0u) && (name != L".." && name != L".")) {
 			//ディレクトリ
 			std::wstring tDir = dir + name;
 			tDir += L"\\";
 
-			if(type_ == TYPE_DIR)
-			{
+			if (type_ == TYPE_DIR) {
 				//ディレクトリ
 				ref_count_ptr<ScriptSelectSceneMenuItem> item = new ScriptSelectSceneMenuItem(
-					ScriptSelectSceneMenuItem::TYPE_DIR, tDir, NULL);
+					ScriptSelectSceneMenuItem::TYPE_DIR, tDir, nullptr);
 				listItem_.push_back(item);
-			}
-			else
-			{
+			} else {
 				_SearchScript(tDir);
 			}
 			continue;
 		}
-		if(wcscmp(data.cFileName, L"..")==0 || wcscmp(data.cFileName, L".")==0)
+		if (wcscmp(data.cFileName, L"..") == 0 || wcscmp(data.cFileName, L".") == 0)
 			continue;
 
 		//ファイル
@@ -582,50 +557,46 @@ void ScriptSelectFileModel::_SearchScript(const std::wstring& dir)
 
 		_CreateMenuItem(path);
 
-	}while(FindNextFile(hFind,&data));
+	} while (FindNextFile(hFind, &data));
 	FindClose(hFind);
 }
 void ScriptSelectFileModel::_CreateMenuItem(const std::wstring& path)
 {
-	std::vector<ref_count_ptr<ScriptInformation> >listInfo =
-		ScriptInformation::CreateScriptInformationList(path, true);
-	for(int iInfo = 0 ; iInfo < listInfo.size() ; iInfo++)
-	{
-		ref_count_ptr<ScriptInformation> info = listInfo[iInfo];
-		if(!_IsValidScriptInformation(info))continue;
+	std::vector<ref_count_ptr<ScriptInformation>> listInfo = ScriptInformation::CreateScriptInformationList(path, true);
+	for (auto info : listInfo) {
+		if (!_IsValidScriptInformation(info))
+			continue;
 
 		int typeItem = _ConvertTypeInfoToItem(info->GetType());
 		ref_count_ptr<ScriptSelectSceneMenuItem> item = new ScriptSelectSceneMenuItem(
 			typeItem, info->GetScriptPath(), info);
 		listItem_.push_back(item);
 	}
-
 }
 bool ScriptSelectFileModel::_IsValidScriptInformation(ref_count_ptr<ScriptInformation> info)
 {
 	int typeScript = info->GetType();
 	bool bTarget = false;
-	switch(type_)
-	{
-		case TYPE_SINGLE:
-			bTarget = (typeScript == ScriptInformation::TYPE_SINGLE);
-			break;
-		case TYPE_PLURAL:
-			bTarget = (typeScript == ScriptInformation::TYPE_PLURAL);
-			break;
-		case TYPE_STAGE:
-			bTarget |= (typeScript == ScriptInformation::TYPE_STAGE);
-			//bTarget |= (typeScript == ScriptInformation::TYPE_PACKAGE);
-			break;
-		case TYPE_PACKAGE:
-			bTarget = (typeScript == ScriptInformation::TYPE_PACKAGE);
-			break;
-		case TYPE_DIR:
-			bTarget = (typeScript != ScriptInformation::TYPE_PLAYER);
-			break;
-		case TYPE_ALL:
-			bTarget = (typeScript != ScriptInformation::TYPE_PLAYER);
-			break;
+	switch (type_) {
+	case TYPE_SINGLE:
+		bTarget = (typeScript == ScriptInformation::TYPE_SINGLE);
+		break;
+	case TYPE_PLURAL:
+		bTarget = (typeScript == ScriptInformation::TYPE_PLURAL);
+		break;
+	case TYPE_STAGE:
+		bTarget = (typeScript == ScriptInformation::TYPE_STAGE);
+		//bTarget |= (typeScript == ScriptInformation::TYPE_PACKAGE);
+		break;
+	case TYPE_PACKAGE:
+		bTarget = (typeScript == ScriptInformation::TYPE_PACKAGE);
+		break;
+	case TYPE_DIR:
+		bTarget = (typeScript != ScriptInformation::TYPE_PLAYER);
+		break;
+	case TYPE_ALL:
+		bTarget = (typeScript != ScriptInformation::TYPE_PLAYER);
+		break;
 	}
 
 	return bTarget;
@@ -633,28 +604,26 @@ bool ScriptSelectFileModel::_IsValidScriptInformation(ref_count_ptr<ScriptInform
 int ScriptSelectFileModel::_ConvertTypeInfoToItem(int typeInfo)
 {
 	int typeItem = ScriptSelectSceneMenuItem::TYPE_SINGLE;
-	switch(typeInfo)
-	{
-		case ScriptInformation::TYPE_SINGLE:
-			typeItem = ScriptSelectSceneMenuItem::TYPE_SINGLE;
-			break;
-		case ScriptInformation::TYPE_PLURAL:
-			typeItem = ScriptSelectSceneMenuItem::TYPE_PLURAL;
-			break;
-		case ScriptInformation::TYPE_STAGE:
-			typeItem = ScriptSelectSceneMenuItem::TYPE_STAGE;
-			break;
-		case ScriptInformation::TYPE_PACKAGE:
-			typeItem = ScriptSelectSceneMenuItem::TYPE_PACKAGE;
-			break;
+	switch (typeInfo) {
+	case ScriptInformation::TYPE_SINGLE:
+		typeItem = ScriptSelectSceneMenuItem::TYPE_SINGLE;
+		break;
+	case ScriptInformation::TYPE_PLURAL:
+		typeItem = ScriptSelectSceneMenuItem::TYPE_PLURAL;
+		break;
+	case ScriptInformation::TYPE_STAGE:
+		typeItem = ScriptSelectSceneMenuItem::TYPE_STAGE;
+		break;
+	case ScriptInformation::TYPE_PACKAGE:
+		typeItem = ScriptSelectSceneMenuItem::TYPE_PACKAGE;
+		break;
 	}
 	return typeItem;
 }
 void ScriptSelectFileModel::CreateMenuItem()
 {
 	bCreated_ = false;
-	if(type_ == TYPE_DIR)
-	{
+	if (type_ == TYPE_DIR) {
 		SystemController::GetInstance()->GetSystemInformation()->SetLastScriptSearchDirectory(dir_);
 	}
 	Start();
@@ -674,16 +643,13 @@ PlayTypeSelectScene::PlayTypeSelectScene(ref_count_ptr<ScriptInformation> info)
 	AddMenuItem(new PlayTypeSelectMenuItem(L"Play", mx, my));
 
 	//リプレイ
-	if(info->GetType() != ScriptInformation::TYPE_PACKAGE)
-	{
+	if (info->GetType() != ScriptInformation::TYPE_PACKAGE) {
 		int itemCount = 1;
 		std::wstring pathScript = info->GetScriptPath();
 		replayInfoManager_ = new ReplayInformationManager();
 		replayInfoManager_->UpdateInformationList(pathScript);
 		std::vector<int> listReplayIndex = replayInfoManager_->GetIndexList();
-		for(int iList = 0 ; iList < listReplayIndex.size() ; iList++)
-		{
-			int index = listReplayIndex[iList];
+		for (int index : listReplayIndex) {
 			ref_count_ptr<ReplayInformation> replay = replayInfoManager_->GetInformation(index);
 			int itemY = 256 + (itemCount % pageMaxY_) * 20;
 
@@ -693,34 +659,28 @@ PlayTypeSelectScene::PlayTypeSelectScene(ref_count_ptr<ScriptInformation> info)
 				replay->GetTotalScore(),
 				replay->GetPlayerScriptReplayName().c_str(),
 				replay->GetAvarageFps(),
-				replay->GetDateAsString().c_str()
-			);
+				replay->GetDateAsString().c_str());
 			AddMenuItem(new PlayTypeSelectMenuItem(text, mx, itemY));
-			itemCount++;
+			++itemCount;
 		}
 	}
-
 }
 void PlayTypeSelectScene::Work()
 {
 	MenuTask::Work();
-	if(!_IsWaitedKeyFree())return;
+	if (!_IsWaitedKeyFree())
+		return;
 
 	EDirectInput* input = EDirectInput::GetInstance();
-	if(input->GetVirtualKeyState(EDirectInput::KEY_OK) == KEY_PUSH)
-	{
-		if(info_->GetType() == ScriptInformation::TYPE_PACKAGE)
-		{
+	if (input->GetVirtualKeyState(EDirectInput::KEY_OK) == KEY_PUSH) {
+		if (info_->GetType() == ScriptInformation::TYPE_PACKAGE) {
 			//パッケージモード
 			SceneManager* sceneManager = SystemController::GetInstance()->GetSceneManager();
 			sceneManager->TransPackageScene(info_);
-		}
-		else
-		{
+		} else {
 			//パッケージ以外
 			int indexSelect = GetSelectedItemIndex();
-			if(indexSelect == 0)
-			{
+			if (indexSelect == 0) {
 				//自機選択
 				TransitionManager* transitionManager = SystemController::GetInstance()->GetTransitionManager();
 				transitionManager->DoFadeOut();
@@ -733,15 +693,15 @@ void PlayTypeSelectScene::Work()
 				ref_count_ptr<PlayerSelectScene> task = new PlayerSelectScene(info_);
 				taskManager->AddTask(task);
 				taskManager->AddWorkFunction(TTaskFunction<PlayerSelectScene>::Create(
-					task, &PlayerSelectScene::Work), PlayerSelectScene::TASK_PRI_WORK);
+					task, &PlayerSelectScene::Work),
+					PlayerSelectScene::TASK_PRI_WORK);
 				taskManager->AddRenderFunction(TTaskFunction<PlayerSelectScene>::Create(
-					task, &PlayerSelectScene::Render), PlayerSelectScene::TASK_PRI_RENDER);
-			}
-			else
-			{
+					task, &PlayerSelectScene::Render),
+					PlayerSelectScene::TASK_PRI_RENDER);
+			} else {
 				//リプレイ
 				std::vector<int> listReplayIndex = replayInfoManager_->GetIndexList();
-				int replayIndex = listReplayIndex[indexSelect-1];
+				int replayIndex = listReplayIndex[indexSelect - 1];
 				ref_count_ptr<ReplayInformation> replay = replayInfoManager_->GetInformation(replayIndex);
 
 				SceneManager* sceneManager = SystemController::GetInstance()->GetSceneManager();
@@ -751,17 +711,14 @@ void PlayTypeSelectScene::Work()
 
 		return;
 	}
-	else if(input->GetVirtualKeyState(EDirectInput::KEY_CANCEL) == KEY_PUSH)
-	{
+	if (input->GetVirtualKeyState(EDirectInput::KEY_CANCEL) == KEY_PUSH) {
 		ETaskManager* taskManager = ETaskManager::GetInstance();
-		ref_count_ptr<ScriptSelectScene> scriptSelectScene =
-			ref_count_ptr<ScriptSelectScene>::DownCast(taskManager->GetTask(typeid(ScriptSelectScene)));
+		ref_count_ptr<ScriptSelectScene> scriptSelectScene = ref_count_ptr<ScriptSelectScene>::DownCast(taskManager->GetTask(typeid(ScriptSelectScene)));
 		scriptSelectScene->SetActive(true);
 
 		taskManager->RemoveTask(typeid(PlayTypeSelectScene));
 		return;
 	}
-
 }
 void PlayTypeSelectScene::Render()
 {
@@ -775,19 +732,17 @@ PlayTypeSelectMenuItem::PlayTypeSelectMenuItem(std::wstring text, int x, int y)
 	pos_.y = y;
 
 	DxText dxText;
-	dxText.SetFontColorTop(D3DCOLOR_ARGB(255,255,255,255));
-	dxText.SetFontColorBottom(D3DCOLOR_ARGB(255,64,64,64));
+	dxText.SetFontColorTop(D3DCOLOR_ARGB(255, 255, 255, 255));
+	dxText.SetFontColorBottom(D3DCOLOR_ARGB(255, 64, 64, 64));
 	dxText.SetFontBorderType(directx::DxFont::BORDER_FULL);
-	dxText.SetFontBorderColor(D3DCOLOR_ARGB(255,32,32,128));
+	dxText.SetFontBorderColor(D3DCOLOR_ARGB(255, 32, 32, 128));
 	dxText.SetFontBorderWidth(1);
 	dxText.SetFontSize(14);
 	dxText.SetFontBold(true);
 	dxText.SetText(text);
 	objText_ = dxText.CreateRenderObject();
 }
-PlayTypeSelectMenuItem::~PlayTypeSelectMenuItem()
-{
-}
+PlayTypeSelectMenuItem::~PlayTypeSelectMenuItem() = default;
 void PlayTypeSelectMenuItem::Work()
 {
 	_WorkSelectedItem();
@@ -797,8 +752,7 @@ void PlayTypeSelectMenuItem::Render()
 	objText_->SetPosition(pos_);
 	objText_->Render();
 
-	if(menu_->GetSelectedMenuItem() == this)
-	{
+	if (menu_->GetSelectedMenuItem() == this) {
 		DirectGraphics* graphics = DirectGraphics::GetBase();
 		graphics->SetBlendMode(DirectGraphics::MODE_BLEND_ADD_RGB);
 
@@ -828,8 +782,8 @@ PlayerSelectScene::PlayerSelectScene(ref_count_ptr<ScriptInformation> info)
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	int screenWidth = graphics->GetScreenWidth();
 	int screenHeight = graphics->GetScreenHeight();
-	RECT_D srcBack = {0., 0., 640., 480.};
-	RECT_D destBack = {0., 0., (double)screenWidth, (double)screenHeight};
+	RECT_D srcBack = { 0.0, 0.0, 640.0, 480.0 };
+	RECT_D destBack = { 0.0, 0.0, (double)screenWidth, (double)screenHeight };
 
 	spriteBack_ = new Sprite2D();
 	spriteBack_->SetTexture(textureBack);
@@ -841,60 +795,51 @@ PlayerSelectScene::PlayerSelectScene(ref_count_ptr<ScriptInformation> info)
 
 	//自機一覧を作成
 	std::vector<std::wstring> listPlayerPath = info_->GetPlayerList();
-	if(listPlayerPath.size() == 0)
-	{
+	if (listPlayerPath.empty()) {
 		listPlayer_ = systemInfo->GetFreePlayerScriptInformationList();
-	}
-	else
-	{
+	} else {
 		listPlayer_ = info_->CreatePlayerScriptInformationList();
 	}
 
 	//メニュー作成
-	for(int iMenu = 0 ; iMenu < listPlayer_.size(); iMenu++)
-	{
-		AddMenuItem(new PlayerSelectMenuItem(listPlayer_[iMenu]));
+	for (auto& iMenu : listPlayer_) {
+		AddMenuItem(new PlayerSelectMenuItem(iMenu));
 	}
 
 	const std::vector<ref_count_ptr<ScriptInformation>>& listLastPlayerSelect = systemInfo->GetLastPlayerSelectedList();
 	bool bSameList = false;
-	if(listPlayer_.size() == listLastPlayerSelect.size())
-	{
+	if (listPlayer_.size() == listLastPlayerSelect.size()) {
 		bSameList = true;
-		for(int iList = 0 ; iList < listPlayer_.size() ; iList++)
-		{
+		for (int iList = 0; iList < listPlayer_.size(); ++iList) {
 			bSameList &= listPlayer_[iList] == listLastPlayerSelect[iList];
 		}
 	}
-	if(bSameList)
-	{
+	if (bSameList) {
 		int lastIndex = systemInfo->GetLastSelectedPlayerIndex();
 		cursorY_ = lastIndex % (pageMaxY_ + 1);
 		pageCurrent_ = lastIndex / (pageMaxY_ + 1) + 1;
 	}
-
 }
 void PlayerSelectScene::Work()
 {
 	int lastCursorY = cursorY_;
 
 	MenuTask::Work();
-	if(!_IsWaitedKeyFree())return;
+	if (!_IsWaitedKeyFree())
+		return;
 
 	EDirectInput* input = EDirectInput::GetInstance();
-	if(input->GetVirtualKeyState(EDirectInput::KEY_OK) == KEY_PUSH)
-	{
+	if (input->GetVirtualKeyState(EDirectInput::KEY_OK) == KEY_PUSH) {
 		int index = GetSelectedItemIndex();
 		ref_count_ptr<ScriptInformation> infoPlayer = listPlayer_[index];
 		SystemController::GetInstance()->GetSystemInformation()->SetLastSelectedPlayerIndex(index, listPlayer_);
 
 		SceneManager* sceneManager = SystemController::GetInstance()->GetSceneManager();
-		sceneManager->TransStgScene(info_, infoPlayer, NULL);
+		sceneManager->TransStgScene(info_, infoPlayer, nullptr);
 
 		return;
 	}
-	else if(input->GetVirtualKeyState(EDirectInput::KEY_CANCEL) == KEY_PUSH)
-	{
+	if (input->GetVirtualKeyState(EDirectInput::KEY_CANCEL) == KEY_PUSH) {
 		ETaskManager* taskManager = ETaskManager::GetInstance();
 		taskManager->SetRenderFunctionEnable(true, typeid(ScriptSelectScene));
 		taskManager->SetWorkFunctionEnable(true, typeid(PlayTypeSelectScene));
@@ -905,8 +850,10 @@ void PlayerSelectScene::Work()
 		return;
 	}
 
-	if(lastCursorY != cursorY_)frameSelect_ = 0;
-	else frameSelect_++;
+	if (lastCursorY != cursorY_)
+		frameSelect_ = 0;
+	else
+		++frameSelect_;
 }
 void PlayerSelectScene::Render()
 {
@@ -916,53 +863,46 @@ void PlayerSelectScene::Render()
 	spriteBack_->Render();
 
 	int top = (pageCurrent_ - 1) * (pageMaxY_ + 1);
-	ref_count_ptr<ScriptInformation> infoSelected = NULL;
+	ref_count_ptr<ScriptInformation> infoSelected = nullptr;
 	{
 		Lock lock(cs_);
-		for(int iItem = 0 ; iItem <= pageMaxY_ ; iItem++)
-		{
+		for (int iItem = 0; iItem <= pageMaxY_; ++iItem) {
 			int index = top + iItem;
-			if(index < item_.size() && item_[index] != NULL)
-			{
-				PlayerSelectMenuItem* pItem = (PlayerSelectMenuItem*)item_[index].GetPointer();
+			if (index < item_.size() && item_[index] != nullptr) {
+				auto* pItem = (PlayerSelectMenuItem*)item_[index].GetPointer();
 				ref_count_ptr<ScriptInformation> info = pItem->GetScriptInformation();
-				if(GetSelectedItemIndex() == index)
+				if (GetSelectedItemIndex() == index)
 					infoSelected = info;
 			}
 		}
 	}
 
-	if(infoSelected != NULL)
-	{
+	if (infoSelected != nullptr) {
 		DxText dxTextInfo;
-		dxTextInfo.SetFontBorderColor(D3DCOLOR_ARGB(255,255,255,255));
+		dxTextInfo.SetFontBorderColor(D3DCOLOR_ARGB(255, 255, 255, 255));
 		dxTextInfo.SetFontBorderType(directx::DxFont::BORDER_NONE);
 		dxTextInfo.SetFontBold(true);
 
 		//イメージ
 		ref_count_ptr<Texture> texture = spriteImage_->GetTexture();
-		std::wstring pathImage1 = L"";
-		if(texture != NULL)pathImage1 = texture->GetName();
+		std::wstring pathImage1;
+		if (texture != nullptr)
+			pathImage1 = texture->GetName();
 		std::wstring pathImage2 = infoSelected->GetImagePath();
-		if(pathImage1 != pathImage2)
-		{
+		if (pathImage1 != pathImage2) {
 			texture = new Texture();
 			File file(pathImage2);
-			if(file.IsExists())
-			{
+			if (file.IsExists()) {
 				texture->CreateFromFileInLoadThread(pathImage2);
 				spriteImage_->SetTexture(texture);
-			}
-			else
-				spriteImage_->SetTexture(NULL);
-
+			} else
+				spriteImage_->SetTexture(nullptr);
 		}
 
 		texture = spriteImage_->GetTexture();
-		if(texture != NULL && texture->IsLoad())
-		{
-			RECT_D rcSrc = {0., 0., (double)texture->GetWidth(), (double)texture->GetHeight()};
-			RECT_D rcDest = {0., 0., (double)texture->GetWidth(), (double)texture->GetHeight()};
+		if (texture != nullptr && texture->IsLoad()) {
+			RECT_D rcSrc = { 0.0, 0.0, (double)texture->GetWidth(), (double)texture->GetHeight() };
+			RECT_D rcDest = { 0.0, 0.0, (double)texture->GetWidth(), (double)texture->GetHeight() };
 			spriteImage_->SetSourceRect(rcSrc);
 			spriteImage_->SetDestinationRect(rcDest);
 			spriteImage_->Render();
@@ -976,18 +916,17 @@ void PlayerSelectScene::Render()
 		path = StringUtility::ReplaceAll(path, root, L"");
 
 		std::wstring archive = infoSelected->GetArchivePath();
-		if(archive.size() > 0)
-		{
+		if (!archive.empty()) {
 			archive = PathProperty::ReplaceYenToSlash(archive);
 			archive = StringUtility::ReplaceAll(archive, root, L"");
 			path += StringUtility::Format(L" [%s]", archive.c_str());
 		}
 
-		dxTextInfo.SetFontColorTop(D3DCOLOR_ARGB(255,255,255,255));
-		dxTextInfo.SetFontColorBottom(D3DCOLOR_ARGB(255,255,128,128));
+		dxTextInfo.SetFontColorTop(D3DCOLOR_ARGB(255, 255, 255, 255));
+		dxTextInfo.SetFontColorBottom(D3DCOLOR_ARGB(255, 255, 128, 128));
 		dxTextInfo.SetFontSize(14);
 		dxTextInfo.SetText(path);
-		dxTextInfo.SetPosition(40,32);
+		dxTextInfo.SetPosition(40, 32);
 		dxTextInfo.Render();
 
 		//テキスト
@@ -995,41 +934,38 @@ void PlayerSelectScene::Render()
 		dxTextInfo.SetFontBold(false);
 		dxTextInfo.SetFontBorderWidth(2);
 		dxTextInfo.SetFontSize(16);
-		dxTextInfo.SetFontBorderColor(D3DCOLOR_ARGB(255,255,255,255));
-		dxTextInfo.SetFontColorTop(D3DCOLOR_ARGB(255,160,160,160));
-		dxTextInfo.SetFontColorBottom(D3DCOLOR_ARGB(255,255,64,64));
+		dxTextInfo.SetFontBorderColor(D3DCOLOR_ARGB(255, 255, 255, 255));
+		dxTextInfo.SetFontColorTop(D3DCOLOR_ARGB(255, 160, 160, 160));
+		dxTextInfo.SetFontColorBottom(D3DCOLOR_ARGB(255, 255, 64, 64));
 		dxTextInfo.SetText(infoSelected->GetText());
 		dxTextInfo.SetPosition(320, 240);
 		dxTextInfo.Render();
-
 	}
 
 	std::wstring strDescription = StringUtility::Format(
-		L"攻撃方法を選択してください (%d/%d)", pageCurrent_, GetPageCount() );
+		L"攻撃方法を選択してください (%d/%d)", pageCurrent_, GetPageCount());
 
 	DxText dxTextDescription;
-	dxTextDescription.SetFontColorTop(D3DCOLOR_ARGB(255,128,128,255));
-	dxTextDescription.SetFontColorBottom(D3DCOLOR_ARGB(255,64,64,255));
+	dxTextDescription.SetFontColorTop(D3DCOLOR_ARGB(255, 128, 128, 255));
+	dxTextDescription.SetFontColorBottom(D3DCOLOR_ARGB(255, 64, 64, 255));
 	dxTextDescription.SetFontBorderType(directx::DxFont::BORDER_FULL);
-	dxTextDescription.SetFontBorderColor(D3DCOLOR_ARGB(255,255,255,255));
+	dxTextDescription.SetFontBorderColor(D3DCOLOR_ARGB(255, 255, 255, 255));
 	dxTextDescription.SetFontBorderWidth(2);
 	dxTextDescription.SetFontSize(20);
 	dxTextDescription.SetFontBold(true);
 	dxTextDescription.SetText(strDescription);
-	dxTextDescription.SetPosition(32,8);
+	dxTextDescription.SetPosition(32, 8);
 	dxTextDescription.Render();
 
 	{
 		Lock lock(cs_);
-		for(int iItem = 0 ; iItem <= pageMaxY_ ; iItem++)
-		{
+		for (int iItem = 0; iItem <= pageMaxY_; ++iItem) {
 			int index = top + iItem;
-			if(index < item_.size() && item_[index] != NULL)
-			{
+			if (index < item_.size() && item_[index] != nullptr) {
 				int mx = 320;
 				int my = 48 + (iItem % (pageMaxY_ + 1)) * 18;
 
-				PlayerSelectMenuItem* pItem = (PlayerSelectMenuItem*)item_[index].GetPointer();
+				auto* pItem = (PlayerSelectMenuItem*)item_[index].GetPointer();
 				ref_count_ptr<ScriptInformation> info = pItem->GetScriptInformation();
 
 				DxText dxText;
@@ -1038,26 +974,26 @@ void PlayerSelectScene::Render()
 				dxText.SetFontBorderWidth(2);
 				dxText.SetFontSize(16);
 				dxText.SetFontBold(true);
-				dxText.SetFontColorTop(D3DCOLOR_ARGB(255,255,255,255));
-				dxText.SetFontColorBottom(D3DCOLOR_ARGB(255,64,64,255));
-				dxText.SetFontBorderColor(D3DCOLOR_ARGB(255,32,32,128));
+				dxText.SetFontColorTop(D3DCOLOR_ARGB(255, 255, 255, 255));
+				dxText.SetFontColorBottom(D3DCOLOR_ARGB(255, 64, 64, 255));
+				dxText.SetFontBorderColor(D3DCOLOR_ARGB(255, 32, 32, 128));
 				dxText.SetText(info->GetTitle());
 				dxText.Render();
 
-				if(GetSelectedItemIndex() == index)
-				{
+				if (GetSelectedItemIndex() == index) {
 					graphics->SetBlendMode(DirectGraphics::MODE_BLEND_ADD_RGB);
 					int cycle = 60;
 					int alpha = frameSelect_ % cycle;
-					if(alpha < cycle / 2)alpha = 255 * (float)((float)(cycle / 2 - alpha) / (float)(cycle / 2));
-					else alpha = 255 * (float)((float)(alpha - cycle / 2) / (float)(cycle / 2));
-					dxText.SetVertexColor(D3DCOLOR_ARGB(255, alpha, alpha, alpha ));
+					if (alpha < cycle / 2)
+						alpha = 255 * (float)((float)(cycle / 2 - alpha) / (float)(cycle / 2));
+					else
+						alpha = 255 * (float)((float)(alpha - cycle / 2) / (float)(cycle / 2));
+					dxText.SetVertexColor(D3DCOLOR_ARGB(255, alpha, alpha, alpha));
 					dxText.Render();
 					graphics->SetBlendMode(DirectGraphics::MODE_BLEND_ALPHA);
 				}
 			}
 		}
-
 	}
 }
 
@@ -1066,14 +1002,11 @@ PlayerSelectMenuItem::PlayerSelectMenuItem(ref_count_ptr<ScriptInformation> info
 {
 	info_ = info;
 }
-PlayerSelectMenuItem::~PlayerSelectMenuItem()
-{
-}
+PlayerSelectMenuItem::~PlayerSelectMenuItem() = default;
 void PlayerSelectMenuItem::Work()
 {
 	_WorkSelectedItem();
 }
 void PlayerSelectMenuItem::Render()
 {
-
 }

--- a/source/TouhouDanmakufu/DnhExecutor/ScriptSelectScene.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/ScriptSelectScene.cpp
@@ -491,7 +491,7 @@ void ScriptSelectScene::AddMenuItem(std::list<ref_count_ptr<ScriptSelectSceneMen
 }
 
 //ScriptSelectSceneMenuItem
-ScriptSelectSceneMenuItem::ScriptSelectSceneMenuItem(int type, std::wstring path, ref_count_ptr<ScriptInformation> info)
+ScriptSelectSceneMenuItem::ScriptSelectSceneMenuItem(int type, const std::wstring& path, ref_count_ptr<ScriptInformation> info)
 {
 	type_ = type;
 	path_ = PathProperty::ReplaceYenToSlash(path);
@@ -514,7 +514,7 @@ ScriptSelectModel::~ScriptSelectModel()
 
 
 //ScriptSelectFileModel
-ScriptSelectFileModel::ScriptSelectFileModel(int type, std::wstring dir)
+ScriptSelectFileModel::ScriptSelectFileModel(int type, const std::wstring& dir)
 {
 	type_ = type;
 	dir_ = dir;
@@ -534,7 +534,7 @@ void ScriptSelectFileModel::_Run()
 	}
 	bCreated_= true;
 }
-void ScriptSelectFileModel::_SearchScript(std::wstring dir)
+void ScriptSelectFileModel::_SearchScript(const std::wstring& dir)
 {
 	WIN32_FIND_DATA data;
 	HANDLE hFind;
@@ -585,7 +585,7 @@ void ScriptSelectFileModel::_SearchScript(std::wstring dir)
 	}while(FindNextFile(hFind,&data));
 	FindClose(hFind);
 }
-void ScriptSelectFileModel::_CreateMenuItem(std::wstring path)
+void ScriptSelectFileModel::_CreateMenuItem(const std::wstring& path)
 {
 	std::vector<ref_count_ptr<ScriptInformation> >listInfo =
 		ScriptInformation::CreateScriptInformationList(path, true);
@@ -856,7 +856,7 @@ PlayerSelectScene::PlayerSelectScene(ref_count_ptr<ScriptInformation> info)
 		AddMenuItem(new PlayerSelectMenuItem(listPlayer_[iMenu]));
 	}
 
-	std::vector<ref_count_ptr<ScriptInformation> > listLastPlayerSelect = systemInfo->GetLastPlayerSelectedList();
+	const std::vector<ref_count_ptr<ScriptInformation>>& listLastPlayerSelect = systemInfo->GetLastPlayerSelectedList();
 	bool bSameList = false;
 	if(listPlayer_.size() == listLastPlayerSelect.size())
 	{

--- a/source/TouhouDanmakufu/DnhExecutor/ScriptSelectScene.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/ScriptSelectScene.hpp
@@ -35,14 +35,14 @@ private:
 	std::vector<ref_count_ptr<DxTextRenderObject>> objMenuText_;
 	int frameSelect_;
 
-	virtual void _ChangePage();
+	void _ChangePage() override;
 
 public:
 	ScriptSelectScene();
-	~ScriptSelectScene();
-	virtual void Work();
-	virtual void Render();
-	virtual void Clear();
+	~ScriptSelectScene() override;
+	void Work() override;
+	void Render() override;
+	void Clear() override;
 
 	int GetType();
 	void SetModel(ref_count_ptr<ScriptSelectModel> model);
@@ -70,7 +70,7 @@ private:
 
 public:
 	ScriptSelectSceneMenuItem(int type, const std::wstring& path, ref_count_ptr<ScriptInformation> info);
-	~ScriptSelectSceneMenuItem();
+	~ScriptSelectSceneMenuItem() override;
 
 	int GetType() const { return type_; }
 	std::wstring GetPath() const { return path_; }
@@ -83,8 +83,8 @@ public:
 	{
 		ref_count_ptr<MenuItem> lsp = lf;
 		ref_count_ptr<MenuItem> rsp = rf;
-		ScriptSelectSceneMenuItem* lp = (ScriptSelectSceneMenuItem*)lsp.GetPointer();
-		ScriptSelectSceneMenuItem* rp = (ScriptSelectSceneMenuItem*)rsp.GetPointer();
+		auto* lp = (ScriptSelectSceneMenuItem*)lsp.GetPointer();
+		auto* rp = (ScriptSelectSceneMenuItem*)rsp.GetPointer();
 
 		if (lp->GetType() == ScriptSelectSceneMenuItem::TYPE_DIR && rp->GetType() != ScriptSelectSceneMenuItem::TYPE_DIR)
 			return TRUE;
@@ -135,7 +135,7 @@ protected:
 	int timeLastUpdate_;
 
 	std::list<ref_count_ptr<ScriptSelectSceneMenuItem>> listItem_;
-	virtual void _Run();
+	void _Run() override;
 	virtual void _SearchScript(const std::wstring& dir);
 	void _CreateMenuItem(const std::wstring& path);
 	bool _IsValidScriptInformation(ref_count_ptr<ScriptInformation> info);
@@ -143,8 +143,8 @@ protected:
 
 public:
 	ScriptSelectFileModel(int type, const std::wstring& dir);
-	virtual ~ScriptSelectFileModel();
-	virtual void CreateMenuItem();
+	~ScriptSelectFileModel() override;
+	void CreateMenuItem() override;
 
 	int GetType() const { return type_; }
 	std::wstring GetDirectory() const { return dir_; }
@@ -169,8 +169,8 @@ private:
 
 public:
 	PlayTypeSelectScene(ref_count_ptr<ScriptInformation> info);
-	void Work();
-	void Render();
+	void Work() override;
+	void Render() override;
 };
 class PlayTypeSelectMenuItem : public TextLightUpMenuItem {
 	ref_count_ptr<DxTextRenderObject> objText_;
@@ -180,9 +180,9 @@ class PlayTypeSelectMenuItem : public TextLightUpMenuItem {
 
 public:
 	PlayTypeSelectMenuItem(std::wstring text, int x, int y);
-	virtual ~PlayTypeSelectMenuItem();
-	void Work();
-	void Render();
+	~PlayTypeSelectMenuItem() override;
+	void Work() override;
+	void Render() override;
 };
 
 /**********************************************************
@@ -202,12 +202,12 @@ private:
 	std::vector<ref_count_ptr<ScriptInformation>> listPlayer_;
 	int frameSelect_;
 
-	virtual void _ChangePage() { frameSelect_ = 0; };
+	void _ChangePage() override { frameSelect_ = 0; };
 
 public:
 	PlayerSelectScene(ref_count_ptr<ScriptInformation> info);
-	void Work();
-	void Render();
+	void Work() override;
+	void Render() override;
 };
 class PlayerSelectMenuItem : public TextLightUpMenuItem {
 	ref_count_ptr<ScriptInformation> info_;
@@ -216,9 +216,9 @@ class PlayerSelectMenuItem : public TextLightUpMenuItem {
 
 public:
 	PlayerSelectMenuItem(ref_count_ptr<ScriptInformation> info);
-	virtual ~PlayerSelectMenuItem();
-	void Work();
-	void Render();
+	~PlayerSelectMenuItem() override;
+	void Work() override;
+	void Render() override;
 
 	ref_count_ptr<ScriptInformation> GetScriptInformation() { return info_; }
 };

--- a/source/TouhouDanmakufu/DnhExecutor/ScriptSelectScene.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/ScriptSelectScene.hpp
@@ -1,102 +1,95 @@
 #ifndef __TOUHOUDANMAKUFU_EXE_SCRIPT_SELECT_SCENE__
 #define __TOUHOUDANMAKUFU_EXE_SCRIPT_SELECT_SCENE__
 
-#include"GcLibImpl.hpp"
-#include"Common.hpp"
+#include "Common.hpp"
+#include "GcLibImpl.hpp"
 
 class ScriptSelectSceneMenuItem;
 class ScriptSelectModel;
 /**********************************************************
 //ScriptSelectScene
 **********************************************************/
-class ScriptSelectScene : public TaskBase , public MenuTask
-{
-	public:
-		enum
-		{
-			TASK_PRI_WORK = 5,
-			TASK_PRI_RENDER = 5,
-		};
-		enum
-		{
-			TYPE_SINGLE,
-			TYPE_PLURAL,
-			TYPE_STAGE,
-			TYPE_PACKAGE,
-			TYPE_DIR,
-			TYPE_ALL,
-		};
-		enum
-		{
-			COUNT_MENU_TEXT = 10,
-		};
-		class Sort;
+class ScriptSelectScene : public TaskBase, public MenuTask {
+public:
+	enum {
+		TASK_PRI_WORK = 5,
+		TASK_PRI_RENDER = 5,
+	};
+	enum {
+		TYPE_SINGLE,
+		TYPE_PLURAL,
+		TYPE_STAGE,
+		TYPE_PACKAGE,
+		TYPE_DIR,
+		TYPE_ALL,
+	};
+	enum {
+		COUNT_MENU_TEXT = 10,
+	};
+	class Sort;
 
-	private:
-		ref_count_ptr<ScriptSelectModel> model_;
-		ref_count_ptr<Sprite2D> spriteBack_;
-		ref_count_ptr<Sprite2D> spriteImage_;
-		std::vector<ref_count_ptr<DxTextRenderObject> > objMenuText_;
-		int frameSelect_;
+private:
+	ref_count_ptr<ScriptSelectModel> model_;
+	ref_count_ptr<Sprite2D> spriteBack_;
+	ref_count_ptr<Sprite2D> spriteImage_;
+	std::vector<ref_count_ptr<DxTextRenderObject>> objMenuText_;
+	int frameSelect_;
 
-		virtual void _ChangePage();
+	virtual void _ChangePage();
 
-	public:
-		ScriptSelectScene();
-		~ScriptSelectScene();
-		virtual void Work();
-		virtual void Render();
-		virtual void Clear();
+public:
+	ScriptSelectScene();
+	~ScriptSelectScene();
+	virtual void Work();
+	virtual void Render();
+	virtual void Clear();
 
-		int GetType();
-		void SetModel(ref_count_ptr<ScriptSelectModel> model);
-		void ClearModel();
-		void AddMenuItem(std::list<ref_count_ptr<ScriptSelectSceneMenuItem> > &listItem);
-
+	int GetType();
+	void SetModel(ref_count_ptr<ScriptSelectModel> model);
+	void ClearModel();
+	void AddMenuItem(std::list<ref_count_ptr<ScriptSelectSceneMenuItem>>& listItem);
 };
 
-class ScriptSelectSceneMenuItem : public MenuItem
-{
+class ScriptSelectSceneMenuItem : public MenuItem {
 	friend ScriptSelectScene;
-	public:
-		enum
-		{
-			TYPE_SINGLE,
-			TYPE_PLURAL,
-			TYPE_STAGE,
-			TYPE_PACKAGE,
-			TYPE_DIR,
-		};
 
-	private:
-		int type_;
-		std::wstring path_;
-		ref_count_ptr<ScriptInformation> info_;
-		ScriptSelectScene* _GetScriptSelectScene(){return (ScriptSelectScene*)menu_;}
+public:
+	enum {
+		TYPE_SINGLE,
+		TYPE_PLURAL,
+		TYPE_STAGE,
+		TYPE_PACKAGE,
+		TYPE_DIR,
+	};
 
-	public:
-		ScriptSelectSceneMenuItem(int type, std::wstring path, ref_count_ptr<ScriptInformation> info);
-		~ScriptSelectSceneMenuItem();
+private:
+	int type_;
+	std::wstring path_;
+	ref_count_ptr<ScriptInformation> info_;
+	ScriptSelectScene* _GetScriptSelectScene() { return (ScriptSelectScene*)menu_; }
 
-		int GetType(){return type_;}
-		std::wstring GetPath(){return path_;}
-		ref_count_ptr<ScriptInformation> GetScriptInformation(){return info_;}
+public:
+	ScriptSelectSceneMenuItem(int type, const std::wstring& path, ref_count_ptr<ScriptInformation> info);
+	~ScriptSelectSceneMenuItem();
+
+	int GetType() const { return type_; }
+	std::wstring GetPath() const { return path_; }
+	ref_count_ptr<ScriptInformation> GetScriptInformation() { return info_; }
 };
 
-class ScriptSelectScene::Sort
-{
-	public:
-	BOOL operator()(const ref_count_ptr<MenuItem>& lf, const ref_count_ptr<MenuItem>& rf)
+class ScriptSelectScene::Sort {
+public:
+	BOOL operator()(const ref_count_ptr<MenuItem>& lf, const ref_count_ptr<MenuItem>& rf) const
 	{
 		ref_count_ptr<MenuItem> lsp = lf;
 		ref_count_ptr<MenuItem> rsp = rf;
 		ScriptSelectSceneMenuItem* lp = (ScriptSelectSceneMenuItem*)lsp.GetPointer();
 		ScriptSelectSceneMenuItem* rp = (ScriptSelectSceneMenuItem*)rsp.GetPointer();
 
-		if(lp->GetType() == ScriptSelectSceneMenuItem::TYPE_DIR &&
-			rp->GetType() != ScriptSelectSceneMenuItem::TYPE_DIR)return TRUE;
-		if(lp->GetType() != ScriptSelectSceneMenuItem::TYPE_DIR &&
-			rp->GetType() == ScriptSelectSceneMenuItem::TYPE_DIR)return FALSE;
+		if (lp->GetType() == ScriptSelectSceneMenuItem::TYPE_DIR && rp->GetType() != ScriptSelectSceneMenuItem::TYPE_DIR)
+			return TRUE;
+		if (lp->GetType() != ScriptSelectSceneMenuItem::TYPE_DIR && rp->GetType() == ScriptSelectSceneMenuItem::TYPE_DIR)
+			return FALSE;
 
 		std::wstring lPath = lp->GetPath();
 		std::wstring rPath = rp->GetPath();
@@ -109,131 +102,125 @@ class ScriptSelectScene::Sort
 /**********************************************************
 //ScriptSelectModel
 **********************************************************/
-class ScriptSelectModel
-{
+class ScriptSelectModel {
 	friend ScriptSelectScene;
-	protected:
-		volatile bool bCreated_;
-		ScriptSelectScene* scene_;
 
-	public:
-		ScriptSelectModel();
-		virtual ~ScriptSelectModel();
+protected:
+	volatile bool bCreated_;
+	ScriptSelectScene* scene_;
 
-		virtual void CreateMenuItem() = 0;
-		bool IsCreated(){return bCreated_;}
+public:
+	ScriptSelectModel();
+	virtual ~ScriptSelectModel();
+
+	virtual void CreateMenuItem() = 0;
+	bool IsCreated() const { return bCreated_; }
 };
 
-class ScriptSelectFileModel : public ScriptSelectModel , public Thread
-{
-	public:
-		enum
-		{
-			TYPE_SINGLE = ScriptSelectScene::TYPE_SINGLE,
-			TYPE_PLURAL = ScriptSelectScene::TYPE_PLURAL,
-			TYPE_STAGE = ScriptSelectScene::TYPE_STAGE,
-			TYPE_PACKAGE = ScriptSelectScene::TYPE_PACKAGE,
-			TYPE_DIR = ScriptSelectScene::TYPE_DIR,
-			TYPE_ALL = ScriptSelectScene::TYPE_ALL,
-		};
+class ScriptSelectFileModel : public ScriptSelectModel, public Thread {
+public:
+	enum {
+		TYPE_SINGLE = ScriptSelectScene::TYPE_SINGLE,
+		TYPE_PLURAL = ScriptSelectScene::TYPE_PLURAL,
+		TYPE_STAGE = ScriptSelectScene::TYPE_STAGE,
+		TYPE_PACKAGE = ScriptSelectScene::TYPE_PACKAGE,
+		TYPE_DIR = ScriptSelectScene::TYPE_DIR,
+		TYPE_ALL = ScriptSelectScene::TYPE_ALL,
+	};
 
-	protected:
-		int type_;
-		std::wstring dir_;
-		std::wstring pathWait_;
-		int timeLastUpdate_;
+protected:
+	int type_;
+	std::wstring dir_;
+	std::wstring pathWait_;
+	int timeLastUpdate_;
 
-		std::list<ref_count_ptr<ScriptSelectSceneMenuItem> > listItem_;
-		virtual void _Run();
-		virtual void _SearchScript(std::wstring dir);
-		void _CreateMenuItem(std::wstring path);
-		bool _IsValidScriptInformation(ref_count_ptr<ScriptInformation> info);
-		int _ConvertTypeInfoToItem(int typeInfo);
-	public:
-		ScriptSelectFileModel(int type, std::wstring dir);
-		virtual ~ScriptSelectFileModel();
-		virtual void CreateMenuItem();
+	std::list<ref_count_ptr<ScriptSelectSceneMenuItem>> listItem_;
+	virtual void _Run();
+	virtual void _SearchScript(const std::wstring& dir);
+	void _CreateMenuItem(const std::wstring& path);
+	bool _IsValidScriptInformation(ref_count_ptr<ScriptInformation> info);
+	int _ConvertTypeInfoToItem(int typeInfo);
 
-		int GetType(){return type_;}
-		std::wstring GetDirectory(){return dir_;}
+public:
+	ScriptSelectFileModel(int type, const std::wstring& dir);
+	virtual ~ScriptSelectFileModel();
+	virtual void CreateMenuItem();
 
-		std::wstring GetWaitPath(){return pathWait_;}
-		void SetWaitPath(std::wstring path){pathWait_ = path;}
+	int GetType() const { return type_; }
+	std::wstring GetDirectory() const { return dir_; }
+
+	std::wstring GetWaitPath() const { return pathWait_; }
+	void SetWaitPath(const std::wstring& path) { pathWait_ = path; }
 };
 
 /**********************************************************
 //PlayTypeSelectScene
 **********************************************************/
-class PlayTypeSelectScene : public TaskBase , public MenuTask
-{
-	public:
-		enum
-		{
-			TASK_PRI_WORK = 6,
-			TASK_PRI_RENDER = 6,
-		};
+class PlayTypeSelectScene : public TaskBase, public MenuTask {
+public:
+	enum {
+		TASK_PRI_WORK = 6,
+		TASK_PRI_RENDER = 6,
+	};
 
-	private:
-		ref_count_ptr<ScriptInformation> info_;
-		ref_count_ptr<ReplayInformationManager> replayInfoManager_;
+private:
+	ref_count_ptr<ScriptInformation> info_;
+	ref_count_ptr<ReplayInformationManager> replayInfoManager_;
 
-	public:
-		PlayTypeSelectScene(ref_count_ptr<ScriptInformation> info);
-		void Work();
-		void Render();
+public:
+	PlayTypeSelectScene(ref_count_ptr<ScriptInformation> info);
+	void Work();
+	void Render();
 };
-class PlayTypeSelectMenuItem : public TextLightUpMenuItem
-{
-		ref_count_ptr<DxTextRenderObject> objText_;
-		POINT pos_;
+class PlayTypeSelectMenuItem : public TextLightUpMenuItem {
+	ref_count_ptr<DxTextRenderObject> objText_;
+	POINT pos_;
 
-		PlayTypeSelectScene* _GetTitleScene(){return (PlayTypeSelectScene*)menu_;}
-	public:
-		PlayTypeSelectMenuItem(std::wstring text, int x, int y);
-		virtual ~PlayTypeSelectMenuItem();
-		void Work();
-		void Render();
+	PlayTypeSelectScene* _GetTitleScene() { return (PlayTypeSelectScene*)menu_; }
+
+public:
+	PlayTypeSelectMenuItem(std::wstring text, int x, int y);
+	virtual ~PlayTypeSelectMenuItem();
+	void Work();
+	void Render();
 };
 
 /**********************************************************
 //PlayerSelectScene
 **********************************************************/
-class PlayerSelectScene : public TaskBase , public MenuTask
-{
-	public:
-		enum
-		{
-			TASK_PRI_WORK = 7,
-			TASK_PRI_RENDER = 7,
-		};
+class PlayerSelectScene : public TaskBase, public MenuTask {
+public:
+	enum {
+		TASK_PRI_WORK = 7,
+		TASK_PRI_RENDER = 7,
+	};
 
-	private:
-		ref_count_ptr<Sprite2D> spriteBack_;
-		ref_count_ptr<Sprite2D> spriteImage_;
-		ref_count_ptr<ScriptInformation> info_;
-		std::vector<ref_count_ptr<ScriptInformation> > listPlayer_;
-		int frameSelect_;
+private:
+	ref_count_ptr<Sprite2D> spriteBack_;
+	ref_count_ptr<Sprite2D> spriteImage_;
+	ref_count_ptr<ScriptInformation> info_;
+	std::vector<ref_count_ptr<ScriptInformation>> listPlayer_;
+	int frameSelect_;
 
-		virtual void _ChangePage(){frameSelect_ = 0;};
-	public:
-		PlayerSelectScene(ref_count_ptr<ScriptInformation> info);
-		void Work();
-		void Render();
+	virtual void _ChangePage() { frameSelect_ = 0; };
+
+public:
+	PlayerSelectScene(ref_count_ptr<ScriptInformation> info);
+	void Work();
+	void Render();
 };
-class PlayerSelectMenuItem : public TextLightUpMenuItem
-{
-		ref_count_ptr<ScriptInformation> info_;
+class PlayerSelectMenuItem : public TextLightUpMenuItem {
+	ref_count_ptr<ScriptInformation> info_;
 
-		PlayerSelectScene* _GetTitleScene(){return (PlayerSelectScene*)menu_;}
-	public:
-		PlayerSelectMenuItem(ref_count_ptr<ScriptInformation> info);
-		virtual ~PlayerSelectMenuItem();
-		void Work();
-		void Render();
+	PlayerSelectScene* _GetTitleScene() { return (PlayerSelectScene*)menu_; }
 
-		ref_count_ptr<ScriptInformation> GetScriptInformation(){return info_;}
+public:
+	PlayerSelectMenuItem(ref_count_ptr<ScriptInformation> info);
+	virtual ~PlayerSelectMenuItem();
+	void Work();
+	void Render();
+
+	ref_count_ptr<ScriptInformation> GetScriptInformation() { return info_; }
 };
-
 
 #endif
-

--- a/source/TouhouDanmakufu/DnhExecutor/StgScene.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/StgScene.cpp
@@ -12,7 +12,7 @@ void EStgSystemController::DoRetry()
 {
 	SceneManager* sceneManager = SystemController::GetInstance()->GetSceneManager();
 	ref_count_ptr<StgStageInformation> infoStage = stageController_->GetStageInformation();
-	sceneManager->TransStgScene(infoStage->GetMainScriptInformation(), infoStage->GetPlayerScriptInformation(), NULL);
+	sceneManager->TransStgScene(infoStage->GetMainScriptInformation(), infoStage->GetPlayerScriptInformation(), nullptr);
 }
 
 /**********************************************************

--- a/source/TouhouDanmakufu/DnhExecutor/StgScene.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/StgScene.hpp
@@ -8,8 +8,8 @@
 **********************************************************/
 class EStgSystemController : public StgSystemController {
 protected:
-	virtual void DoEnd();
-	virtual void DoRetry();
+	void DoEnd() override;
+	void DoRetry() override;
 };
 
 /**********************************************************
@@ -17,8 +17,8 @@ protected:
 **********************************************************/
 class PStgSystemController : public StgSystemController {
 protected:
-	virtual void DoEnd();
-	virtual void DoRetry();
+	void DoEnd() override;
+	void DoRetry() override;
 };
 
 #endif

--- a/source/TouhouDanmakufu/DnhExecutor/System.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/System.cpp
@@ -50,7 +50,7 @@ void SystemController::ClearTaskWithoutSystem()
 	ETaskManager* taskManager = ETaskManager::GetInstance();
 	taskManager->RemoveTaskWithoutTypeInfo(listInfo);
 }
-void SystemController::ShowErrorDialog(std::wstring msg)
+void SystemController::ShowErrorDialog(const std::wstring& msg)
 {
 	HWND hParent = EDirectGraphics::GetInstance()->GetAttachedWindowHandle();
 	ErrorDialog dialog(hParent);

--- a/source/TouhouDanmakufu/DnhExecutor/System.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/System.cpp
@@ -21,8 +21,8 @@ SystemController::SystemController()
 }
 SystemController::~SystemController()
 {
-	transitionManager_ = NULL;
-	sceneManager_ = NULL;
+	transitionManager_ = nullptr;
+	sceneManager_ = nullptr;
 }
 void SystemController::Reset()
 {
@@ -31,12 +31,12 @@ void SystemController::Reset()
 
 	DnhConfiguration* config = DnhConfiguration::CreateInstance();
 	std::wstring pathPackageScript = config->GetPackageScriptPath();
-	if (pathPackageScript.size() == 0) {
+	if (pathPackageScript.empty()) {
 		infoSystem_->UpdateFreePlayerScriptInformationList();
 		sceneManager_->TransTitleScene();
 	} else {
 		ref_count_ptr<ScriptInformation> info = ScriptInformation::CreateScriptInformation(pathPackageScript, false);
-		if (info == NULL)
+		if (info == nullptr)
 			ShowErrorDialog(ErrorUtility::GetFileNotFoundErrorMessage(pathPackageScript));
 		sceneManager_->TransPackageScene(info, true);
 	}
@@ -60,12 +60,8 @@ void SystemController::ShowErrorDialog(const std::wstring& msg)
 /**********************************************************
 //SceneManager
 **********************************************************/
-SceneManager::SceneManager()
-{
-}
-SceneManager::~SceneManager()
-{
-}
+SceneManager::SceneManager() = default;
+SceneManager::~SceneManager() = default;
 void SceneManager::TransTitleScene()
 {
 	EDirectInput* input = EDirectInput::GetInstance();
@@ -100,7 +96,7 @@ void SceneManager::TransScriptSelectScene(int type)
 	taskManager->AddRenderFunction(TTaskFunction<ScriptSelectScene>::Create(task, &ScriptSelectScene::Render),
 		ScriptSelectScene::TASK_PRI_RENDER);
 
-	ref_count_ptr<ScriptSelectModel> model = NULL;
+	ref_count_ptr<ScriptSelectModel> model = nullptr;
 	if (type == ScriptSelectScene::TYPE_SINGLE
 		|| type == ScriptSelectScene::TYPE_PLURAL
 		|| type == ScriptSelectScene::TYPE_STAGE
@@ -111,7 +107,7 @@ void SceneManager::TransScriptSelectScene(int type)
 		SystemInformation* systemInfo = SystemController::GetInstance()->GetSystemInformation();
 		if (type == ScriptSelectScene::TYPE_DIR)
 			dir = systemInfo->GetLastScriptSearchDirectory();
-		ScriptSelectFileModel* fileModel = new ScriptSelectFileModel(type, dir);
+		auto* fileModel = new ScriptSelectFileModel(type, dir);
 		std::wstring pathWait = systemInfo->GetLastSelectedScriptPath();
 		fileModel->SetWaitPath(pathWait);
 		model = fileModel;
@@ -193,14 +189,13 @@ void SceneManager::TransStgScene(ref_count_ptr<ScriptInformation> infoMain, ref_
 		ref_count_ptr<ScriptInformation> infoPlayer;
 		std::vector<ref_count_ptr<ScriptInformation>> listPlayer;
 		std::vector<std::wstring> listPlayerPath = infoMain->GetPlayerList();
-		if (listPlayerPath.size() == 0) {
+		if (listPlayerPath.empty()) {
 			listPlayer = SystemController::GetInstance()->GetSystemInformation()->GetFreePlayerScriptInformationList();
 		} else {
 			listPlayer = infoMain->CreatePlayerScriptInformationList();
 		}
 
-		for (int iPlayer = 0; iPlayer < listPlayer.size(); iPlayer++) {
-			ref_count_ptr<ScriptInformation> tInfo = listPlayer[iPlayer];
+		for (auto tInfo : listPlayer) {
 			if (tInfo->GetID() != replayPlayerID)
 				continue;
 			std::wstring tPlayerScriptFileName = PathProperty::GetFileName(tInfo->GetScriptPath());
@@ -211,9 +206,9 @@ void SceneManager::TransStgScene(ref_count_ptr<ScriptInformation> infoMain, ref_
 			break;
 		}
 
-		if (infoPlayer == NULL) {
+		if (infoPlayer == nullptr) {
 			std::wstring log = StringUtility::Format(L"自機スクリプトが見つかりません:[%s]", replayPlayerScriptFileName.c_str());
-			throw gstd::wexception(log.c_str());
+			throw gstd::wexception(log);
 		}
 
 		TransStgScene(infoMain, infoPlayer, infoReplay);
@@ -234,7 +229,7 @@ void SceneManager::TransPackageScene(ref_count_ptr<ScriptInformation> infoMain, 
 		//STGシーン初期化
 		ref_count_ptr<StgSystemInformation> infoStgSystem = new StgSystemInformation();
 		infoStgSystem->SetMainScriptInformation(infoMain);
-		ref_count_ptr<StgSystemController> task = NULL;
+		ref_count_ptr<StgSystemController> task = nullptr;
 		if (!bOnlyPackage)
 			task = new EStgSystemController();
 		else
@@ -243,7 +238,7 @@ void SceneManager::TransPackageScene(ref_count_ptr<ScriptInformation> infoMain, 
 		//STGタスク初期化
 		ETaskManager* taskManager = ETaskManager::GetInstance();
 		task->Initialize(infoStgSystem);
-		task->Start(NULL, NULL);
+		task->Start(nullptr, nullptr);
 
 		//タスククリア
 		TransitionManager* transitionManager = SystemController::GetInstance()->GetTransitionManager();
@@ -272,12 +267,8 @@ void SceneManager::TransPackageScene(ref_count_ptr<ScriptInformation> infoMain, 
 /**********************************************************
 //TransitionManager
 **********************************************************/
-TransitionManager::TransitionManager()
-{
-}
-TransitionManager::~TransitionManager()
-{
-}
+TransitionManager::TransitionManager() = default;
+TransitionManager::~TransitionManager() = default;
 void TransitionManager::_CreateCurrentSceneTexture()
 {
 	DirectGraphics* graphics = EDirectGraphics::GetInstance();
@@ -290,7 +281,7 @@ void TransitionManager::_CreateCurrentSceneTexture()
 	graphics->BeginScene();
 	taskManager->CallRenderFunction();
 	graphics->EndScene();
-	graphics->SetRenderTarget(NULL);
+	graphics->SetRenderTarget(nullptr);
 }
 void TransitionManager::_AddTask(ref_count_ptr<TransitionEffect> effect)
 {
@@ -323,7 +314,7 @@ void TransitionManager::DoFadeOut()
 void SystemTransitionEffectTask::Work()
 {
 	TransitionEffectTask::Work();
-	if (effect_ != NULL && effect_->IsEnd()) {
+	if (effect_ != nullptr && effect_->IsEnd()) {
 		WorkRenderTaskManager* taskManager = ETaskManager::GetInstance();
 		taskManager->RemoveTask(this);
 		return;
@@ -344,14 +335,11 @@ SystemInformation::SystemInformation()
 
 	lastPlayerSelectIndex_ = 0;
 }
-SystemInformation::~SystemInformation()
-{
-}
+SystemInformation::~SystemInformation() = default;
 void SystemInformation::_SearchFreePlayerScript(std::wstring dir)
 {
 	listFreePlayer_ = ScriptInformation::FindPlayerScriptInformationList(dir);
-	for (int iPlayer = 0; iPlayer < listFreePlayer_.size(); iPlayer++) {
-		ref_count_ptr<ScriptInformation> info = listFreePlayer_[iPlayer];
+	for (auto info : listFreePlayer_) {
 		std::wstring path = info->GetScriptPath();
 		std::wstring log = StringUtility::Format(L"自機スクリプト：%s", path.c_str());
 		ELogger::WriteTop(log);
@@ -387,15 +375,13 @@ SystemResidentTask::SystemResidentTask()
 	textFps_.SetHorizontalAlignment(DxText::ALIGNMENT_RIGHT);
 	textFps_.SetPosition(0, screenHeight - 20);
 }
-SystemResidentTask::~SystemResidentTask()
-{
-}
+SystemResidentTask::~SystemResidentTask() = default;
 void SystemResidentTask::RenderFps()
 {
 	WorkRenderTaskManager* taskManager = ETaskManager::GetInstance();
-	if (taskManager->GetTask(typeid(EStgSystemController)) != NULL)
+	if (taskManager->GetTask(typeid(EStgSystemController)) != nullptr)
 		return;
-	if (taskManager->GetTask(typeid(PStgSystemController)) != NULL)
+	if (taskManager->GetTask(typeid(PStgSystemController)) != nullptr)
 		return;
 
 	DirectGraphics* graphics = DirectGraphics::GetBase();

--- a/source/TouhouDanmakufu/DnhExecutor/System.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/System.hpp
@@ -23,7 +23,7 @@ public:
 	TransitionManager* GetTransitionManager() { return transitionManager_.GetPointer(); }
 	SystemInformation* GetSystemInformation() { return infoSystem_.GetPointer(); }
 
-	void ShowErrorDialog(std::wstring msg);
+	void ShowErrorDialog(const std::wstring& msg);
 
 private:
 	SystemController();
@@ -91,18 +91,18 @@ public:
 	SystemInformation();
 	virtual ~SystemInformation();
 
-	int GetLastTitleSelectedIndex() { return lastTitleSelectedIndex_; }
+	int GetLastTitleSelectedIndex() const { return lastTitleSelectedIndex_; }
 	void SetLastTitleSelectedIndex(int index) { lastTitleSelectedIndex_ = index; }
-	std::wstring GetLastScriptSearchDirectory() { return dirLastScriptSearch_; }
-	void SetLastScriptSearchDirectory(std::wstring dir) { dirLastScriptSearch_ = dir; }
-	std::wstring GetLastSelectedScriptPath() { return pathLastSelectedScript_; }
-	void SetLastSelectedScriptPath(std::wstring path) { pathLastSelectedScript_ = path; }
-	int GetLastSelectScriptSceneType() { return lastSelectScriptSceneType_; }
+	std::wstring GetLastScriptSearchDirectory() const { return dirLastScriptSearch_; }
+	void SetLastScriptSearchDirectory(const std::wstring& dir) { dirLastScriptSearch_ = dir; }
+	std::wstring GetLastSelectedScriptPath() const { return pathLastSelectedScript_; }
+	void SetLastSelectedScriptPath(const std::wstring& path) { pathLastSelectedScript_ = path; }
+	int GetLastSelectScriptSceneType() const { return lastSelectScriptSceneType_; }
 	void SetLastSelectScriptSceneType(int type) { lastSelectScriptSceneType_ = type; }
 
-	int GetLastSelectedPlayerIndex() { return lastPlayerSelectIndex_; }
+	int GetLastSelectedPlayerIndex() const { return lastPlayerSelectIndex_; }
 	std::vector<ref_count_ptr<ScriptInformation>>& GetLastPlayerSelectedList() { return listLastPlayerSelect_; }
-	void SetLastSelectedPlayerIndex(int index, std::vector<ref_count_ptr<ScriptInformation>>& list)
+	void SetLastSelectedPlayerIndex(int index, const std::vector<ref_count_ptr<ScriptInformation>>& list)
 	{
 		lastPlayerSelectIndex_ = index;
 		listLastPlayerSelect_ = list;

--- a/source/TouhouDanmakufu/DnhExecutor/System.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/System.hpp
@@ -15,7 +15,7 @@ class SystemController : public Singleton<SystemController> {
 	friend Singleton<SystemController>;
 
 public:
-	virtual ~SystemController();
+	~SystemController() override;
 	void Reset();
 	void ClearTaskWithoutSystem();
 
@@ -79,8 +79,8 @@ private:
 
 class SystemTransitionEffectTask : public TransitionEffectTask {
 public:
-	void Work();
-	void Render();
+	void Work() override;
+	void Render() override;
 };
 
 /**********************************************************
@@ -136,7 +136,7 @@ public:
 
 public:
 	SystemResidentTask();
-	~SystemResidentTask();
+	~SystemResidentTask() override;
 	void RenderFps();
 
 private:

--- a/source/TouhouDanmakufu/DnhExecutor/TitleScene.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/TitleScene.cpp
@@ -84,7 +84,7 @@ void TitleScene::Render()
 }
 
 //TitleSceneMenuItem
-TitleSceneMenuItem::TitleSceneMenuItem(std::wstring text, std::wstring description, int x, int y)
+TitleSceneMenuItem::TitleSceneMenuItem(const std::wstring& text, const std::wstring&, int x, int y)
 {
 	pos_.x = x;
 	pos_.y = y;

--- a/source/TouhouDanmakufu/DnhExecutor/TitleScene.cpp
+++ b/source/TouhouDanmakufu/DnhExecutor/TitleScene.cpp
@@ -15,8 +15,8 @@ TitleScene::TitleScene()
 	DirectGraphics* graphics = DirectGraphics::GetBase();
 	int screenWidth = graphics->GetScreenWidth();
 	int screenHeight = graphics->GetScreenHeight();
-	RECT_D srcBack = { 0., 0., 640., 480. };
-	RECT_D destBack = { 0., 0., (double)screenWidth, (double)screenHeight };
+	RECT_D srcBack = { 0.0, 0.0, 640.0, 480.0 };
+	RECT_D destBack = { 0.0, 0.0, (double)screenWidth, (double)screenHeight };
 
 	spriteBack_ = new Sprite2D();
 	spriteBack_->SetTexture(textureBack);
@@ -24,7 +24,7 @@ TitleScene::TitleScene()
 
 	std::wstring strText[] = { L"All", L"Single", L"Plural", L"Stage", L"Package", L"Directory", L"Quit" };
 	std::wstring strDescription[] = { L"", L"", L"", L"", L"", L"", L"", L"" };
-	for (int iItem = 0; iItem < ITEM_COUNT; iItem++) {
+	for (int iItem = 0; iItem < ITEM_COUNT; ++iItem) {
 		int x = 48 + iItem * 6 + 12 * pow((double)-1, (int)(iItem - 1));
 		int y = 154 + iItem * 30;
 		AddMenuItem(new TitleSceneMenuItem(strText[iItem], strDescription[iItem], x, y));
@@ -69,7 +69,8 @@ void TitleScene::Work()
 			break;
 		}
 		return;
-	} else if (input->GetVirtualKeyState(EDirectInput::KEY_CANCEL) == KEY_PUSH) {
+	}
+	if (input->GetVirtualKeyState(EDirectInput::KEY_CANCEL) == KEY_PUSH) {
 		cursorY_ = ITEM_QUIT;
 	}
 }
@@ -84,7 +85,7 @@ void TitleScene::Render()
 }
 
 //TitleSceneMenuItem
-TitleSceneMenuItem::TitleSceneMenuItem(const std::wstring& text, const std::wstring&, int x, int y)
+TitleSceneMenuItem::TitleSceneMenuItem(const std::wstring& text, const std::wstring& /*unused*/, int x, int y)
 {
 	pos_.x = x;
 	pos_.y = y;
@@ -100,9 +101,7 @@ TitleSceneMenuItem::TitleSceneMenuItem(const std::wstring& text, const std::wstr
 	dxText.SetText(text);
 	objText_ = dxText.CreateRenderObject();
 }
-TitleSceneMenuItem::~TitleSceneMenuItem()
-{
-}
+TitleSceneMenuItem::~TitleSceneMenuItem() = default;
 void TitleSceneMenuItem::Work()
 {
 	_WorkSelectedItem();

--- a/source/TouhouDanmakufu/DnhExecutor/TitleScene.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/TitleScene.hpp
@@ -35,7 +35,7 @@ public:
 
 class TitleSceneMenuItem : public TextLightUpMenuItem {
 public:
-	TitleSceneMenuItem(std::wstring text, std::wstring description, int x, int y);
+	TitleSceneMenuItem(const std::wstring& text, const std::wstring& description, int x, int y);
 	virtual ~TitleSceneMenuItem();
 	void Work();
 	void Render();

--- a/source/TouhouDanmakufu/DnhExecutor/TitleScene.hpp
+++ b/source/TouhouDanmakufu/DnhExecutor/TitleScene.hpp
@@ -29,16 +29,16 @@ private:
 
 public:
 	TitleScene();
-	void Work();
-	void Render();
+	void Work() override;
+	void Render() override;
 };
 
 class TitleSceneMenuItem : public TextLightUpMenuItem {
 public:
 	TitleSceneMenuItem(const std::wstring& text, const std::wstring& description, int x, int y);
-	virtual ~TitleSceneMenuItem();
-	void Work();
-	void Render();
+	~TitleSceneMenuItem() override;
+	void Work() override;
+	void Render() override;
 
 private:
 	ref_count_ptr<DxTextRenderObject> objText_;

--- a/source/TouhouDanmakufu/DnhViewer/ScenePanel.hpp
+++ b/source/TouhouDanmakufu/DnhViewer/ScenePanel.hpp
@@ -17,7 +17,7 @@ public:
 	bool EndStg();
 	void SetStgState(bool bStart);
 
-	bool IsFixedArea() { return bFixedArea_; }
+	bool IsFixedArea() const { return bFixedArea_; }
 	void SetFixedArea(bool bFixed) { bFixedArea_ = bFixed; }
 
 	void ClearData();

--- a/source/TouhouDanmakufu/DnhViewer/ScriptSelect.cpp
+++ b/source/TouhouDanmakufu/DnhViewer/ScriptSelect.cpp
@@ -33,7 +33,7 @@ void ScriptSelectDialog::Initialize()
 	buttonOk_.Attach(GetDlgItem(hWnd_, IDOK));
 	buttonCancel_.Attach(GetDlgItem(hWnd_, IDCANCEL));
 }
-void ScriptSelectDialog::_SearchScript(std::wstring dir)
+void ScriptSelectDialog::_SearchScript(const std::wstring& dir)
 {
 	WIN32_FIND_DATA data;
 	HANDLE hFind;
@@ -146,7 +146,7 @@ LRESULT ScriptSelectDialog::_WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam
 	}
 	return _CallPreviousWindowProcedure(hWnd, uMsg, wParam, lParam);
 }
-void ScriptSelectDialog::ShowModal(std::wstring path)
+void ScriptSelectDialog::ShowModal(const std::wstring& path)
 {
 	for (int iInfo = 0; iInfo < listInfo_.size(); iInfo++) {
 		ref_count_ptr<ScriptInformation> info = listInfo_[iInfo];

--- a/source/TouhouDanmakufu/DnhViewer/ScriptSelect.hpp
+++ b/source/TouhouDanmakufu/DnhViewer/ScriptSelect.hpp
@@ -26,13 +26,13 @@ protected:
 
 public:
 	virtual void Initialize();
-	virtual void ShowModal(std::wstring path);
+	virtual void ShowModal(const std::wstring& path);
 
 	ref_count_ptr<ScriptInformation> GetSelectedScript() { return infoSelected_; }
 
 protected:
 	virtual bool _IsValidScript(ref_count_ptr<ScriptInformation> info) { return NULL; }
-	void _SearchScript(std::wstring dir);
+	void _SearchScript(const std::wstring& dir);
 	virtual void _Filter() {}
 	virtual LRESULT _WindowProcedure(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 


### PR DESCRIPTION
While we're modernizing the code, crucial thing is to ensure it is clear and stuff. And yep, const-correctness is the smallest issue here, But it's better to know which methods indeed modify internal state, which does not. That's initial step into modernizing it further.
Yet it's C++11 modernizing which improved by a bit readability, that is adding range-for loops, nullptr instead of NULL, virtual/override changes etc. For this task I used clang-tidy analyzer. It didn't catch all opportunities for modernizing, like failing transforming some for loops into range-for loops, which I corrected manually.

Lack of tests is unfortunate here, but there weren't any intrusive changes involved - only two things above took the place. The game is not malfunctioning throughout the runs, seems it shouldn't after such changes. Feel free to ask questions, modify it as per needs.